### PR TITLE
Fail gracefully on replacements errors

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -80,6 +80,7 @@ const opts = {
     ".ts": "ts",
     ".ftl": "text",
     ".woff": "dataurl",
+    ".html": "text",
   },
   logLevel: "info",
 };

--- a/src/components/Toggle.less
+++ b/src/components/Toggle.less
@@ -1,5 +1,8 @@
-// many classes to handle specificity for cursor
-.dcg-toggle-view.dcg-toggled.dsm-disabled-toggle {
-  opacity: 0.3;
-  cursor: not-allowed;
+.dcg-toggle-view.dsm-disabled-toggle {
+  cursor: not-allowed !important;
+  opacity: 0.3 !important;
+  &:not(.dcg-toggled) .dcg-toggle-switch {
+    background: #666 !important;
+    box-shadow: none !important;
+  }
 }

--- a/src/i18n/i18n-core.ts
+++ b/src/i18n/i18n-core.ts
@@ -2,22 +2,36 @@ import enFTL from "../../localization/en.ftl";
 import { FluentBundle, FluentResource, FluentVariable } from "@fluent/bundle";
 import { desmosRequire } from "globals/window";
 
-const { currentLanguage } = desmosRequire("lib/i18n-core") as {
+interface Intl {
   currentLanguage: () => string;
-};
+}
+let i18nCore: Intl | null = null;
+function currentLanguage() {
+  // defend against currentLangauge being used before Desmos loaded, e.g.
+  // for showing panic messages
+  if (i18nCore === null) {
+    try {
+      i18nCore = desmosRequire("lib/i18n-core") as Intl;
+    } catch (e) {}
+  }
+  if (i18nCore === null) return "en";
+  else return i18nCore.currentLanguage();
+}
 
 const locales = new Map<string, FluentBundle>();
 
 export function format(
   key: string,
-  args?: Record<string, FluentVariable> | null | undefined
-) {
+  args?: Record<string, FluentVariable> | null | undefined,
+  missingReplacement?: string | undefined
+): string {
   const lang = currentLanguage();
   const bundle = locales.get(lang) ?? locales.get("en")!;
   const message = bundle.getMessage(key);
   if (message === undefined || message.value === null) {
-    console.warn("Error formatting key", key, "in locale", lang);
-    return "";
+    if (missingReplacement === undefined)
+      console.warn("Error formatting key", key, "in locale", lang);
+    return missingReplacement ?? "";
   }
   return bundle.formatPattern(message.value, args);
 }

--- a/src/i18n/i18n-core.ts
+++ b/src/i18n/i18n-core.ts
@@ -7,7 +7,7 @@ interface Intl {
 }
 let i18nCore: Intl | null = null;
 function currentLanguage() {
-  // defend against currentLangauge being used before Desmos loaded, e.g.
+  // defend against currentLanguage being used before Desmos loaded, e.g.
   // for showing panic messages
   if (i18nCore === null) {
     try {

--- a/src/panic/html.d.ts
+++ b/src/panic/html.d.ts
@@ -1,0 +1,4 @@
+declare module "*.html" {
+  const content: string;
+  export default content;
+}

--- a/src/panic/panic.html
+++ b/src/panic/panic.html
@@ -27,12 +27,23 @@
   #dsm-panic-apply-reload-btn {
     float: right;
   }
+  #dsm-plugins-disabled,
+  #dsm-encountered-errors {
+    /* Don't show until something gets added to this list */
+    display: none;
+  }
 </style>
 <div id="dsm-panic-popover">
-  <h2>DesModder Errors Detected</h2>
-  <p>
-    Following errors: (the checkboxes do nothing for now. This is temporary)
+  <h2>DesModder Loading Errors Manager</h2>
+  <p id="dsm-encountered-errors">
+    DesModder encountered loading errors with the following plugins: (check the
+    box to disable plugin)
   </p>
   <ul id="dsm-panic-list"></ul>
+  <p id="dsm-plugins-disabled">
+    The following plugins are already disabled from loading: (uncheck box to
+    allow enabling plugin)
+  </p>
+  <ul id="dsm-disabled-list"></ul>
   <button id="dsm-panic-apply-reload-btn">Apply and Reload</button>
 </div>

--- a/src/panic/panic.html
+++ b/src/panic/panic.html
@@ -26,14 +26,60 @@
   }
   #dsm-panic-apply-reload-btn {
     float: right;
+    padding: 3px 10px;
   }
   #dsm-plugins-disabled,
   #dsm-encountered-errors {
     /* Don't show until something gets added to this list */
     display: none;
   }
