### PR TITLE
🌐: Fully localise performance-info plugin

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -141,3 +141,10 @@ shift-enter-newline-desc = Use Shift+Enter to type newlines in notes and image/f
 ## Performance Display
 performance-info-name = Performance Display
 performance-info-desc = Displays information about the performance of the current graph.
+performance-info-refresh-graph = Refresh Graph
+performance-info-refresh-graph-tooltip = Refresh the graph to test initial load time
+performance-info-sticky-tooltip = Keep menu open
+performance-info-time-in-worker = Time In Worker
+performance-info-compiling = Compiling
+performance-info-rendering = Rendering
+performance-info-other = Other

--- a/src/plugins/performance-info/PerformanceView.tsx
+++ b/src/plugins/performance-info/PerformanceView.tsx
@@ -3,6 +3,7 @@ import { Component, jsx } from "DCGView";
 import Controller from "./Controller";
 import DesModderController from "main/Controller";
 import "./PerformanceView.less";
+import { format } from "i18n/i18n-core";
 
 export class PerformanceView extends Component<{
   controller: () => Controller;
@@ -12,7 +13,7 @@ export class PerformanceView extends Component<{
     return (
       <div class="dcg-popover-interior dsm-performance-info-menu">
         <div class="dsm-pi-pin-menu-button-container">
-          <Tooltip gravity="w" tooltip="Keep menu open">
+          <Tooltip gravity="s" tooltip={format("performance-info-sticky-tooltip")}>
             <IconButton
               iconClass={"dsm-icon-bookmark"}
               onTap={() => {
@@ -28,21 +29,21 @@ export class PerformanceView extends Component<{
         </div>
         <ul>
           <li>
-            <strong>Time In Worker: </strong>
+            <strong>{format("performance-info-time-in-worker")}: </strong>
             {() =>
               Math.round(this.props.controller().getTimingData().timeInWorker)
             }
             ms
           </li>
           <li>
-            <strong>Compiling: </strong>
+            <strong>{format("performance-info-compiling")}: </strong>
             {() =>
               Math.round(this.props.controller().getTimingData().updateAnalysis)
             }
             ms
           </li>
           <li>
-            <strong>Rendering: </strong>
+            <strong>{format("performance-info-rendering")}: </strong>
             {() =>
               Math.round(
                 this.props.controller().getTimingData().graphAllChanges
@@ -51,7 +52,7 @@ export class PerformanceView extends Component<{
             ms
           </li>
           <li>
-            <strong>Other: </strong>
+            <strong>{format("performance-info-other")}: </strong>
             {() => {
               const timingData = this.props.controller().getTimingData();
               return Math.round(
@@ -63,7 +64,7 @@ export class PerformanceView extends Component<{
           </li>
         </ul>
         <div class="dsm-pi-refresh-state-button-container">
-          <Tooltip tooltip="Refresh the graph state to measure first load performance">
+          <Tooltip tooltip={format("performance-info-refresh-graph-tooltip")}>
             <Button
               color="primary"
               class="dsm-pi-refresh-state-button"
@@ -71,7 +72,7 @@ export class PerformanceView extends Component<{
                 this.props.controller().refreshState();
               }}
             >
-              Refresh Graph
+              {format("performance-info-refresh-graph")}
             </Button>
           </Tooltip>
         </div>

--- a/src/plugins/performance-info/PerformanceView.tsx
+++ b/src/plugins/performance-info/PerformanceView.tsx
@@ -13,7 +13,10 @@ export class PerformanceView extends Component<{
     return (
       <div class="dcg-popover-interior dsm-performance-info-menu">
         <div class="dsm-pi-pin-menu-button-container">
-          <Tooltip gravity="s" tooltip={format("performance-info-sticky-tooltip")}>
+          <Tooltip
+            gravity="s"
+            tooltip={format("performance-info-sticky-tooltip")}
+          >
             <IconButton
               iconClass={"dsm-icon-bookmark"}
               onTap={() => {

--- a/src/plugins/performance-info/View.ts
+++ b/src/plugins/performance-info/View.ts
@@ -2,11 +2,12 @@ import { jquery } from "utils/depUtils";
 import { desModderController } from "script";
 import { MainPopupFunc } from "./PerformanceView";
 import { controller } from "./index";
+import { format } from "i18n/i18n-core";
 
 export function initView() {
   desModderController.addPillboxButton({
     id: "dsm-pi-menu",
-    tooltip: "Performance Info View",
+    tooltip: format("performance-info-name"),
     iconClass: "dsm-icon-pie-chart",
     popup: (desModderController) =>
       MainPopupFunc(controller, desModderController),


### PR DESCRIPTION
"ms" was left as a literal because it's an SI unit