### PR TITLE
Enable DesModder for all subdomains

### DIFF
--- a/public/chrome/manifest.json
+++ b/public/chrome/manifest.json
@@ -13,7 +13,7 @@
   "action": {},
   "content_scripts": [
     {
-      "matches": ["https://www.desmos.com/calculator*"],
+      "matches": ["https://*.desmos.com/calculator*"],
       "run_at": "document_start",
       "js": ["preload/content.js"],
       "all_frames": true
@@ -27,7 +27,7 @@
         "preload/script.js",
         "worker/append.js"
       ],
-      "matches": ["https://www.desmos.com/*"]
+      "matches": ["https://*.desmos.com/*"]
     }
   ],
   "declarative_net_request": {
@@ -42,6 +42,6 @@
   "permissions": ["storage", "declarativeNetRequest"],
   "host_permissions": ["https://*.desmos.com/*", "https://wakatime.com/"],
   "externally_connectable": {
-    "matches": ["https://www.desmos.com/*"]
+    "matches": ["https://*.desmos.com/*"]
   }
 }

--- a/public/chrome/net_request_rules.json
+++ b/public/chrome/net_request_rules.json
@@ -18,7 +18,7 @@
       ]
     },
     "condition": {
-      "urlFilter": "https://www.desmos.com/*",
+      "urlFilter": "https://*.desmos.com/calculator*",
       "resourceTypes": ["main_frame", "script"]
     }
   },
@@ -47,7 +47,7 @@
       "type": "block"
     },
     "condition": {
-      "urlFilter": "https://www.desmos.com/assets/build/calculator_desktop-*.js|"
+      "urlFilter": "https://*.desmos.com/assets/build/calculator_desktop-*.js|"
     }
   }
 ]

--- a/public/firefox/manifest.json
+++ b/public/firefox/manifest.json
@@ -12,7 +12,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.desmos.com/calculator*"],
+      "matches": ["https://*.desmos.com/calculator*"],
       "run_at": "document_start",
       "js": ["preload/content.js"],
       "all_frames": true

--- a/src/background.ts
+++ b/src/background.ts
@@ -31,7 +31,7 @@ if (BROWSER === "firefox") {
       cancel: url.endsWith(".js"),
     }),
     {
-      urls: ["https://www.desmos.com/assets/build/calculator_desktop-*.js"],
+      urls: ["https://*.desmos.com/assets/build/calculator_desktop-*.js"],
     },
     ["blocking"]
   );
@@ -56,7 +56,7 @@ if (BROWSER === "firefox") {
       ],
     }),
     {
-      urls: ["https://www.desmos.com/*"],
+      urls: ["https://*.desmos.com/calculator*"],
     },
     ["blocking", "responseHeaders"]
   );


### PR DESCRIPTION
Now, DesModder works on https://delta.desmos.com as well as any other
subdomain.

This is easy to get wrong ([last patch when this went wrong](https://github.com/DesModder/DesModder/commit/c3a175bc484060301e134a6bbc02f0969fd57f7b)),
so I have checked, for both Firefox and Chrome:

- [x] https://desmos.com/art images load correctly
- [x] https://teacher.desmos.com works correctly
- [x] The regular calculator works.

This might have just been wrong the last time because it filtered for
`https://*.desmos.com/*`; now, we filter for
`https://*.desmos.com/calculator*` instead, which should not false-
positive any subdomains for enabling COEP and COOP.