+  #dsm-panic-reopen-button {
+    position: absolute;
+    top: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 999;
+    width: 37px;
+    height: 37px;
+    line-height: 34px;
+    font-size: 20px;
+    color: #5f5f5f;
+  }
+  .dsm-panic-button {
+    text-align: center;
+    cursor: pointer;
+    background: #ededed;
+    box-shadow: 0 0 5px rgb(0 0 0 / 15%);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 5px;
+  }
+  #dsm-panic-close-button {
+    border: none;
+    background: transparent;
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    cursor: pointer;
+    font-size: 25px;
+    color: #5f5f5f;
+  }
+  #dsm-panic-close-button:hover,
+  #dsm-panic-reopen-button:hover {
+    color: black;
+  }
+  body.dsm-panic-closed #dsm-panic-popover {
+    display: none;
+  }
+  body:not(.dsm-panic-closed) #dsm-panic-reopen-button {
+    display: none;
+  }
+  body.dsm-panic-closed .dcg-header .dcg-home-link {
+    pointer-events: none;
+    cursor: default;
+  }
 </style>
 <div id="dsm-panic-popover">
+  <button id="dsm-panic-close-button">✖</button>
   <h2>DesModder Loading Errors Manager</h2>
   <p id="dsm-encountered-errors">
     DesModder encountered loading errors with the following plugins: (check box
@@ -45,5 +91,8 @@
     allow enabling plugin)
   </p>
   <ul id="dsm-disabled-list"></ul>
-  <button id="dsm-panic-apply-reload-btn">Apply and Reload</button>
+  <button class="dsm-panic-button" id="dsm-panic-apply-reload-btn">
+    Apply and Reload
+  </button>
 </div>
+<button class="dsm-panic-button" id="dsm-panic-reopen-button">!</button>

--- a/src/panic/panic.html
+++ b/src/panic/panic.html
@@ -36,8 +36,8 @@
 <div id="dsm-panic-popover">
   <h2>DesModder Loading Errors Manager</h2>
   <p id="dsm-encountered-errors">
-    DesModder encountered loading errors with the following plugins: (check the
-    box to disable plugin)
+    DesModder encountered loading errors with the following plugins: (check box
+    to disable plugin)
   </p>
   <ul id="dsm-panic-list"></ul>
   <p id="dsm-plugins-disabled">

--- a/src/panic/panic.html
+++ b/src/panic/panic.html
@@ -1,0 +1,38 @@
+<!-- we don't necessarily have communication with the background script that
+  would insert the style css, so use an inline style element -->
+<style>
+  #dsm-panic-popover {
+    /* positioning */
+    position: absolute;
+    top: 10px;
+    left: calc(50%);
+    transform: translateX(-50%);
+    z-index: 9999;
+    width: max-content;
+    max-width: calc(100% - 20px);
+    /* formatting */
+    background: white;
+    padding: 0 20px 20px 20px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: 6px;
+    box-shadow: 0 5px 10px rgb(0 0 0 / 20%);
+    user-select: text;
+  }
+  #dsm-panic-popover ul {
+    list-style-type: none;
+  }
+  #dsm-panic-popover input[type="checkbox"] {
+    cursor: pointer;
+  }
+  #dsm-panic-apply-reload-btn {
+    float: right;
+  }
+</style>
+<div id="dsm-panic-popover">
+  <h2>DesModder Errors Detected</h2>
+  <p>
+    Following errors: (the checkboxes do nothing for now. This is temporary)
+  </p>
+  <ul id="dsm-panic-list"></ul>
+  <button id="dsm-panic-apply-reload-btn">Apply and Reload</button>
+</div>

