### PR TITLE
Disable GLesmos by default, and show a warning

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -317,6 +317,7 @@ export default interface Calc {
     };
     listModel: unknown;
     _addItemToEndFromAPI(item: ItemModel): void;
+    _showToast(toast: { message: string }): void;
   };
   selectedExpressionId: string;
   //// public

--- a/src/main/Controller.ts
+++ b/src/main/Controller.ts
@@ -294,7 +294,21 @@ export default class Controller {
   }
 
   checkForMetadataChange() {
-    this.graphMetadata = getMetadata();
+    const newMetadata = getMetadata();
+    if (!this.pluginsEnabled["GLesmos"]) {
+      if (
+        Object.entries(newMetadata.expressions).some(
+          ([id, e]) => e.glesmos && !this.graphMetadata.expressions[id]?.glesmos
+        )
+      ) {
+        // list of glesmos expressions changed
+        Calc.controller._showToast({
+          message:
+            "Enable the GLesmos plugin to improve the performance of some implicits in this graph",
+        });
+      }
+    }
+    this.graphMetadata = newMetadata;
     this.applyPinnedStyle();
   }
 

--- a/src/plugins/GLesmos/index.ts
+++ b/src/plugins/GLesmos/index.ts
@@ -14,8 +14,9 @@ function onDisable() {
 export default {
   id: "GLesmos",
   name: "GLesmos",
-  description: "Export as a GLSL fragment shader",
+  description:
+    "Render implicits on the GPU. Can cause the UI slow down or freeze in rare cases; reload the page if you have issues.",
   onEnable: onEnable,
   onDisable: onDisable,
-  enabledByDefault: true,
+  enabledByDefault: false,
 } as const;

--- a/src/plugins/duplicate-hotkey/index.ts
+++ b/src/plugins/duplicate-hotkey/index.ts
@@ -20,9 +20,9 @@ function onDisable() {
 
 export default {
   id: "duplicate-expression-hotkey",
-  name: "Improved Duplication",
+  name: "Duplicate Expression Hotkey",
   description:
-    "Lets you duplicate all expression types, including folders. Ctrl+Q duplicates the currently-selected expression.",
+    "Type Ctrl+Q or Cmd+Q to duplicate the currently-selected expression.",
   onEnable: onEnable,
   onDisable: onDisable,
   enabledByDefault: true,

--- a/src/plugins/show-tips/tips.ts
+++ b/src/plugins/show-tips/tips.ts
@@ -132,7 +132,7 @@ const tips: TipData[] = [
     learnMore: "https://help.desmos.com/hc/en-us/articles/4405489674381-Tables",
   },
   {
-    desc: "Type Control+/ or Command+/ to open the list of keyboard shortcuts",
+    desc: "Type Ctrl+/ or Cmd+/ to open the list of keyboard shortcuts",
   },
   {
     desc: "List comprehensions are great for grids of points or lists of polygons",


### PR DESCRIPTION
Show the warning when GLesmos is disabled, but the user opens a graph with a GLesmos-enabled expression.