### PR TITLE
Use the parse tree for identifier→* replacements

### DIFF
--- a/src/desmodder.ts
+++ b/src/desmodder.ts
@@ -51,3 +51,4 @@ export {
   getQueryParams,
 } from "utils/depUtils";
 export { controller as desModderController } from "./script";
+export { default as traverse } from "./parsing/traverse";

--- a/src/desmodder.ts
+++ b/src/desmodder.ts
@@ -48,7 +48,7 @@ export {
   EvaluateSingleExpression,
   jquery,
   keys,
+  parseDesmosLatex,
   getQueryParams,
 } from "utils/depUtils";
 export { controller as desModderController } from "./script";
-export { default as traverse } from "./parsing/traverse";

--- a/src/parsing/parsenode.ts
+++ b/src/parsing/parsenode.ts
@@ -1,0 +1,613 @@
+interface Base {
+  init(): void;
+  exportPenalty: number;
+  setInputSpan(span: Span): void;
+  getInputString(): string;
+  getInputSpan(): Span;
+  shouldExportAns(): boolean;
+  getAnsVariable(): [string] | [];
+  addDependency(dep: string): void;
+  addDependencies(deps: string[]): void;
+  addDummyDependency(dep: string): void;
+  addDummyDependencies(deps: string[]): void;
+  mergeDependencies(): void;
+  mergeDependenciesInScope(): void;
+  getDependencies(): void;
+  getDummyDependencies(): void;
+  getScope(): Scope;
+  dependsOn(v: string): boolean;
+  getExports(): string[];
+  getLegalExports(): string[];
+  exportsSymbol(v: string): boolean;
+  // exportTo(): unknown;
+  getOperator(): string;
+  isInequality(): boolean;
+  isShadeBetween(): boolean;
+  getAllIds(): string[];
+  getEvaluationInfo(): EvaluationInfo;
+  shouldPromoteToSlider(): boolean;
+  getSliderVariables(): string[];
+  getCompiledDerivative(): Function;
+  asValue(): undefined | string | number | boolean | number[] | unknown;
+  boundDomain(): unknown;
+}
+
+type EvaluationInfo = false | undefined | { val: unknown }[];
+
+interface Error {
+  // "1 ("
+  type: "Error";
+  _msg: {
+    key: string;
+    // There's more
+  };
+  _sliderVariables: string[];
+  isError: true;
+  getError(): string;
+  blocksExport(): boolean;
+  // setDependencies() and allowExport() mutate then return `this`, hence Error
+  setDependencies(): Error;
+  allowExport(): Error;
+}
+
+interface Span {
+  input: string;
+  start: number;
+  end: number;
+}
+
+type Scope = unknown; // TODO
+
+interface Expression extends Base {
+  args: unknown[];
+  treeSize: number;
+  // called within init():
+  registerDependencies(): void;
+  computeTreeSize(): void;
+  copyWithArgs(): Expression;
+}
+
+interface UpperConstant extends Expression {
+  args: [];
+  _constantValue: boolean | number;
+  asCompilerValue(): boolean | number;
+  scalarExprString(): string;
+  isNaN(): boolean;
+}
+
+interface Constant extends UpperConstant {
+  // "1.5"
+  type: "Constant";
+}
+
+interface MixedNumber extends UpperConstant {
+  // "1\\frac{3}{2}"
+  type: "MixedNumber";
+  is_mixed_number: true;
+}
+
+interface DotAccess extends Expression {
+  // "a.w"
+  type: "DotAccess";
+  args: [ChildExprNode, Identifier];
+}
+
+interface OrderedPairAccess extends Expression {
+  // "a.x"
+  type: "OrderedPairAccess";
+  args: [ChildExprNode, Constant];
+  point: ChildExprNode;
+  index: Constant;
+}
+
+interface UpperFunctionCall extends Expression {
+  args: ChildExprNode[];
+  // FunctionCall uses the BuiltinTable
+  _symbol: string;
+}
+
+interface FunctionCall extends UpperFunctionCall {
+  // "f(x)"
+  type: "FunctionCall";
+}
+
+interface SeededFunctionCall extends UpperFunctionCall {
+  // "\\operatorname{random}(3)"
+  type: "SeededFunctionCall";
+  args: [ExtendSeed, ...ChildExprNode[]];
+  seed: unknown;
+}
+
+interface Seed extends Expression {
+  type: "Seed";
+  _stringValue: string;
+  isString: true;
+}
+
+interface ExtendSeed extends Expression {
+  type: "ExtendSeed";
+  seed: Expression;
+  userSeed: Expression;
+  tag: unknown;
+  asValue(): string;
+}
+
+interface FunctionExponent extends Expression {
+  // "f(x)^2"
+  args: [Identifier, ChildExprNode, ChildExprNode];
+  type: "FunctionExponent";
+}
+
+// FunctionFactorial is for stuff like f(x)! ≡ (f(x))!
+interface FunctionFactorial extends Expression {
+  // "f(x)!"
+  args: [Identifier, ChildExprNode];
+  type: "FunctionFactorial";
+}
+
+interface UpperIdentifier extends Expression {
+  args: [];
+  // includes ans.
+  _symbol: string;
+  _errorSymbol: string;
+}
+
+interface Identifier extends UpperIdentifier {
+  // "a"
+  type: "Identifier";
+}
+
+interface Ans extends UpperIdentifier {
+  // Not sure how to get Ans
+  type: "Identifier";
+}
+
+interface Integral extends Expression {
+  // "\\int_{0}^{1}tdt"
+  type: "Integral";
+  // differential, bottom, top, integrant
+  args: [Identifier, ChildExprNode, ChildExprNode, ChildExprNode];
+  _differential: Identifier;
+}
+
+interface Derivative extends Expression {
+  // "\\frac{d}{dx}x";
+  type: "Derivative";
+  args: [ChildExprNode];
+  _symbol: string;
+}
+
+interface Prime extends Expression {
+  // "f''(x)"
+  type: "Prime";
+  args: [ChildExprNode];
+  order: number;
+}
+
+interface List extends Expression {
+  // "[1,2,3]"
+  type: "List";
+  args: ChildExprNode[];
+  length: number;
+  isList: true;
+  asCompilerValue(): (boolean | number)[];
+  // eachArgs(): void // TODO
+  wrap(): unknown;
+}
+
+interface Range extends Expression {
+  // "[1...5]"
+  type: "Range";
+  /*
+  For [1...2], args are List[1,] and List[2,]
+  For [1,2,3,4...9,10,11], args are List[1,2,3,4] and List[9,10,11]
+  */
+  args: [List, List];
+  beginning: List;
+  end: List;
+  isHalfEmpty(): boolean;
+}
+
+interface ListAccess extends Expression {
+  // "L[1]"
+  type: "ListAccess";
+  args: [ChildExprNode, ChildExprNode];
+  list: ChildExprNode;
+  index: ChildExprNode;
+}
+
+interface OrderedPair extends Expression {
+  // "(1,2)"
+  type: "OrderedPair";
+  // (1,2,3) also turns into an OrderedPair, even though it's more of a triplet
+  args: ChildExprNode[];
+}
+
+interface MovablePoint extends OrderedPair {
+  moveStrategy: unknown;
+  defaultDragMode: unknown;
+  valueType: unknown; // types.Point
+  isMovablePoint: true;
+}
+
+interface Piecewise extends Expression {
+  // "\\{x<1:3, x<2, 5\\}"
+  type: "Piecewise";
+  // args[0] ? args[1] : args[2]
+  args: [ChildExprNode, ChildExprNode, ChildExprNode];
+  // chain(): unknown
+  // empty(): unknown
+}
+
+interface RGBColor extends Expression {
+  // Not sure how to get RGBColor
+}
+
+/* Repeated Operators */
+
+interface RepeatedOperator extends Expression {
+  _index: Identifier;
+  // index, start, end, summand
+  args: [Identifier, ChildExprNode, ChildExprNode, ChildExprNode];
+  evaluateConstant(b: [number, number]): number;
+  update(acc: number, el: number): number;
+}
+
+interface Product extends RepeatedOperator {
+  // "\\prod_{i=1}^{9}i"
+  type: "Product";
+  in_place_operator: "*=";
+  starting_value: 1;
+}
+
+interface Sum extends RepeatedOperator {
+  // "\\sum_{i=1}^{9}i"
+  type: "Sum";
+  in_place_operator: "+=";
+  starting_value: 0;
+}
+
+/* Arithmetic operators (expressionTypes) */
+interface Add extends Expression {
+  // "1+2"
+  args: [ChildExprNode, ChildExprNode];
+  type: "Add";
+}
+interface Subtract extends Expression {
+  // "1-2"
+  args: [ChildExprNode, ChildExprNode];
+  type: "Subtract";
+}
+interface Multiply extends Expression {
+  // "1\\cdot 2"
+  args: [ChildExprNode, ChildExprNode];
+  type: "Multiply";
+}
+interface Divide extends Expression {
+  // "\\frac{1}{2}"
+  args: [ChildExprNode, ChildExprNode];
+  type: "Divide";
+}
+interface Exponent extends Expression {
+  // "2^3"
+  args: [ChildExprNode, ChildExprNode];
+  type: "Exponent";
+}
+interface Negative extends Expression {
+  // "-2"
+  args: [ChildExprNode];
+  type: "Negative";
+}
+interface And extends Expression {
+  // "1<2<3"
+  args: [Comparator, Comparator];
+  type: "And";
+}
+interface RawExponent extends Exponent {
+  // Not sure how to get RawExponent
+  // Maybe it's Upper only
+}
+
+/* Comparing expressions */
+
+interface BaseComparator extends Expression {
+  // .create is called with "<", ">", "<=", ">=", and "="
+  create(): BaseComparator;
+  asComparator(): BaseComparator;
+  _difference(): Subtract;
+}
+
+interface Comparator extends BaseComparator {
+  // "1<3"
+  // "1<=3"
+  // "1>3"
+  // "1>=3"
+  // "\\left\\{x=0\\right\\}",
+  type:
+    | "Comparator['<']"
+    | "Comparator['>']"
+    | "Comparator['<=']"
+    | "Comparator['>=']"
+    | "Comparator['=']";
+}
+
+interface DoubleInequality extends Base {
+  // Not sure how to get DoubleInequality
+  type: "DoubleInequality";
+  _operators: [Expression, Expression];
+  _expressions: [Expression, Expression];
+  _indicator: unknown;
+  isShadeBetween(): true;
+}
+
+interface SolvedEquation extends Base {
+  // Not sure how to get SolvedEquation (probably a later transform)
+  type: "SolvedEquation";
+  _symbol: string;
+  _expression: Expression;
+  branchMultiplier: unknown;
+}
+
+interface UpperEquation extends Base {
+  _lhs: ChildExprNode;
+  _rhs: ChildExprNode;
+  _difference: Subtract;
+  asComparator: Comparator;
+}
+
+interface Equation extends UpperEquation {
+  // "1=3"
+  type: "Equation";
+}
+
+interface UpperAssignment extends UpperEquation {
+  _expression: ChildExprNode;
+  _symbol: string;
+  _exports: [] | [string];
+  shouldExportAns(): true;
+  computeExports(): [] | [string];
+  isEquation(): boolean;
+  asEquation(): Equation;
+  shouldPromoteToSlider(): boolean;
+}
+
+interface Assignment extends UpperAssignment {
+  // "a=3"
+  type: "Assignment";
+}
+
+interface Slider extends UpperAssignment {
+  type: "Slider";
+  sliderAssignment: Expression;
+  sliderMin: ChildExprNode;
+  sliderMax: ChildExprNode;
+  sliderSoftMin: ChildExprNode;
+  sliderSoftMax: ChildExprNode;
+  sliderStep: ChildExprNode;
+  sliderIsPlayingOnce: boolean;
+  shouldPromoteToSlider(): false;
+  asAssignment(): Assignment;
+}
+
+interface FunctionDefinition extends UpperEquation {
+  // "f(x)=x^2"
+  type: "FunctionDefinition";
+  // _exports are _symbol but wrapped
+  _exports: [string];
+  _argSymbols: string[];
+  _expression: ChildExprNode;
+  asEquation(): Equation;
+}
+
+/* Full-expr funcs */
+
+interface FullExprFunc extends Expression {
+  args: ChildExprNode[];
+}
+
+interface Stats extends FullExprFunc {
+  // "\\operatorname{stats}(L)"
+  type: "Stats";
+  _symbol: "stats";
+}
+interface Boxplot extends FullExprFunc {
+  // "\\operatorname{boxplot}(L)"
+  type: "Boxplot";
+  _symbol: "boxplot";
+}
+interface Dotplot extends FullExprFunc {
+  // "\\operatorname{dotplot}(L)"
+  type: "Dotplot";
+  _symbol: "dotplot";
+}
+interface Histogram extends FullExprFunc {
+  // "\\operatorname{histogram}(L)"
+  type: "Histogram";
+  _symbol: "histogram";
+}
+interface IndependentTTest extends FullExprFunc {
+  // "\\operatorname{ittest}(L,M)"
+  type: "IndependentTTest";
+  _symbol: "ittest";
+}
+interface TTest extends FullExprFunc {
+  // "\\operatorname{ttest}(L)"
+  type: "TTest";
+  _symbol: "ttest";
+}
+interface Polygon extends FullExprFunc {
+  // "\\operatorname{polygon}(P)"
+  type: "Polygon";
+  _symbol: "polygon";
+}
+
+/* Image */
+
+interface Image extends Base {
+  type: "Image";
+  isImage: true;
+  center: ChildExprNode;
+  radianAngle: ChildExprNode;
+  width: ChildExprNode;
+  height: ChildExprNode;
+  opacity: ChildExprNode;
+  moveStrategy: unknown;
+}
+
+/* Regression */
+
+interface Regression extends Base {
+  type: "Regression";
+  _lhs: ChildExprNode;
+  isLhsSimple: boolean; // just an identifier
+  _logLhs: FunctionCall;
+  _rhs: ChildExprNode;
+  _difference: Subtract;
+  _logDifference: Subtract;
+  isRegression: true;
+  exportTo: unknown;
+  getSliderVariables(): [];
+}
+
+interface OptimizedRegression extends Base {
+  type: "OptimizedRegression";
+  parameters: unknown;
+  residuals: unknown;
+  statistics: unknown;
+  model: unknown;
+  isModelValid: boolean;
+  residualVariable: string;
+  residualSuggestionId: unknown;
+  shouldSuggestLogMode: boolean;
+  isLinear: boolean;
+  parameterWarning: unknown;
+  _exports: [string];
+  getCompiledFunction(): Function;
+  getCompiledDerivative(): Function;
+}
+
+/* Simulation */
+interface Simulation extends Base {
+  type: "Simulation";
+  isSimulation: true;
+  fps: ChildExprNode;
+}
+
+/* Intermediate Representation */
+interface IRExpression extends Base {
+  type: "IRExpression";
+  _chunk: unknown;
+  valueType: unknown;
+  isList: boolean;
+  // length is for isList only
+  length: number;
+  isConstant: boolean;
+  shouldExportAns(): true;
+  getCompiledFunction(): Function;
+  polynomialOrder(): number;
+  getPolynomialCoefficients(): number[];
+  takeDerivative(): IRExpression;
+  boundDomain(): unknown;
+  asValue(): unknown;
+  asCompilerValue(): boolean | number | boolean[] | number[];
+  isNaN(): boolean;
+  getEvaluationInfo(): EvaluationInfo;
+  elementAt(): unknown;
+  findLinearSubset(): unknown;
+  deriveRegressionRestrictions(): unknown;
+  eachElement(f: unknown): void;
+  mapElements(f: unknown): unknown[];
+}
+
+/* Table */
+
+interface TableColumn extends Base {
+  type: "TableColumn";
+  header: ChildExprNode;
+  length: unknown;
+  values: unknown;
+  isIndependent: boolean;
+  _exports: string[];
+  isDiscrete(): boolean;
+  _exportSymbolsTo: unknown;
+  exportTo: unknown;
+  exportToLocal: unknown;
+}
+
+interface Table extends Base {
+  type: "Table";
+  columns: TableColumn[];
+  _exports: string[];
+  exportPenalty: 1;
+  isTable: true;
+  // exportTo
+  getAllIds(): string[];
+}
+
+export type RootOnlyExprNode =
+  | Equation
+  | Assignment
+  | FunctionDefinition
+  | Stats
+  | Boxplot
+  | Dotplot
+  | Histogram
+  | IndependentTTest
+  | TTest
+  | Polygon
+  | Regression;
+
+export type ChildExprNode =
+  | Error
+  | Constant
+  | MixedNumber
+  | DotAccess
+  | FunctionCall
+  | FunctionExponent
+  | FunctionFactorial
+  | Identifier // This includes ans
+  | Integral
+  | Derivative
+  | Prime
+  | List
+  | Range
+  | ListAccess
+  | OrderedPair
+  | OrderedPairAccess
+  | Piecewise
+  | Product
+  | Sum
+  | SeededFunctionCall
+  | Add
+  | Subtract
+  | Multiply
+  | Divide
+  | Exponent
+  | Negative
+  | And
+  | Comparator
+  | Assignment
+  // Seed + ExtendSeed only used in SeededFunctionCalls?
+  | Seed
+  | ExtendSeed;
+
+// These can only occur after further transformation or something
+type IrrelevantExprNode =
+  | Ans
+  | MovablePoint
+  | RGBColor
+  | RepeatedOperator
+  | RawExponent
+  | BaseComparator
+  | DoubleInequality
+  | SolvedEquation
+  | Slider
+  | Image
+  | OptimizedRegression
+  | Simulation
+  | IRExpression
+  | TableColumn
+  | Table;
+
+type Node = RootOnlyExprNode | ChildExprNode;
+export default Node;

