### PR TITLE
🐛 [wolfram2desmos] Bugfix for erroneous csv parsing

### DIFF
--- a/src/desmodder.ts
+++ b/src/desmodder.ts
@@ -39,6 +39,7 @@ export {
 } from "DCGView";
 export {
   EvaluateSingleExpression,
+	TableParse,
   pollForValue,
   mergeClass,
   MaybeClassDict,

--- a/src/plugins/wolfram2desmos/index.ts
+++ b/src/plugins/wolfram2desmos/index.ts
@@ -1,4 +1,4 @@
-import { Calc } from "desmodder";
+import { Calc, TableParse } from "desmodder";
 import Controller from "./Controller";
 import { wolfram2desmos } from "./wolfram2desmos";
 
@@ -43,13 +43,12 @@ function pasteHandler(e: ClipboardEvent) {
   if (
     !(elem?.classList.contains("dcg-label-input") ?? true) &&
     pasteData !== "" &&
-    Calc.controller.getItemModel(Calc.selectedExpressionId).type ===
-      "expression"
+    Calc.controller.getItemModel(Calc.selectedExpressionId).type === "expression" &&
+    TableParse(pasteData??'') === undefined && 
+    (pasteData = wolfram2desmos(pasteData)) !== null
   ) {
     e.stopPropagation();
     e.preventDefault();
-
-    pasteData = wolfram2desmos(pasteData);
     typeInTextArea(pasteData);
   }
 }

--- a/src/plugins/wolfram2desmos/wolfram2desmos.js
+++ b/src/plugins/wolfram2desmos/wolfram2desmos.js
@@ -15,7 +15,8 @@ export function wolfram2desmos(input) {
       return null;
     }
     
-    if (count(/^(.+\n?)+$/) > 0) {
+    // determines if the input is a single row table
+    if (count(/^.+(?:\r\n|\r|\n)(?:.+(?:\r\n|\r|\n)?)+$/) > 0) {
       return null;
     }
     

--- a/src/plugins/wolfram2desmos/wolfram2desmos.js
+++ b/src/plugins/wolfram2desmos/wolfram2desmos.js
@@ -12,9 +12,13 @@ export function wolfram2desmos(input) {
   {
     // determines if the input IS ALREADY latex
     if (count(/((?<=\\left)\|)|(\\)|((\^|\_){)/g) > 0) {
-      return input;
+      return null;
     }
-
+    
+    if (count(/^(.+\n?)+$/) > 0) {
+      return null;
+    }
+    
     // determines if the brackets are correct
     if (count(/\(/g) > count(/\)/g)) {
       console.warn(
@@ -22,7 +26,7 @@ export function wolfram2desmos(input) {
           (count(/\(/g) - count(/\)/g)) +
           " more '(' characters than ')' characters"
       );
-      return input;
+      return null;
     }
     if (count(/\(/g) < count(/\)/g)) {
       console.warn(
@@ -30,11 +34,11 @@ export function wolfram2desmos(input) {
           (count(/\)/g) - count(/\(/g)) +
           " more ')' characters than '(' characters"
       );
-      return input;
+      return null;
     }
     if (count(/\|/g) % 2 == 1) {
       console.warn("Input has uneven '|' brackets");
-      return input;
+      return null;
     }
   }
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -14,7 +14,7 @@ export function EvaluateSingleExpression(s: string): number {
 }
 
 export function TableParse(s: string): Array<string> | undefined{
-  return _DataHelpers(s);
+  return _DataHelpers.parse(s);
 }
 
 interface FuncAny {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -4,10 +4,17 @@ export const keys = desmosRequire("keys");
 const _EvaluateSingleExpression = desmosRequire(
   "core/math/evaluate-single-expression"
 ).default;
+const _DataHelpers = desmosRequire(
+  "main/data_helpers"
+);
 
 export function EvaluateSingleExpression(s: string): number {
   // may also return NaN (which is a number)
   return _EvaluateSingleExpression(s, Calc.controller.isDegreeMode());
+}
+
+export function TableParse(s: string): Array<string> | undefined{
+  return _DataHelpers(s);
 }
 
 interface FuncAny {


### PR DESCRIPTION
I fixed the bug addressed [on issue 17](https://github.com/Heavenira/wolfram2desmos/issues/17) in the wolfram2desmos repository.

I made the following changes:

- Added TableParse as a new util for plugins.
- Used TableParse to prevent csv data being parsed as ascii-math
- The wolfram2desmos function now returns null when input is not ascii-math
- Added new restriction in wolfram2desmos to discriminate single row csv data (which TableParse fails to capture)

I added the TableParse as a util following guideline on this comment: https://github.com/DesModder/DesModder/blob/570c9e160aabbeced815561115b729c7098e680c/src/desmodder.ts#L23-L25
If you need changes in there let me know.