### PR TITLE
🐛 [video-creator] Fix overflow simulation rule preview

### DIFF
--- a/src/plugins/video-creator/components/SimulationPicker.css
+++ b/src/plugins/video-creator/components/SimulationPicker.css
@@ -9,3 +9,30 @@
   padding: 0 8px;
   transform: translateY(1px);
 }
+
+.video-creator-simulation-rules
+  .dcg-clickable-property-row
+  .dcg-mq-math-mode:first-child {
+  min-width: 30px;
+  max-width: 70px;
+}
+
+.video-creator-simulation-rules
+  .dcg-clickable-property-row
+  .dcg-mq-math-mode:last-child {
+  min-width: 30px;
+  max-width: 120px;
+}
+
+.video-creator-simulation-rules
+  .dcg-clickable-property-row
+  .dcg-mq-math-mode::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 8px;
+  bottom: 0;
+  width: 14px;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), #fff);
+  pointer-events: none;
+}


### PR DESCRIPTION
This is a fix to issue #131 which causes the preview of the simulation rules to clip off the popover.

I mirrored the some of the same CSS rules that are already used in Desmos' simulation expressions. One thing that I changed is the max length of the assignment field and the rule field because Desmos uses 120 pixels for both but this still causes overflow in Desmodder. I opted for applying a first and last child rule to them with 70 and 120 pixels respectively.

If you want changes briefly tell me what you want differently, and I will look into it.