### PR TITLE
Glesmos shader cache fix

### DIFF
--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -52,16 +52,26 @@ function buildShaderProgram(
 }
 
 const shaderCache = new Map<string, WebGLProgram>();
-function getShaderProgram(gl: WebGLRenderingContext | WebGL2RenderingContext, key: string, id: string, create: () => { vertexSource: string, fragmentSource: string }) {
-    const cachedShader = shaderCache.get(key);
-    if (cachedShader) {
-        return cachedShader;
-    } else {
-        const sources = create();
-        const shaderProgram = buildShaderProgram(gl, sources.vertexSource, sources.fragmentSource, id);
-        shaderCache.set(key, shaderProgram);
-        return shaderProgram;
-    }
+function getShaderProgram(
+  gl: WebGLRenderingContext | WebGL2RenderingContext,
+  key: string,
+  id: string,
+  create: () => { vertexSource: string; fragmentSource: string }
+) {
+  const cachedShader = shaderCache.get(key);
+  if (cachedShader) {
+    return cachedShader;
+  } else {
+    const sources = create();
+    const shaderProgram = buildShaderProgram(
+      gl,
+      sources.vertexSource,
+      sources.fragmentSource,
+      id
+    );
+    shaderCache.set(key, shaderProgram);
+    return shaderProgram;
+  }
 }
 
 type UniformType = "1f" | "2fv" | "3fv" | "4fv";
@@ -156,13 +166,13 @@ export function initGLesmosCanvas() {
 
   let setGLesmosShader = (shaderCode: string, id: string) => {
     glesmosShaderProgram = getShaderProgram(gl, shaderCode, id, () => {
-        return {
-            fragmentSource: GLESMOS_FRAGMENT_SHADER.replace(
-                /\/\/REPLACE_WITH_GLESMOS[\s\S]*\/\/REPLACE_WITH_GLESMOS_END/g,
-                shaderCode
-            ),
-            vertexSource: VERTEX_SHADER
-        }
+      return {
+        fragmentSource: GLESMOS_FRAGMENT_SHADER.replace(
+          /\/\/REPLACE_WITH_GLESMOS[\s\S]*\/\/REPLACE_WITH_GLESMOS_END/g,
+          shaderCode
+        ),
+        vertexSource: VERTEX_SHADER,
+      };
     });
   };
 

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -70,6 +70,9 @@ function getShaderProgram(
       id
     );
     shaderCache.set(key, shaderProgram);
+    if (shaderCache.size > 100) {
+        shaderCache.delete(Array.from(shaderCache.keys())[0]);
+    }
     return shaderProgram;
   }
 }

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -71,7 +71,7 @@ function getShaderProgram(
     );
     shaderCache.set(key, shaderProgram);
     if (shaderCache.size > 100) {
-        shaderCache.delete(Array.from(shaderCache.keys())[0]);
+      shaderCache.delete(Array.from(shaderCache.keys())[0]);
     }
     return shaderProgram;
   }


### PR DESCRIPTION
Shaders are now cached instead of being remade every time the canvas is rerendered.
This is the same as the previous PR, but without the "frame spreading" feature.