### PR TITLE
Refactor WakaTime plugin

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -143,6 +143,8 @@ wakatime-name = WakaTime
 wakatime-desc = Track your desmos activity on WakaTime.com
 wakatime-opt-secretKey-name = Secret Key
 wakatime-opt-secretKey-desc = API Key used for WakaTime servers
+wakatime-opt-splitProjects-name = Split Projects by Graph
+wakatime-opt-splitProjects-desc = Store each graph as its own project instead of branches of a unified Desmos Project
 
 ## Performance Display
 performance-info-name = Performance Display

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -19,7 +19,8 @@ export type DispatchedEvent =
         | "set-graph-settings"
         | "resize-exp-list"
         | "set-none-selected"
-        | "toggle-graph-settings";
+        | "toggle-graph-settings"
+        | "clear-unsaved-changes";
     }
   | {
       type:

--- a/src/plugins/wakatime/config.ts
+++ b/src/plugins/wakatime/config.ts
@@ -1,0 +1,20 @@
+export const configList = [
+  {
+    key: "splitProjects",
+    type: "boolean",
+    default: false,
+  },
+  {
+    key: "secretKey",
+    type: "string",
+    variant: "password",
+    default: "",
+  },
+  // `as const` ensures that the key values can be used as types
+  // instead of the type 'string'
+] as const;
+
+export interface Config {
+  splitProjects: boolean;
+  secretKey: string;
+}

--- a/src/plugins/wakatime/heartbeat.ts
+++ b/src/plugins/wakatime/heartbeat.ts
@@ -4,6 +4,8 @@ export interface HeartbeatOptions {
   graphName: string;
   graphURL: string;
   lineCount: number;
+  splitProjects: boolean;
+  isWrite: boolean;
 }
 
 export async function sendHeartbeat(key: string, opts: HeartbeatOptions) {
@@ -17,12 +19,12 @@ export async function sendHeartbeat(key: string, opts: HeartbeatOptions) {
     lines: opts.lineCount,
     lineno: null,
     cursorpos: null,
-    is_write: null,
+    is_write: opts.isWrite,
 
     // Everything below will show up in your Leaderboard.
-    project: opts.graphName,
+    project: opts.splitProjects ? opts.graphName : "Desmos Project",
     entity: opts.graphURL,
-    branch: null,
+    branch: opts.splitProjects ? null : opts.graphName,
   };
 
   if (key === "") throw new Error("Secret key not provided.");

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -24,6 +24,7 @@ async function maybeSendHeartbeat(isWrite: boolean) {
     type: "send-heartbeat",
     options: { graphName, graphURL, lineCount, splitProjects, isWrite },
   });
+  lastUpdate = performance.now();
 }
 
 async function onEnable() {
@@ -32,7 +33,7 @@ async function onEnable() {
       e.type === "on-evaluator-changes" ||
       e.type === "clear-unsaved-changes"
     ) {
-      maybeSendHeartbeat(e.type === "clear-unsaved-changes");
+      void maybeSendHeartbeat(e.type === "clear-unsaved-changes");
     }
   });
 }

--- a/src/preload/content.ts
+++ b/src/preload/content.ts
@@ -18,7 +18,7 @@ function getInitialData() {
         [id: string]: { [key: string]: any };
       };
       // Hide secret key from web page
-      if (settings.wakatime?.secretKey !== "") {
+      if (settings.wakatime?.secretKey) {
         settings.wakatime.secretKey = "????????-????-????-????-????????????";
       }
       postMessageDown({
@@ -51,7 +51,7 @@ function _sendHeartbeat(options: HeartbeatOptions) {
           chrome.runtime.id,
           { type: "send-background-heartbeat", options, secretKey },
           (e) => {
-            if (e.type === "heartbeat-error") {
+            if (e?.type === "heartbeat-error") {
               postMessageDown(e);
             }
           }


### PR DESCRIPTION
- Modifies the WakaTime plugin to more closely match other plugins. It now properly follows https://wakatime.com/help/creating-plugin so AFK time will not be counted (heartbeats are only sent as a result of user interaction).
- Adds an option to split each graph into its own project (current behaviour) with the default being to store all graphs as one project ("Desmos Project"). Strongly recommended by Heavenira. (Resolves #450)
- Fixes a few miscellaneous bugs related to the plugin. (Resolves #451)