--- a/src/parsing/parsenode.ts
+++ b/src/parsing/parsenode.ts
@@ -34,7 +34,7 @@ interface Base {
 
 type EvaluationInfo = false | undefined | { val: unknown }[];
 
-interface Error {
+export interface Error {
   // "1 ("
   type: "Error";
   _msg: {
@@ -50,7 +50,7 @@ interface Error {
   allowExport(): Error;
 }
 
-interface Span {
+export interface Span {
   input: string;
   start: number;
   end: number;
@@ -75,24 +75,24 @@ interface UpperConstant extends Expression {
   isNaN(): boolean;
 }
 
-interface Constant extends UpperConstant {
+export interface Constant extends UpperConstant {
   // "1.5"
   type: "Constant";
 }
 
-interface MixedNumber extends UpperConstant {
+export interface MixedNumber extends UpperConstant {
   // "1\\frac{3}{2}"
   type: "MixedNumber";
   is_mixed_number: true;
 }
 
-interface DotAccess extends Expression {
+export interface DotAccess extends Expression {
   // "a.w"
   type: "DotAccess";
   args: [ChildExprNode, Identifier];
 }
 
-interface OrderedPairAccess extends Expression {
+export interface OrderedPairAccess extends Expression {
   // "a.x"
   type: "OrderedPairAccess";
   args: [ChildExprNode, Constant];
@@ -106,25 +106,25 @@ interface UpperFunctionCall extends Expression {
   _symbol: string;
 }
 
-interface FunctionCall extends UpperFunctionCall {
+export interface FunctionCall extends UpperFunctionCall {
   // "f(x)"
   type: "FunctionCall";
 }
 
-interface SeededFunctionCall extends UpperFunctionCall {
+export interface SeededFunctionCall extends UpperFunctionCall {
   // "\\operatorname{random}(3)"
   type: "SeededFunctionCall";
   args: [ExtendSeed, ...ChildExprNode[]];
   seed: unknown;
 }
 
-interface Seed extends Expression {
+export interface Seed extends Expression {
   type: "Seed";
   _stringValue: string;
   isString: true;
 }
 
-interface ExtendSeed extends Expression {
+export interface ExtendSeed extends Expression {
   type: "ExtendSeed";
   seed: Expression;
   userSeed: Expression;
@@ -132,14 +132,14 @@ interface ExtendSeed extends Expression {
   asValue(): string;
 }
 
-interface FunctionExponent extends Expression {
+export interface FunctionExponent extends Expression {
   // "f(x)^2"
   args: [Identifier, ChildExprNode, ChildExprNode];
   type: "FunctionExponent";
 }
 
 // FunctionFactorial is for stuff like f(x)! ≡ (f(x))!
-interface FunctionFactorial extends Expression {
+export interface FunctionFactorial extends Expression {
   // "f(x)!"
   args: [Identifier, ChildExprNode];
   type: "FunctionFactorial";
@@ -152,17 +152,17 @@ interface UpperIdentifier extends Expression {
   _errorSymbol: string;
 }
 
-interface Identifier extends UpperIdentifier {
+export interface Identifier extends UpperIdentifier {
   // "a"
   type: "Identifier";
 }
 
-interface Ans extends UpperIdentifier {
+export interface Ans extends UpperIdentifier {
   // Not sure how to get Ans
-  type: "Identifier";
+  type: "Ans";
 }
 
-interface Integral extends Expression {
+export interface Integral extends Expression {
   // "\\int_{0}^{1}tdt"
   type: "Integral";
   // differential, bottom, top, integrant
@@ -170,21 +170,21 @@ interface Integral extends Expression {
   _differential: Identifier;
 }
 
-interface Derivative extends Expression {
+export interface Derivative extends Expression {
   // "\\frac{d}{dx}x";
   type: "Derivative";
   args: [ChildExprNode];
   _symbol: string;
 }
 
-interface Prime extends Expression {
+export interface Prime extends Expression {
   // "f''(x)"
   type: "Prime";
   args: [ChildExprNode];
   order: number;
 }
 
-interface List extends Expression {
+export interface List extends Expression {
   // "[1,2,3]"
   type: "List";
   args: ChildExprNode[];
@@ -195,7 +195,7 @@ interface List extends Expression {
   wrap(): unknown;
 }
 
-interface Range extends Expression {
+export interface Range extends Expression {
   // "[1...5]"
   type: "Range";
   /*
@@ -208,7 +208,7 @@ interface Range extends Expression {
   isHalfEmpty(): boolean;
 }
 
-interface ListAccess extends Expression {
+export interface ListAccess extends Expression {
   // "L[1]"
   type: "ListAccess";
   args: [ChildExprNode, ChildExprNode];
@@ -216,7 +216,7 @@ interface ListAccess extends Expression {
   index: ChildExprNode;
 }
 
-interface OrderedPair extends Expression {
+export interface OrderedPair extends Expression {
   // "(1,2)"
   type: "OrderedPair";
   // (1,2,3) also turns into an OrderedPair, even though it's more of a triplet
@@ -230,7 +230,7 @@ interface MovablePoint extends OrderedPair {
   isMovablePoint: true;
 }
 
-interface Piecewise extends Expression {
+export interface Piecewise extends Expression {
   // "\\{x<1:3, x<2, 5\\}"
   type: "Piecewise";
   // args[0] ? args[1] : args[2]
@@ -253,14 +253,14 @@ interface RepeatedOperator extends Expression {
   update(acc: number, el: number): number;
 }
 
-interface Product extends RepeatedOperator {
+export interface Product extends RepeatedOperator {
   // "\\prod_{i=1}^{9}i"
   type: "Product";
   in_place_operator: "*=";
   starting_value: 1;
 }
 
-interface Sum extends RepeatedOperator {
+export interface Sum extends RepeatedOperator {
   // "\\sum_{i=1}^{9}i"
   type: "Sum";
   in_place_operator: "+=";
@@ -268,37 +268,37 @@ interface Sum extends RepeatedOperator {
 }
 
 /* Arithmetic operators (expressionTypes) */
-interface Add extends Expression {
+export interface Add extends Expression {
   // "1+2"
   args: [ChildExprNode, ChildExprNode];
   type: "Add";
 }
-interface Subtract extends Expression {
+export interface Subtract extends Expression {
   // "1-2"
   args: [ChildExprNode, ChildExprNode];
   type: "Subtract";
 }
-interface Multiply extends Expression {
+export interface Multiply extends Expression {
   // "1\\cdot 2"
   args: [ChildExprNode, ChildExprNode];
   type: "Multiply";
 }
-interface Divide extends Expression {
+export interface Divide extends Expression {
   // "\\frac{1}{2}"
   args: [ChildExprNode, ChildExprNode];
   type: "Divide";
 }
-interface Exponent extends Expression {
+export interface Exponent extends Expression {
   // "2^3"
   args: [ChildExprNode, ChildExprNode];
   type: "Exponent";
 }
-interface Negative extends Expression {
+export interface Negative extends Expression {
   // "-2"
   args: [ChildExprNode];
   type: "Negative";
 }
-interface And extends Expression {
+export interface And extends Expression {
   // "1<2<3"
   args: [Comparator, Comparator];
   type: "And";
@@ -317,7 +317,7 @@ interface BaseComparator extends Expression {
   _difference(): Subtract;
 }
 
-interface Comparator extends BaseComparator {
+export interface Comparator extends BaseComparator {
   // "1<3"
   // "1<=3"
   // "1>3"
@@ -355,7 +355,7 @@ interface UpperEquation extends Base {
   asComparator: Comparator;
 }
 
-interface Equation extends UpperEquation {
+export interface Equation extends UpperEquation {
   // "1=3"
   type: "Equation";
 }
@@ -371,12 +371,12 @@ interface UpperAssignment extends UpperEquation {
   shouldPromoteToSlider(): boolean;
 }
 
-interface Assignment extends UpperAssignment {
+export interface Assignment extends UpperAssignment {
   // "a=3"
   type: "Assignment";
 }
 
-interface Slider extends UpperAssignment {
+export interface Slider extends UpperAssignment {
   type: "Slider";
   sliderAssignment: Expression;
   sliderMin: ChildExprNode;
@@ -389,11 +389,12 @@ interface Slider extends UpperAssignment {
   asAssignment(): Assignment;
 }
 
-interface FunctionDefinition extends UpperEquation {
+export interface FunctionDefinition extends UpperEquation {
   // "f(x)=x^2"
   type: "FunctionDefinition";
   // _exports are _symbol but wrapped
   _exports: [string];
+  _symbol: string;
   _argSymbols: string[];
   _expression: ChildExprNode;
   asEquation(): Equation;
@@ -405,37 +406,37 @@ interface FullExprFunc extends Expression {
   args: ChildExprNode[];
 }
 
-interface Stats extends FullExprFunc {
+export interface Stats extends FullExprFunc {
   // "\\operatorname{stats}(L)"
   type: "Stats";
   _symbol: "stats";
 }
-interface Boxplot extends FullExprFunc {
+export interface Boxplot extends FullExprFunc {
   // "\\operatorname{boxplot}(L)"
   type: "Boxplot";
   _symbol: "boxplot";
 }
-interface Dotplot extends FullExprFunc {
+export interface Dotplot extends FullExprFunc {
   // "\\operatorname{dotplot}(L)"
   type: "Dotplot";
   _symbol: "dotplot";
 }
-interface Histogram extends FullExprFunc {
+export interface Histogram extends FullExprFunc {
   // "\\operatorname{histogram}(L)"
   type: "Histogram";
   _symbol: "histogram";
 }
-interface IndependentTTest extends FullExprFunc {
+export interface IndependentTTest extends FullExprFunc {
   // "\\operatorname{ittest}(L,M)"
   type: "IndependentTTest";
   _symbol: "ittest";
 }
-interface TTest extends FullExprFunc {
+export interface TTest extends FullExprFunc {
   // "\\operatorname{ttest}(L)"
   type: "TTest";
   _symbol: "ttest";
 }
-interface Polygon extends FullExprFunc {
+export interface Polygon extends FullExprFunc {
   // "\\operatorname{polygon}(P)"
   type: "Polygon";
   _symbol: "polygon";
@@ -443,7 +444,7 @@ interface Polygon extends FullExprFunc {
 
 /* Image */
 
-interface Image extends Base {
+export interface Image extends Base {
   type: "Image";
   isImage: true;
   center: ChildExprNode;
@@ -456,7 +457,7 @@ interface Image extends Base {
 
 /* Regression */
 
-interface Regression extends Base {
+export interface Regression extends Base {
   type: "Regression";
   _lhs: ChildExprNode;
   isLhsSimple: boolean; // just an identifier
@@ -469,7 +470,7 @@ interface Regression extends Base {
   getSliderVariables(): [];
 }
 
-interface OptimizedRegression extends Base {
+export interface OptimizedRegression extends Base {
   type: "OptimizedRegression";
   parameters: unknown;
   residuals: unknown;
@@ -487,14 +488,14 @@ interface OptimizedRegression extends Base {
 }
 
 /* Simulation */
-interface Simulation extends Base {
+export interface Simulation extends Base {
   type: "Simulation";
   isSimulation: true;
   fps: ChildExprNode;
 }
 
 /* Intermediate Representation */
-interface IRExpression extends Base {
+export interface IRExpression extends Base {
   type: "IRExpression";
   _chunk: unknown;
   valueType: unknown;
@@ -521,7 +522,7 @@ interface IRExpression extends Base {
 
 /* Table */
 
-interface TableColumn extends Base {
+export interface TableColumn extends Base {
   type: "TableColumn";
   header: ChildExprNode;
   length: unknown;
@@ -534,7 +535,7 @@ interface TableColumn extends Base {
   exportToLocal: unknown;
 }
 
-interface Table extends Base {
+export interface Table extends Base {
   type: "Table";
   columns: TableColumn[];
   _exports: string[];

--- a/src/parsing/traverse.ts
+++ b/src/parsing/traverse.ts
@@ -1,16 +1,11 @@
 import Node, { ChildExprNode } from "./parsenode";
 
-class Path<n extends Node = Node> {
-  shouldSkip = false;
+export class Path<n extends Node = Node> {
   constructor(
     public node: n,
     public parent: Path | null,
     public index: number
   ) {}
-
-  skip() {
-    this.shouldSkip = true;
-  }
 
   getChildren() {
     if ("args" in this.node) {
@@ -43,29 +38,9 @@ export default function traverse(node: Node, callbacks: Callbacks) {
 
 function traversePath(path: Path, callbacks: Callbacks) {
   callbacks.enter?.(path);
-  if (!path.shouldSkip) {
-    const children = path.getChildren();
-    for (let i = 0; i < children.length; i++) {
-      traversePath(new Path(children[i], path, i), callbacks);
-    }
+  const children = path.getChildren();
+  for (let i = 0; i < children.length; i++) {
+    traversePath(new Path(children[i], path, i), callbacks);
   }
   callbacks.exit?.(path);
 }
-
-(window as any).traverse = traverse;
-
-/*
-// sample code to replace all `t` identifiers with `u`.
-{
-  const s = String.raw`t^2+2t+[1...5][t]`;
-  const node = require("core/math/baseparser").parse(s);
-  traverse(node, {
-    enter: (path) => {
-      if (path.node.type === "Identifier" && path.node._symbol === "t") {
-        path.node._symbol = "u";
-      }
-    },
-  });
-  console.log(node.printLatex());
-}
-*/

--- a/src/parsing/traverse.ts
+++ b/src/parsing/traverse.ts
@@ -1,0 +1,71 @@
+import Node, { ChildExprNode } from "./parsenode";
+
+class Path<n extends Node = Node> {
+  shouldSkip = false;
+  constructor(
+    public node: n,
+    public parent: Path | null,
+    public index: number
+  ) {}
+
+  skip() {
+    this.shouldSkip = true;
+  }
+
+  getChildren() {
+    if ("args" in this.node) {
+      return this.node.args as ChildExprNode[];
+    }
+    switch (this.node.type) {
+      case "Assignment":
+      case "FunctionDefinition":
+        return [this.node._expression];
+      case "Regression":
+      case "Equation":
+        return [this.node._lhs, this.node._rhs];
+      case "Error":
+        return [];
+      default:
+        const type = (this.node as any).type;
+        throw `Unexpected node type: ${type}. How did you obtain it?`;
+    }
+  }
+}
+
+interface Callbacks {
+  enter?(path: Path): void;
+  exit?(path: Path): void;
+}
+
+export default function traverse(node: Node, callbacks: Callbacks) {
+  traversePath(new Path(node, null, 0), callbacks);
+}
+
+function traversePath(path: Path, callbacks: Callbacks) {
+  callbacks.enter?.(path);
+  if (!path.shouldSkip) {
+    const children = path.getChildren();
+    for (let i = 0; i < children.length; i++) {
+      traversePath(new Path(children[i], path, i), callbacks);
+    }
+  }
+  callbacks.exit?.(path);
+}
+
+(window as any).traverse = traverse;
+
+/*
+// sample code to replace all `t` identifiers with `u`.
+{
+  const s = String.raw`t^2+2t+[1...5][t]`;
+  const node = require("core/math/baseparser").parse(s);
+  traverse(node, {
+    enter: (path) => {
+      if (path.node.type === "Identifier" && path.node._symbol === "t") {
+        path.node._symbol = "u";
+      }
+    },
+  });
+  console.log(node.printLatex());
+}
+*/

--- a/src/plugins/find-replace/backend.ts
+++ b/src/plugins/find-replace/backend.ts
@@ -1,13 +1,13 @@
-import { Calc } from "desmodder";
+import { Calc, parseDesmosLatex } from "desmodder";
+import traverse, { Path } from "parsing/traverse";
+import { Identifier } from "parsing/parsenode";
 
-function replace(from: RegExp, to: string) {
+function replace(replaceLatex: (s: string) => string) {
   // replaceString is applied to stuff like labels
   // middle group in regex accounts for 1 layer of braces, sufficient for `Print ${a+2}`
   function replaceString(s: string) {
     // `from` should have "global" flag enabled in order to replace all
-    return s.replace(/(?<=\$\{)((?:[^{}]|\{[^}]*\})+)(?=\})/g, (e) =>
-      e.replace(from, to)
-    );
+    return s.replace(/(?<=\$\{)((?:[^{}]|\{[^}]*\})+)(?=\})/g, replaceLatex);
   }
   const simpleKeys = [
     "latex",
@@ -33,14 +33,14 @@ function replace(from: RegExp, to: string) {
   state.expressions.list.forEach((expr: any) => {
     rootKeys.forEach((k) => {
       if (k in expr) {
-        expr[k] = expr[k].replace(from, to);
+        expr[k] = replaceLatex(expr[k]);
       }
     });
     for (const sub of ["slider", "parametricDomain", "polarDomain"]) {
       if (expr[sub]) {
         ["max", "min", "step"].forEach((k) => {
           if (k in expr[sub]) {
-            expr[sub][k] = expr[sub][k].replace(from, to);
+            expr[sub][k] = replaceLatex(expr[sub][k]);
           }
         });
       }
@@ -52,10 +52,10 @@ function replace(from: RegExp, to: string) {
       expr.columns.forEach((col: any) => {
         simpleKeys.forEach((k) => {
           if (k in col) {
-            col[k] = col[k].replace(from, to);
+            col[k] = replaceLatex(col[k]);
           }
         });
-        col.values = col.values.map((s: string) => s.replace(from, to));
+        col.values = col.values.map(replaceLatex);
       });
     }
     if (expr.clickableInfo) {
@@ -68,7 +68,7 @@ function replace(from: RegExp, to: string) {
         expr.clickableInfo.rules.forEach((rule: any) => {
           ["assignment", "expression"].forEach((k) => {
             if (k in rule) {
-              rule[k] = rule[k].replace(from, to);
+              rule[k] = replaceLatex(rule[k]);
             }
           });
         });
@@ -85,19 +85,70 @@ function escapeRegExp(s: string) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 }
 
-export function refactor(fromExpr: string, toExpr: string) {
-  // `\b` takes \w ≡ [A-Za-z0-9_] as word characters. (digits and underscores are included).
-  // For a search key of "w", we want to match the "w" in "2w", so we can't use just `\b` at start
-  // the positive lookahead and lookbehind are designed to (for a search of "w")
-  //   match the "w" in "\\left(w,", "2w", "w", "w\\right)"
-  //   not match the "w" in "P_{aww}", "w_{1}"
-  // I'm not 100% sure these protect all use cases, but they do a decent job.
-  // escapeRegExp needed for any input with parentheses, powers, etc.
-  replace(
-    RegExp(
-      "(?<=\\b|\\d|\\W|^)" + escapeRegExp(fromExpr) + "(?=\\b|\\W|$)",
-      "g"
-    ),
-    toExpr
-  );
+export function refactor(from: string, replacement: string) {
+  const fromParsed = parseDesmosLatex(from);
+  if (fromParsed.type === "Identifier") {
+    replace((s: string) => {
+      const node = parseDesmosLatex(s);
+      if (node.type === "Error") {
+        return s;
+      }
+      const idPositions: {
+        start: number;
+        end: number;
+        isDifferential: boolean;
+      }[] = [];
+      traverse(node, {
+        exit(path: Path) {
+          if (
+            path.node.type === "Identifier" &&
+            path.node._symbol === fromParsed._symbol
+          ) {
+            // A normal identifier
+            idPositions.push({
+              ...path.node.getInputSpan(),
+              // It's actually a differential like dx
+              // path.parent?.node.type === "Integral" && path.index === 0
+              isDifferential:
+                path.node._errorSymbol === "d" + path.node._symbol,
+            });
+          } else if (
+            (path.node.type === "Assignment" ||
+              path.node.type === "FunctionDefinition") &&
+            path.node._symbol === fromParsed._symbol
+          ) {
+            // An assignment like a=5
+            // LHS is an identifier, but it doesn't become an arg
+            const span = path.node.getInputSpan();
+            idPositions.push({
+              // Need this code (imperfect) to handle funky input like
+              // replacing "a_{0}" in "  a_{0}    =    72 "
+              // TODO: better handling, and handle argSymbols in FunctionDefinition
+              //    Maybe .asEquation() can help
+              start: span.start,
+              end: span.start + fromParsed._symbol.length,
+              isDifferential: false,
+            });
+          }
+        },
+      });
+      // args don't necessarily go in latex order
+      const sorted = idPositions.sort((a, b) => a.start - b.start);
+      let acc = "";
+      let endIndex = 0;
+      for (let { start, end, isDifferential } of sorted) {
+        acc += s.slice(endIndex, start);
+        if (isDifferential) {
+          acc += "d";
+        }
+        acc += replacement;
+        endIndex = end;
+      }
+      acc += s.slice(endIndex);
+      return acc;
+    });
+  } else {
+    const regex = RegExp(escapeRegExp(from), "g");
+    replace((s: string) => s.replace(regex, replacement));
+  }
 }

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,4 +1,5 @@
 import { desmosRequire, Calc } from "globals/window";
+import Node from "../parsing/parsenode";
 
 const _EvaluateSingleExpression = desmosRequire(
   "core/math/evaluate-single-expression"
@@ -6,6 +7,9 @@ const _EvaluateSingleExpression = desmosRequire(
 
 export const jquery = desmosRequire("jquery");
 export const keys = desmosRequire("keys");
+export const parseDesmosLatex = desmosRequire("parser").parse as (
+  s: string
+) => Node;
 
 export function EvaluateSingleExpression(s: string): number {
   // may also return NaN (which is a number)


### PR DESCRIPTION
Fixes #103 and some rare issues. But this mainly sets up for further parse tree stuff. Partially resolves #39 