--- a/src/panic/panic.ts
+++ b/src/panic/panic.ts
@@ -1,0 +1,47 @@
+import { format } from "../i18n/i18n-core";
+import panicHTML from "./panic.html";
+
+const existingPanics = new Set<string>();
+
+function insertPanicElement() {
+  const frag = document.createRange().createContextualFragment(panicHTML);
+  document.body.appendChild(frag);
+  document
+    .getElementById("dsm-panic-apply-reload-btn")!
+    .addEventListener("click", () => {
+      // TODO: apply changes;
+      location.reload();
+    });
+}
+
+function getPanicPopover() {
+  return document.getElementById("dsm-panic-popover");
+}
+
+function ensurePanicPopover() {
+  const popover = getPanicPopover();
+  if (popover === null) insertPanicElement();
+  return getPanicPopover()!;
+}
+
+export function addPanic(problem: string) {
+  const panicPopover = ensurePanicPopover();
+  if (!existingPanics.has(problem)) {
+    const id = "dsm_panic_" + problem;
+    const idInQuotes = JSON.stringify(id);
+    const list = panicPopover.querySelector("ul")!;
+    list.appendChild(
+      document.createRange().createContextualFragment(`<li>
+      <label for=${idInQuotes}>
+        <input type="checkbox" id=${idInQuotes} />
+      </label>
+    </li>`)
+    );
+    const problemName = format(problem + "-name", undefined, problem);
+    list
+      .lastElementChild!.querySelector("label")!
+      .appendChild(document.createTextNode(problemName));
+    console.log("panicking for", problem);
+  }
+  existingPanics.add(problem);
+}

--- a/src/panic/panic.ts
+++ b/src/panic/panic.ts
@@ -8,7 +8,6 @@ function insertPanicElement() {
   document
     .getElementById("dsm-panic-apply-reload-btn")!
     .addEventListener("click", () => {
-      // TODO: apply changes;
       const inputs: HTMLInputElement[] = Array.from(
         document.querySelectorAll("#dsm-panic-popover ul input")
       );
@@ -40,8 +39,7 @@ function getPanicPopover() {
 }
 
 function ensurePanicPopover() {
-  const popover = getPanicPopover();
-  if (popover === null) insertPanicElement();
+  if (getPanicPopover() === null) insertPanicElement();
   return getPanicPopover()!;
 }
 

--- a/src/panic/panic.ts
+++ b/src/panic/panic.ts
@@ -23,6 +23,16 @@ function insertPanicElement() {
       });
       location.reload();
     });
