### PR TITLE
🐛 Fix builtin-settings extension storage being ignored

### DIFF
--- a/src/plugins/builtin-settings/index.ts
+++ b/src/plugins/builtin-settings/index.ts
@@ -47,7 +47,11 @@ function onEnable(config: Config) {
       queryConfig[key] = false;
     }
   }
-  Calc.updateSettings(manageConfigChange(config, queryConfig));
+  const newChanges = manageConfigChange(config, queryConfig);
+  Calc.updateSettings({
+    ...config,
+    ...newChanges,
+  });
 }
 
 function onDisable() {


### PR DESCRIPTION
Broken in #144. Now extension storage correctly affects the settings,
but they *can* be overriden by query parameters