### PR TITLE
Improve replacements

### DIFF
--- a/src/preload/moduleOverrides/hide-errors.replacements
+++ b/src/preload/moduleOverrides/hide-errors.replacements
@@ -166,9 +166,8 @@ __ret__ && !window.DesModder.controller.isErrorHidden(this.model?.id)
 *Find* => `from`
 ```js
 if ("Enter" === $e)
-  return t && (t.preventDefault(), t.stopPropagation()),
+  return $t && ($t.preventDefault(), $t.stopPropagation()),
     this.controller.dispatch({ type: "on-special-key-pressed", key: "Enter" })
-
 ```
 
 *Replace* `from` with

--- a/src/preload/moduleOverrides/hide-errors.replacements
+++ b/src/preload/moduleOverrides/hide-errors.replacements
@@ -174,7 +174,7 @@ if ("Enter" === $e)
 *Replace* `from` with
 ```js
 __from__
-else if ("Shift-Enter" === e) {
+else if ("Shift-Enter" === $e) {
   window.DesModder.controller.hideError(this.model.id);
   return this.controller.dispatch({
     type: "on-special-key-pressed",

--- a/src/preload/replacementHelpers/applyReplacement.ts
+++ b/src/preload/replacementHelpers/applyReplacement.ts
@@ -256,6 +256,7 @@ function findPattern(
   inside: Range,
   allowDuplicates: boolean
 ): MatchResult {
+  const fullPattern = pattern;
   // filter whitespace out of pattern
   pattern = pattern.filter((token) => !isIgnoredWhitespace(token));
   let found: MatchResult | null = null;
@@ -272,7 +273,7 @@ function findPattern(
   }
   if (found === null)
     throw new ReplacementError(
-      `Pattern not found: ${pattern.map((v) => v.value).join("")}`
+      `Pattern not found: ${fullPattern.map((v) => v.value).join("")}`
     );
   return found;
 }

--- a/src/preload/replacementHelpers/parse.ts
+++ b/src/preload/replacementHelpers/parse.ts
@@ -22,7 +22,7 @@ export interface ModuleBlock extends BaseBlock {
   tag: "ModuleBlock";
   modules: string[];
   plugin: string;
-  replaceCommand: Command;
+  replaceCommands: Command[];
 }
 
 export interface Command {
@@ -113,20 +113,6 @@ function parseBlock(
       i++;
     }
   }
-  const expectedReplaces = start.command === "module" ? 1 : 0;
-  const numReplaces = commands.filter((x) => x.command === "replace").length;
-  if (numReplaces !== expectedReplaces)
-    throw new ReplacementError(
-      `Block ${start.command} expects ${expectedReplaces} ` +
-        `*replace* command(s) but got ${numReplaces}`
-    );
-  if (
-    start.command === "module" &&
-    commands.findIndex((x) => x.command === "replace") < commands.length - 1
-  )
-    throw new ReplacementError(
-      `Module block should have *replace* command at end, but found one in the middle`
-    );
   const base = {
     heading: heading.text,
     filename,
@@ -135,8 +121,8 @@ function parseBlock(
     ? {
         tag: "ModuleBlock",
         ...base,
-        commands: commands.slice(0, -1),
-        replaceCommand: commands[commands.length - 1],
+        commands: commands.filter((x) => x.command !== "replace"),
+        replaceCommands: commands.filter((x) => x.command === "replace"),
         plugin,
         modules: start.args,
       }

--- a/src/preload/replacementHelpers/tokenize.ts
+++ b/src/preload/replacementHelpers/tokenize.ts
@@ -13,6 +13,7 @@ export type PatternToken =
     };
 
 export function tokenizeReplacement(replacementString: string) {
+  replacementString = replacementString.replace(/\r/g, "");
   if (!replacementString.startsWith("#"))
     throw new ReplacementError("File is missing heading");
   const tokens: ReplacementToken[] = [];


### PR DESCRIPTION
- Get rid of carriage returns in replacements
- Allow multiple replacements in one block
- Keep track of invalidated ranges
- Give line numbers on tokenizer errors
- Include spaces in "pattern not found" error
