### PR TITLE
🐛 Override settings from query parameters

### DIFF
--- a/src/desmodder.ts
+++ b/src/desmodder.ts
@@ -46,5 +46,6 @@ export {
   keys,
   promisify,
   OptionalProperties,
+  getQueryParams,
 } from "utils";
 export { controller as desModderController } from "./script";

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -71,3 +71,6 @@ export const promisify =
 export type OptionalProperties<T> = {
   [K in keyof T]?: T[K];
 };
+
+export const getQueryParams: () => { [key: string]: string | true } =
+  desmosRequire("lib/parse-query-params").getQueryParams;


### PR DESCRIPTION
They apply temporarily until page refresh or until the the options are re-toggled within the extension settings

Fixes part, but not all, of #101 