### PR TITLE
Fix find-replace styles and Ctrl+F hotkey

### DIFF
--- a/src/plugins/find-replace/ReplaceBar.less
+++ b/src/plugins/find-replace/ReplaceBar.less
@@ -1,10 +1,18 @@
-.dcg-expressions-scrolled ~ .find-replace-expression-replace-bar {
-  // z-index to avoid being below .dcg-expressions-scrolled's box shadow
-  z-index: 4;
-  box-shadow: -2px 2px 4px rgb(0 0 0 / 15%);
+.dsm-find-replace-expression-replace-bar {
+  .dcg-expressions-scrolled ~ & {
+    // z-index to avoid being below .dcg-expressions-scrolled's box shadow
+    z-index: 4;
+    box-shadow: -2px 2px 4px rgb(0 0 0 / 15%);
+  }
+
+  .dcg-expression-search-bar {
+    display: flex;
+    align-items: center;
+    padding-top: 0;
+  }
 }
 
-.find-replace-replace-all {
+.dsm-find-replace-replace-all {
   @color: hsv(215, 80%, 85%);
 
   color: @color;

--- a/src/plugins/find-replace/ReplaceBar.tsx
+++ b/src/plugins/find-replace/ReplaceBar.tsx
@@ -54,7 +54,7 @@ export default class ReplaceBar extends Component<{
         </div>
         {/* Using a standard Button looks horrible on the gray background */}
         <div
-          class="find-replace-replace-all"
+          class="dsm-find-replace-replace-all"
           role="button"
           onTap={() => this.controller.refactorAll()}
         >

--- a/src/plugins/find-replace/View.ts
+++ b/src/plugins/find-replace/View.ts
@@ -34,7 +34,7 @@ export default class View {
     searchBar.parentNode.insertBefore(searchContainer, searchBar);
     searchContainer.appendChild(searchBar);
     this.mountNode = document.createElement("div");
-    this.mountNode.className = "find-replace-expression-replace-bar";
+    this.mountNode.className = "dsm-find-replace-expression-replace-bar";
     searchContainer.appendChild(this.mountNode);
     this.replaceView = mountToNode(ReplaceBar, this.mountNode, {
       controller: constArg(this.controller),

--- a/src/plugins/text-mode/Controller.ts
+++ b/src/plugins/text-mode/Controller.ts
@@ -19,6 +19,7 @@ export default class Controller {
     // expression UI doesn't render in text mode, we replace markTickRequiredNextFrame
     // with a version that calls markTickRequiredNextFrame only when sliders are playing
     if (this.inTextMode) {
+      Calc.controller.dispatch({ type: "close-expression-search" });
       Calc.controller.markTickRequiredNextFrame = function () {
         if (this.getPlayingSliders().length > 0) {
           (this as any).__proto__.markTickRequiredNextFrame.apply(this);

--- a/src/preload/moduleOverrides/instancehotkeys.ts
+++ b/src/preload/moduleOverrides/instancehotkeys.ts
@@ -8,16 +8,14 @@ export default () => ({
     
     @how
       Replaces
-        this.controller.isExpressionListFocused() &&
-          (this.controller.dispatch({ type: "open-expression-search" }), ...
-      with just the right side of the `&&`:
-        (this.controller.dispatch({ type: "open-expression-search" }), ...
+        this.controller.isExpressionListFocused()
+      with `true`
     */
     if (path.node.name === "isExpressionListFocused") {
-      const andPath = path.findParent((p) =>
-        p.isLogicalExpression()
-      ) as babel.NodePath<t.LogicalExpression> | null;
-      andPath?.replaceWith(andPath.node.right);
+      const callPath = path.findParent((p) =>
+        p.isCallExpression()
+      ) as babel.NodePath<t.CallExpression> | null;
+      callPath?.replaceWith(t.booleanLiteral(true));
     }
   },
 });

--- a/src/preload/moduleOverrides/instancehotkeys.ts
+++ b/src/preload/moduleOverrides/instancehotkeys.ts
@@ -1,3 +1,4 @@
+import template from "@babel/template";
 import * as t from "@babel/types";
 
 export default () => ({
@@ -9,13 +10,16 @@ export default () => ({
     @how
       Replaces
         this.controller.isExpressionListFocused()
-      with `true`
+      with
+        !window.DesModder?.controller?.inTextMode?.()
     */
     if (path.node.name === "isExpressionListFocused") {
       const callPath = path.findParent((p) =>
         p.isCallExpression()
       ) as babel.NodePath<t.CallExpression> | null;
-      callPath?.replaceWith(t.booleanLiteral(true));
+      callPath?.replaceWith(
+        template.expression.ast(`!window.DesModder?.controller?.inTextMode?.()`)
+      );
     }
   },
 });


### PR DESCRIPTION
- Fix Ctrl+F hotkey when expressions list is not selected
- Prevent expression search while inside text mode
- Move "replace all" button to same line as replace box