+  document
+    .getElementById("dsm-panic-close-button")!
+    .addEventListener("click", () => {
+      document.body.classList.add("dsm-panic-closed");
+    });
+  document
+    .getElementById("dsm-panic-reopen-button")!
+    .addEventListener("click", () => {
+      document.body.classList.remove("dsm-panic-closed");
+    });
 }
 
 function getPanicPopover() {

--- a/src/preload/moduleOverrides/core.replacements
+++ b/src/preload/moduleOverrides/core.replacements
@@ -1,6 +1,6 @@
 # Core Replacements
 
-*plugin* `workaround-core`
+*plugin* `pin-expressions` `hide-errors` `text-mode` `GLesmos`
 
 Replacements that apply to more than one plugin.
 

--- a/src/preload/moduleOverrides/extra-expression-buttons.replacements
+++ b/src/preload/moduleOverrides/extra-expression-buttons.replacements
@@ -1,6 +1,6 @@
 # Replacements for Extra Expression Buttons
 
-*plugin* `workaround-pin-expressions-and-folder-tools`
+*plugin* `pin-expressions` `folder-tools`
 
 TODO: work this into an API so it doesn't need a ton of injected code.
 

--- a/src/preload/moduleOverrides/find-replace.replacements
+++ b/src/preload/moduleOverrides/find-replace.replacements
@@ -9,7 +9,7 @@
 *Find* => `from`
 
 ```js
-this.controller.isExpressionListFocused(TEMP_FORCE_ERROR_PLEASE_REMOVE)
+this.controller.isExpressionListFocused()
 ```
 
 *Replace* `from` with

--- a/src/preload/moduleOverrides/find-replace.replacements
+++ b/src/preload/moduleOverrides/find-replace.replacements
@@ -1,6 +1,6 @@
 # Replacements for Find-Replace
 
-*plugin* `find-replace`
+*plugin* `find-and-replace`
 
 ## Allow find-replace to appear, even if the expression list is not focused
 
@@ -9,7 +9,7 @@
 *Find* => `from`
 
 ```js
-this.controller.isExpressionListFocused()
+this.controller.isExpressionListFocused(TEMP_FORCE_ERROR_PLEASE_REMOVE)
 ```
 
 *Replace* `from` with

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -76,7 +76,7 @@ $DCGView.createElement(
 *Find*
 
 ```js
-drawSketchToCtx = function ($t) {__body__}
+drawSketchToCtx = function ($t, $TEMP_FORCE_ERROR_PLEASE_REMOVE) {__body__}
 ```
 
 *Find* inside `__body__`

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -76,7 +76,7 @@ $DCGView.createElement(
 *Find*
 
 ```js
-drawSketchToCtx = function ($t, $TEMP_FORCE_ERROR_PLEASE_REMOVE) {__body__}
+drawSketchToCtx = function ($t) {__body__}
 ```
 
 *Find* inside `__body__`

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -1,6 +1,6 @@
 # Replacements for GLesmos
 
-*plugin* `glesmos`
+*plugin* `GLesmos`
 
 ## Add a menu option for switching an expression to glesmos rendering mode
 

--- a/src/preload/moduleReplacements.ts
+++ b/src/preload/moduleReplacements.ts
@@ -27,4 +27,40 @@ for (const replacement of replacementStrings) {
   replacements.push(...parseFile(replacement.file, replacement.filename));
 }
 
+// importing from plugins index causes a loading order issue
+// (desmos dependencies get imported before desmos is loaded),
+// so just hardcode the plugin names for now
+const pluginNames = [
+  "builtin-settings",
+  "set-primary-color",
+  "wolfram2desmos",
+  "pin-expressions",
+  "video-creator",
+  "wakatime",
+  "find-and-replace",
+  "debug-mode",
+  "show-tips",
+  "right-click-tray",
+  "duplicate-expression-hotkey",
+  "GLesmos",
+  "shift-enter-newline",
+  "hide-errors",
+  "folder-tools",
+  "text-mode",
+  "performance-info",
+];
+
+replacements.forEach((r) => {
+  r.plugins.forEach((plugin) => {
+    if (!pluginNames.includes(plugin))
+      console.warn(
+        "Plugin",
+        plugin,
+        "specified in replacement",
+        r.filename,
+        "not found: at risk of instability on panic."
+      );
+  });
+});
+
 export default replacements;

--- a/src/preload/replacementHelpers/applyReplacement.ts
+++ b/src/preload/replacementHelpers/applyReplacement.ts
@@ -153,14 +153,14 @@ function applyStringReplacements(repls: Block[], str: Token[]): Token[] {
       const prefix = idTable.get(r)!;
       table.merge(getSymbols(r.commands, str).prefix(prefix));
     } catch (e) {
-      addPanic(r.plugin);
+      r.plugins.forEach(addPanic);
     }
   }
   const finalRepls = repls.flatMap((r) => {
     try {
       return blockReplacements(r, idTable, table);
     } catch (e) {
-      addPanic(r.plugin);
+      r.plugins.forEach(addPanic);
       return [];
     }
   });

--- a/src/preload/replacementHelpers/applyReplacement.ts
+++ b/src/preload/replacementHelpers/applyReplacement.ts
@@ -1,3 +1,4 @@
+import { addPanic } from "../../panic/panic";
 import { ReplacementError } from "./errors";
 import { Command, Block } from "./parse";
 import { PatternToken, patternTokens } from "./tokenize";
@@ -148,41 +149,58 @@ function applyStringReplacements(repls: Block[], str: Token[]): Token[] {
   );
   const table = new SymbolTable(str);
   for (const r of repls) {
-    const prefix = idTable.get(r)!;
-    table.merge(getSymbols(r.commands, str).prefix(prefix));
+    try {
+      const prefix = idTable.get(r)!;
+      table.merge(getSymbols(r.commands, str).prefix(prefix));
+    } catch (e) {
+      addPanic(r.plugin);
+    }
   }
   const finalRepls = repls.flatMap((r) => {
-    const prefix = idTable.get(r)!;
-    return r.replaceCommands.map((command) => {
-      if (command.command !== "replace")
-        throw new ReplacementError(
-          "Programming error: replaceCommand is not *replace*"
-        );
-      if (command.args.length !== 1)
-        throw new ReplacementError(
-          `*replace* command must have exactly 1 argument. You passed ${command.args.length}`
-        );
-      if (command.patternArg === undefined)
-        throw new ReplacementError(
-          `*replace* command missing a pattern argument.`
-        );
-      const res: Replacement = {
-        heading: r.heading,
-        from: table.getRequired(prefix + command.args[0]),
-        to: command.patternArg.flatMap((token) => {
-          if (
-            token.type === "PatternBalanced" ||
-            token.type === "PatternIdentifier"
-          ) {
-            return table.getSlice(prefix + token.value);
-          } else return token;
-        }),
-      };
-      return res;
-    });
+    try {
+      return blockReplacements(r, idTable, table);
+    } catch (e) {
+      addPanic(r.plugin);
+      return [];
+    }
   });
 
   return Array.from(withReplacements(table.str, finalRepls));
+}
+
+function blockReplacements(
+  r: Block,
+  idTable: Map<Block, string>,
+  table: SymbolTable
+): Replacement[] {
+  const prefix = idTable.get(r)!;
+  return r.replaceCommands.map((command) => {
+    if (command.command !== "replace")
+      throw new ReplacementError(
+        "Programming error: replaceCommand is not *replace*"
+      );
+    if (command.args.length !== 1)
+      throw new ReplacementError(
+        `*replace* command must have exactly 1 argument. You passed ${command.args.length}`
+      );
+    if (command.patternArg === undefined)
+      throw new ReplacementError(
+        `*replace* command missing a pattern argument.`
+      );
+    const res: Replacement = {
+      heading: r.heading,
+      from: table.getRequired(prefix + command.args[0]),
+      to: command.patternArg.flatMap((token) => {
+        if (
+          token.type === "PatternBalanced" ||
+          token.type === "PatternIdentifier"
+        ) {
+          return table.getSlice(prefix + token.value);
+        } else return token;
+      }),
+    };
+    return res;
+  });
 }
 
 function* withReplacements(tokens: readonly Token[], repls: Replacement[]) {

--- a/src/preload/replacementHelpers/parse.ts
+++ b/src/preload/replacementHelpers/parse.ts
@@ -10,7 +10,7 @@ export interface Block {
   heading: string;
   commands: Command[];
   modules: string[];
-  plugin: string;
+  plugins: string[];
   replaceCommands: Command[];
   workerOnly: boolean;
 }
@@ -29,13 +29,9 @@ export default function parseFile(
   const tokens = tokenizeReplacement(fileString);
   if (tokens[0].tag !== "heading" || tokens[0].depth !== 1)
     throw new ReplacementError("First line must be a # Heading");
-  if (
-    tokens[1].tag !== "emph" ||
-    tokens[1].command !== "plugin" ||
-    tokens[1].args.length !== 1
-  )
+  if (tokens[1].tag !== "emph" || tokens[1].command !== "plugin")
     throw new ReplacementError("Second line must be *plugin* `plugin-name`");
-  const pluginName = tokens[1].args[0];
+  const plugins = tokens[1].args;
   const rules: Block[] = [];
   for (let i = 2; i < tokens.length; i++) {
     const token = tokens[i];
@@ -51,7 +47,7 @@ export default function parseFile(
       const blockEndIndex =
         nextHeadingIndex < 0 ? tokens.length : nextHeadingIndex;
       const block = tokens.slice(i + 1, blockEndIndex);
-      rules.push(parseBlock(prevToken, token, block, pluginName, filename));
+      rules.push(parseBlock(prevToken, token, block, plugins, filename));
       i = blockEndIndex;
     } else if (token.tag === "emph") {
       throw new ReplacementError(
@@ -74,7 +70,7 @@ function parseBlock(
   heading: ReplacementToken & { tag: "heading" },
   start: ReplacementToken & { tag: "emph" },
   tokens: ReplacementToken[],
-  plugin: string,
+  plugins: string[],
   filename: string
 ): Block {
   if (start.args.length === 0)
@@ -104,7 +100,7 @@ function parseBlock(
     filename,
     commands: commands.filter((x) => x.command !== "replace"),
     replaceCommands: commands.filter((x) => x.command === "replace"),
-    plugin,
+    plugins,
     modules: start.args,
     workerOnly,
   };

--- a/src/preload/script.ts
+++ b/src/preload/script.ts
@@ -10,7 +10,7 @@ import { postMessageUp, listenToMessageDown } from "utils/messages";
 import { pollForValue } from "utils/utils";
 
 /* This script is loaded at document_start, before the page's scripts, to give it 
-time to set ALMOND_OVERRIDES and replace module definitions */
+time to set ALMOND_OVERRIDES to expose `require` */
 
 // workerAppend will get filled in from a message
 let workerAppend: string = "console.error('worker append not filled in')";
@@ -86,6 +86,7 @@ async function load(pluginsForceDisabled: Set<string>) {
 listenToMessageDown((message) => {
   if (message.type === "apply-plugins-force-disabled") {
     message.value.forEach((disabledPlugin) => addForceDisabled(disabledPlugin));
+    (window as any).DesModderForceDisabled = message.value;
     void load(message.value);
     // cancel listener
     return true;

--- a/src/script.ts
+++ b/src/script.ts
@@ -5,9 +5,8 @@ import Controller from "main/Controller";
 import View from "main/View";
 
 const controller = new Controller();
-export { controller as desModderController };
-
 const view = new View();
+export { controller as desModderController };
 
 window.DesModder = {
   view,

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,22 +1,29 @@
+import { addPanic } from "./panic/panic";
 import { pollForValue } from "./utils/utils";
 import "fonts/style.css";
 import window from "globals/window";
 import Controller from "main/Controller";
 import View from "main/View";
 
-const controller = new Controller();
-const view = new View();
+let controller;
 export { controller as desModderController };
 
-window.DesModder = {
-  view,
-  controller,
-  exposedPlugins: controller.exposedPlugins,
-};
-void (async () => {
-  const pillbox = (await pollForValue(() =>
-    document.querySelector(".dcg-overgraph-pillbox-elements")
-  )) as HTMLElement;
-  controller.init(view);
-  view.init(controller, pillbox);
-})();
+try {
+  controller = new Controller();
+  const view = new View();
+
+  window.DesModder = {
+    view,
+    controller,
+    exposedPlugins: controller.exposedPlugins,
+  };
+  void (async () => {
+    const pillbox = (await pollForValue(() =>
+      document.querySelector(".dcg-overgraph-pillbox-elements")
+    )) as HTMLElement;
+    controller.init(view);
+    view.init(controller, pillbox);
+  })();
+} catch (e) {
+  addPanic("DesModder");
+}

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,29 +1,23 @@
-import { addPanic } from "./panic/panic";
 import { pollForValue } from "./utils/utils";
 import "fonts/style.css";
 import window from "globals/window";
 import Controller from "main/Controller";
 import View from "main/View";
 
-let controller;
+const controller = new Controller();
 export { controller as desModderController };
 
-try {
-  controller = new Controller();
-  const view = new View();
+const view = new View();
 
-  window.DesModder = {
-    view,
-    controller,
-    exposedPlugins: controller.exposedPlugins,
-  };
-  void (async () => {
-    const pillbox = (await pollForValue(() =>
-      document.querySelector(".dcg-overgraph-pillbox-elements")
-    )) as HTMLElement;
-    controller.init(view);
-    view.init(controller, pillbox);
-  })();
-} catch (e) {
-  addPanic("DesModder");
-}
+window.DesModder = {
+  view,
+  controller,
+  exposedPlugins: controller.exposedPlugins,
+};
+void (async () => {
+  const pillbox = (await pollForValue(() =>
+    document.querySelector(".dcg-overgraph-pillbox-elements")
+  )) as HTMLElement;
+  controller.init(view);
+  view.init(controller, pillbox);
+})();

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -18,8 +18,15 @@ type MessageWindowToContent =
       value: Map<PluginID, boolean>;
     }
   | {
+      type: "set-plugins-force-disabled";
+      value: Set<PluginID>;
+    }
+  | {
       type: "set-plugin-settings";
       value: Map<PluginID, GenericSettings>;
+    }
+  | {
+      type: "get-plugins-force-disabled";
     }
   | {
       type: "get-initial-data";
@@ -42,6 +49,10 @@ type MessageContentToWindow =
   | {
       type: "apply-plugins-enabled";
       value: Map<PluginID, boolean>;
+    }
+  | {
+      type: "apply-plugins-force-disabled";
+      value: Set<PluginID>;
     }
   | {
       type: "apply-plugin-settings";

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,4 @@
-type FuncAny = () => any;
-
-async function _pollForValue<T>(func: () => T) {
+export async function pollForValue<T>(func: () => T) {
   return await new Promise<T>((resolve) => {
     const interval = setInterval(() => {
       const val = func();
@@ -10,10 +8,6 @@ async function _pollForValue<T>(func: () => T) {
       }
     }, 50);
   });
-}
-
-export async function pollForValue(func: FuncAny) {
-  return await _pollForValue(func);
 }
 
 interface ClassDict {


### PR DESCRIPTION
Relates to #480, but there is still work to be done to finish the ideas in that issue.

- Show panic messages (non-functional)
- Require replacements to have valid plugin names
- Add actual forced plugin disabling
- Remove accidentally-committed files
- Prevent enabling force-disabled plugins
- Allow hiding loading error manager
- Remove try-catch around main init
