### PR TITLE
🌐: Add localised aria-label to GLesmos toggle

### DIFF
--- a/src/preload/moduleOverrides/expression-menus__fill.ts
+++ b/src/preload/moduleOverrides/expression-menus__fill.ts
@@ -32,6 +32,7 @@ export default (dependencyNameMap: DependencyNameMap) => ({
             { class: %%DCGView%%.const("dcg-options-menu-section-title dsm-gl-fill-title") },
             () => DesModder.controller.format("GLesmos-label-toggle-glesmos"),
             %%DCGView%%.createElement(%%ToggleView%%.ToggleView, {
+              ariaLabel: () => DesModder.controller.format("GLesmos-label-toggle-glesmos"),
               toggled: () => window.DesModder?.controller?.isGlesmosMode?.(%%this%%.id),
               onChange: (a) => window.DesModder?.controller?.toggleGlesmos?.(%%this%%.id),
             })


### PR DESCRIPTION
Previous label was "Rendered with GLesmos", which showed even when the slider was disabled. Re-added and renamed to "Render with GLesmos".
Closes #424