### PR TITLE
Allow lists in GLesmos

### DIFF
--- a/src/parsing/IR.ts
+++ b/src/parsing/IR.ts
@@ -93,13 +93,6 @@ interface SymbolicListVar extends HasValueType {
   // valueType must be a list
 }
 
-interface BroadcastResult extends HasValueType {
-  type: Opcodes["BroadcastResult"];
-  args: unknown;
-  length: number;
-  isConstantBroadcast: boolean;
-}
-
 interface Constant extends HasValueType {
   type: Opcodes["Constant"];
   value: unknown;
@@ -184,6 +177,7 @@ interface List extends HasValueType {
 
 interface ListAccess extends HasValueType {
   type: Opcodes["ListAccess"];
+  // args: [list, index]
   args: [number, number];
 }
 
@@ -194,6 +188,7 @@ interface DeferredListAccess extends HasValueType {
 
 interface InboundsListAccess extends HasValueType {
   type: Opcodes["InboundsListAccess"];
+  // args: [list, index]
   args: [number, number];
 }
 
@@ -226,11 +221,22 @@ interface BeginBroadcast extends HasValueType {
   type: Opcodes["BeginBroadcast"];
   length: number;
   endIndex: number;
+  // args: [index of list length]
+  args: [number];
 }
 
 interface EndBroadcast extends HasValueType {
   type: Opcodes["EndBroadcast"];
-  args: unknown;
+  // args: [matching StartBroadcast index, return index, ...more return indices]
+  args: number[];
+}
+
+interface BroadcastResult extends HasValueType {
+  type: Opcodes["BroadcastResult"];
+  // args: [matching EndBroadcast index]
+  args: [number];
+  constantLength?: number;
+  isConstantBroadcast: boolean;
 }
 
 interface BeginLoop extends HasValueType {

--- a/src/plugins/GLesmos/Controller.ts
+++ b/src/plugins/GLesmos/Controller.ts
@@ -28,8 +28,8 @@ export default class Controller {
         float a = 1.0 - (1.0 - from.a) * (1.0 - top.a);
         return vec4((from.rgb * from.a * (1.0 - top.a) + top.rgb * top.a) / a, a);
       }`,
-      "vec4 outColor = vec4(0.0);",
       "void glesmosMain(vec2 coords) {",
+      "  outColor = vec4(0.0);",
       "  float x = coords.x; float y = coords.y;",
       compiledGL.bodies.join("\n"),
       "}",

--- a/src/plugins/GLesmos/builtins.ts
+++ b/src/plugins/GLesmos/builtins.ts
@@ -1,6 +1,6 @@
 // reference https://www.khronos.org/registry/OpenGL-Refpages/gl4/index.php
 
-// Test using https://www.desmos.com/calculator/2l2pnpsazy
+// Test using https://www.desmos.com/calculator/lfgehepjce
 const builtins: {
   [K: string]:
     | undefined
@@ -71,32 +71,24 @@ const builtins: {
     tag: "simple",
   },
   sinh: {
-    def: "float sinh(float x) { float a=abs(x); return -0.5*sign(x)*exp(a)*expm1(-2.0*a); }",
-    deps: ["expm1"],
     tag: "simple",
   },
   cosh: {
-    body: "0.5*(exp(x)+exp(-x))",
     tag: "simple",
   },
   tanh: {
-    def: "float tanh(float x) { float m=expm1(-2.0*abs(x)); return -sign(x)*m/(2.0+m); }",
-    deps: ["expm1"],
     tag: "simple",
   },
   coth: {
     body: "1.0/tanh(x)",
-    deps: ["tanh"],
     tag: "simple",
   },
   sech: {
     body: "1.0/cosh(x)",
-    deps: ["cosh"],
     tag: "simple",
   },
   csch: {
     body: "1.0/sinh(x)",
-    deps: ["sinh"],
     tag: "simple",
   },
   arcsinh: {
@@ -546,10 +538,6 @@ const builtins: {
   },
 
   /** HELPERS for numeric stability */
-  expm1: {
-    body: "x+0.5*x*x == x ? x : exp(x)-1.0",
-    tag: "simple",
-  },
   log1p: {
     body: "x-0.5*x*x == x ? x : log(1.0+x)",
     tag: "simple",

--- a/src/plugins/GLesmos/builtins.ts
+++ b/src/plugins/GLesmos/builtins.ts
@@ -292,8 +292,34 @@ const builtins: {
   // mad: {},
   // careful: GLSL length is Euclidean norm
   // length: {},
-  // min: {},
-  // max: {},
+  min: {
+    // We know n >= 1: otherwise the `min` could be constant-collapsed to 0
+    make: (n) => `
+    float minList(float[${n}] L) {
+      float m = L[0];
+      for (int i=1; i<${n}; i++) {
+        m = min(m, L[i]);
+      }
+      return m;
+    }
+    `,
+    alias: "minList",
+    tag: "list",
+  },
+  max: {
+    // We know n >= 1: otherwise the `min` could be constant-collapsed to 0
+    make: (n) => `
+    float maxList(float[${n}] L) {
+      float m = L[0];
+      for (int i=1; i<${n}; i++) {
+        m = max(m, L[i]);
+      }
+      return m;
+    }
+    `,
+    alias: "maxList",
+    tag: "list",
+  },
   // argmin: {},
   // argmax: {},
   // median: {},
@@ -386,7 +412,7 @@ export function getDefinition(s: string) {
   // which should be specialized to a list of 10 args
   const data = getBuiltin(s);
   if (data === undefined) {
-    throw `Undefined: ${s}`;
+    throw `Undefined identifier: ${s}`;
   }
   if (data.tag === "simple") {
     const name = data?.alias ?? s;

--- a/src/plugins/GLesmos/emitChunkGL.ts
+++ b/src/plugins/GLesmos/emitChunkGL.ts
@@ -1,7 +1,14 @@
-import { getFunctionName } from "./builtins";
+import { getFunctionName, getBuiltin } from "./builtins";
 import { IRChunk, IRInstruction } from "parsing/IR";
 import { compileObject, getGLType } from "./outputHelpers";
 import { countReferences, opcodes, printOp, Types } from "./opcodeDeps";
+import { desmosRequire } from "globals/workerSelf";
+
+export const ListLength = desmosRequire(
+  "core/math/ir/features/list-length"
+) as {
+  getConstantListLength(chunk: IRChunk, index: number): number;
+};
 
 function getIdentifier(index: number) {
   return `_${index}`;
@@ -59,13 +66,20 @@ function getSourceBinOp(
 
 function getSourceSimple(
   ci: IRInstruction,
+  instructionIndex: number,
   inlined: string[],
-  deps: Set<string>
+  deps: Set<string>,
+  lists: string[],
+  chunk: IRChunk
 ) {
   switch (ci.type) {
     case opcodes.Constant:
       if (Types.isList(ci.valueType)) {
-        throw "Lists not yet implemented";
+        const id = getIdentifier(instructionIndex);
+        const val = ci.value as any[];
+        const init = val.map(compileObject).join(",");
+        lists.push(`float ${id}[${val.length}] = float[](${init});\n`);
+        return id;
       } else {
         return compileObject(ci.value);
       }
@@ -96,7 +110,7 @@ function getSourceSimple(
         maybeInlined(ci.args[2], inlined)
       );
     case opcodes.List:
-      throw "Lists not yet implemented";
+      throw "List construction not yet implemented";
     case opcodes.DeferredListAccess:
     case opcodes.Distribution:
     case opcodes.SymbolicVar:
@@ -104,13 +118,24 @@ function getSourceSimple(
       const op = printOp(ci.type);
       throw `Programming Error: expect ${op} to be removed before emitting code.`;
     case opcodes.ListAccess:
-      throw "Lists not yet implemented";
+      throw "List access not yet implemented";
     // in-bounds list access assumes that args[1] is an integer
     // between 1 and args[0].length, inclusive
     case opcodes.InboundsListAccess:
-      throw "Lists not yet implemented";
+      return (
+        maybeInlined(ci.args[0], inlined) +
+        "[" +
+        maybeInlined(ci.args[1], inlined) +
+        "-1]"
+      );
     case opcodes.NativeFunction:
-      deps.add(ci.symbol);
+      if (getBuiltin(ci.symbol)?.tag === "list") {
+        deps.add(
+          ci.symbol + "#" + ListLength.getConstantListLength(chunk, ci.args[0])
+        );
+      } else {
+        deps.add(ci.symbol);
+      }
       const name = getFunctionName(ci.symbol);
       const args = ci.args.map((e) => maybeInlined(e, inlined)).join(",");
       return `${name}(${args})`;
@@ -196,13 +221,70 @@ function getEndLoopSource(
   return s;
 }
 
+function getBeginBroadcastSource(
+  instructionIndex: number,
+  ci: IRInstruction & { type: typeof opcodes.BeginBroadcast },
+  chunk: IRChunk
+) {
+  const endInstruction = chunk.getInstruction(ci.endIndex);
+  const varInits = [];
+  let broadcastLength = 0;
+  if (endInstruction.type === opcodes.EndBroadcast) {
+    for (let i = 1; i < endInstruction.args.length; i++) {
+      const index = ci.endIndex + i;
+      const broadcastRes = chunk.getInstruction(index);
+      if (broadcastRes.type === opcodes.BroadcastResult) {
+        const len = broadcastRes.constantLength;
+        if (typeof len !== "number") {
+          throw "Broadcast not supported on list with non-constant length";
+        }
+        broadcastLength = len;
+        varInits.push(`float[${len}] ${getIdentifier(index)};\n`);
+      }
+    }
+  }
+  const broadcastIndexVar = getIdentifier(instructionIndex);
+  return (
+    varInits.join("") +
+    `for(int ${broadcastIndexVar}=1;${broadcastIndexVar}<=${broadcastLength};++${broadcastIndexVar}){\n`
+  );
+}
+
+function getEndBroadcastSource(
+  instructionIndex: number,
+  ci: IRInstruction & { type: typeof opcodes.EndBroadcast },
+  chunk: IRChunk,
+  inlined: string[]
+) {
+  const resultAssignments = [];
+  const broadcastIndexVar = getIdentifier(ci.args[0]);
+
+  for (let i = 1; i < ci.args.length; i++) {
+    const index = instructionIndex + i;
+    if (index < chunk.instructionsLength()) {
+      if (chunk.getInstruction(index).type === opcodes.BroadcastResult) {
+        resultAssignments.push(
+          getIdentifier(index) +
+            "[" +
+            broadcastIndexVar +
+            "-1]=" +
+            getIdentifier(ci.args[i]) +
+            ";\n"
+        );
+      }
+    }
+  }
+  return resultAssignments.join("") + "}\n";
+}
+
 function getSourceAndNextIndex(
   chunk: IRChunk,
   currInstruction: IRInstruction,
   instructionIndex: number,
   referenceCountList: number[],
   inlined: string[],
-  deps: Set<string>
+  deps: Set<string>,
+  lists: string[]
 ) {
   const incrementedIndex = instructionIndex + 1;
   switch (currInstruction.type) {
@@ -224,8 +306,24 @@ function getSourceAndNextIndex(
         nextIndex: incrementedIndex,
       };
     case opcodes.BeginBroadcast:
+      return {
+        source: getBeginBroadcastSource(
+          instructionIndex,
+          currInstruction,
+          chunk
+        ),
+        nextIndex: incrementedIndex,
+      };
     case opcodes.EndBroadcast:
-      throw "Broadcasts not yet implemented";
+      return {
+        source: getEndBroadcastSource(
+          instructionIndex,
+          currInstruction,
+          chunk,
+          inlined
+        ),
+        nextIndex: incrementedIndex,
+      };
     case opcodes.BeginLoop:
       deps.add("round");
       return {
@@ -248,7 +346,14 @@ function getSourceAndNextIndex(
         nextIndex: incrementedIndex,
       };
     default:
-      let src = getSourceSimple(currInstruction, inlined, deps);
+      let src = getSourceSimple(
+        currInstruction,
+        instructionIndex,
+        inlined,
+        deps,
+        lists,
+        chunk
+      );
       if (referenceCountList[instructionIndex] <= 1) {
         inlined[instructionIndex] = `(${src})`;
         // referenced at most once, so just inline it
@@ -273,6 +378,7 @@ export default function emitChunkGL(chunk: IRChunk) {
   let outputSource = "";
   let inlined: string[] = [];
   let deps = new Set<string>();
+  let lists: string[] = [];
   for (
     let instructionIndex = 0;
     instructionIndex < chunk.instructionsLength();
@@ -285,14 +391,15 @@ export default function emitChunkGL(chunk: IRChunk) {
       instructionIndex,
       referenceCountList,
       inlined,
-      deps
+      deps,
+      lists
     );
     outputSource += u.source;
     instructionIndex = u.nextIndex;
   }
   outputSource += `return ${maybeInlined(chunk.returnIndex, inlined)};`;
   return {
-    source: outputSource,
+    source: lists.join("") + outputSource,
     deps,
   };
 }

--- a/src/plugins/GLesmos/emitChunkGL.ts
+++ b/src/plugins/GLesmos/emitChunkGL.ts
@@ -250,7 +250,7 @@ function getBeginBroadcastSource(
   const broadcastIndexVar = getIdentifier(instructionIndex);
   return (
     varInits.join("") +
-    `for(int ${broadcastIndexVar}=1;${broadcastIndexVar}<=${broadcastLength};++${broadcastIndexVar}){\n`
+    `for(float ${broadcastIndexVar}=1.0;${broadcastIndexVar}<=${broadcastLength}.0;++${broadcastIndexVar}){\n`
   );
 }
 

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -75,21 +75,21 @@ const FULLSCREEN_QUAD = new Float32Array([
   -1, 1, 1, 1, 1, -1, -1, 1, 1, -1, -1, -1,
 ]);
 
-const VERTEX_SHADER = `
+const VERTEX_SHADER = `#version 300 es
 
-    attribute highp vec2 vertexPosition;
+in highp vec2 vertexPosition;
+out vec2 texCoord;
 
-    varying vec2 texCoord;
-
-    void main() {
-        texCoord = vertexPosition * 0.5 + 0.5;
-        gl_Position = vec4(vertexPosition, 0.0, 1.0);
-    }
+void main() {
+    texCoord = vertexPosition * 0.5 + 0.5;
+    gl_Position = vec4(vertexPosition, 0.0, 1.0);
+}
 `;
 
-const GLESMOS_FRAGMENT_SHADER = `
-varying mediump vec2 texCoord;
+const GLESMOS_FRAGMENT_SHADER = `#version 300 es
 precision highp float;
+in vec2 texCoord;
+out vec4 outColor;
 
 uniform vec2 corner;
 uniform vec2 size;
@@ -100,13 +100,11 @@ uniform float Infinity;
 #define M_E 2.71828182845904523536028747135266
 
 //REPLACE_WITH_GLESMOS
-vec4 outColor = vec4(0.0);
 void glesmosMain(vec2 coords) {}
 //REPLACE_WITH_GLESMOS_END
 
 void main() {
     glesmosMain(texCoord * size + corner);
-    gl_FragColor = outColor;
 }
 
 `;
@@ -114,7 +112,7 @@ void main() {
 export function initGLesmosCanvas() {
   //================= INIT ELEMENTS =======================
   let c: HTMLCanvasElement = document.createElement("canvas");
-  let gl: WebGLRenderingContext = c.getContext("webgl", {
+  let gl: WebGLRenderingContext = c.getContext("webgl2", {
     // Disable premultiplied alpha
     // Thanks to <https://stackoverflow.com/a/12290551/7481517>
     premultipliedAlpha: false,
@@ -157,12 +155,6 @@ export function initGLesmosCanvas() {
     );
   };
 
-  setGLesmosShader(
-    `vec4 outColor = vec4(0.0);
-    void glesmosMain(vec2 coords) {}`,
-    "Empty"
-  );
-
   let render = (id: string) => {
     if (glesmosShaderProgram) {
       gl.useProgram(glesmosShaderProgram);
@@ -191,8 +183,6 @@ export function initGLesmosCanvas() {
       throw glesmosError("Shader failed");
     }
   };
-
-  render("Base");
 
   //================= CLEANUP =============
 

--- a/src/plugins/GLesmos/outputHelpers.ts
+++ b/src/plugins/GLesmos/outputHelpers.ts
@@ -57,11 +57,17 @@ export function compileObject(x: any): string {
 export function getGLType(v: ValueType) {
   switch (v) {
     case Types.Bool:
-      return "boolean";
+      return "bool";
     case Types.Number:
       return "float";
     case Types.Point:
       return "vec2";
+    case Types.ListOfBool:
+      return "bool[]";
+    case Types.ListOfNumber:
+      return "float[]";
+    case Types.ListOfPoint:
+      return "vec2[]";
     default:
       throw `Type ${v} is not yet supported`;
   }

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,4 +1,5 @@
 import { desmosRequire, Calc } from "globals/window";
+import { IRChunk } from "parsing/IR";
 import Node from "../parsing/parsenode";
 
 const _EvaluateSingleExpression = desmosRequire(


### PR DESCRIPTION
There are still quite a few rough edges:
- list length must be determinable at compile time.
  - This *could* be worked around by obtaining upper bounds for lists (e.g. requiring list slices to always decrease the list length), then storing filtered shorter lists in a long array with a separate variable for the length. This would open up the possibility of the `unique` function, list filters, and some others.
- The `sort` function is pretty slow, which is to be expected. As such, I haven't implemented `median` and the other quantiles
  - The quantile functions *could* be sped up (compared to a simple index into a sort) by implementing quickselect
- The `shuffle` function, the `random` function, and a few others have not been implemented because they should not occur at GL compile time (either they should be constants, or their list length is non-constant)