### PR TITLE
Capture simultaneous sliders in GLesmos

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -111,6 +111,7 @@ video-creator-desc = Lets you export videos and GIFs of your graphs based on act
 video-creator-menu = Video Creator Menu
 video-creator-to = to
 video-creator-step = , step
+video-creator-ticks-step = Time step (ms):
 video-creator-prev-action = Prev
 video-creator-next-action = Next
 video-creator-size = Size:

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -133,6 +133,7 @@ video-creator-fps = FPS:
 video-creator-method-once = once
 video-creator-method-slider = slider
 video-creator-method-action = action
+video-creator-method-ticks = ticks
 
 ## Shift+Enter Newline
 shift-enter-newline-name = Shift+Enter Newline

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -167,7 +167,7 @@ interface CalcPrivate {
     };
     /** Mark UI tick required to convert render shells to full item lines */
     markTickRequiredNextFrame: () => void;
-    getPlayingSliders: () => unknown[];
+    getPlayingSliders: () => { latex: string }[];
     _tickSliders: (nowTimestamp: number) => void;
   };
   _calc: {

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -168,6 +168,7 @@ interface CalcPrivate {
     /** Mark UI tick required to convert render shells to full item lines */
     markTickRequiredNextFrame: () => void;
     getPlayingSliders: () => unknown[];
+    _tickSliders: (nowTimestamp: number) => void;
   };
   _calc: {
     globalHotkeys: TopLevelComponents;

--- a/src/plugins/video-creator/Controller.ts
+++ b/src/plugins/video-creator/Controller.ts
@@ -42,7 +42,7 @@ export default class Controller {
   exportProgress = -1;
 
   // ** capture methods
-  captureMethod: CaptureMethod = "once";
+  #captureMethod: CaptureMethod = "once";
   sliderSettings: SliderSettings = {
     variable: "a",
     minLatex: "0",
@@ -131,9 +131,23 @@ export default class Controller {
     return this.outfileName ?? getCurrentGraphTitle() ?? DEFAULT_FILENAME;
   }
 
-  setCaptureMethod(method: CaptureMethod) {
-    this.captureMethod = method;
+  set captureMethod(method: CaptureMethod) {
+    this.#captureMethod = method;
     this.updateView();
+  }
+
+  get captureMethod() {
+    return this.isCaptureMethodValid(this.#captureMethod)
+      ? this.#captureMethod
+      : "once";
+  }
+
+  isCaptureMethodValid(method: CaptureMethod) {
+    return method === "action"
+      ? this.hasAction()
+      : method === "ticks"
+      ? Calc.controller.getPlayingSliders().length > 0
+      : true;
   }
 
   isCaptureWidthValid() {
@@ -245,17 +259,23 @@ export default class Controller {
     if (!this.isCaptureWidthValid() || !this.isCaptureHeightValid()) {
       return false;
     }
-    if (this.captureMethod === "once") {
-      return true;
-    } else if (this.captureMethod === "slider") {
-      return (
-        this.isSliderSettingValid("variable") &&
-        this.isSliderSettingValid("minLatex") &&
-        this.isSliderSettingValid("maxLatex") &&
-        this.isSliderSettingValid("stepLatex")
-      );
-    } else if (this.captureMethod === "action") {
-      return this.isTickCountValid();
+    switch (this.captureMethod) {
+      case "once":
+        return true;
+      case "slider":
+        return (
+          this.isSliderSettingValid("variable") &&
+          this.isSliderSettingValid("minLatex") &&
+          this.isSliderSettingValid("maxLatex") &&
+          this.isSliderSettingValid("stepLatex")
+        );
+      case "action":
+      case "ticks":
+        return this.isTickCountValid();
+      default: {
+        const exhaustiveCheck: never = this.captureMethod;
+        return exhaustiveCheck;
+      }
     }
   }
 

--- a/src/plugins/video-creator/Controller.ts
+++ b/src/plugins/video-creator/Controller.ts
@@ -236,7 +236,8 @@ export default class Controller {
   }
 
   isTickTimeStepValid() {
-    return this.getTickTimeStepNumber() > 0;
+    const ts = this.getTickTimeStepNumber();
+    return !isNaN(ts) && ts > 0;
   }
 
   getMatchingSlider() {
@@ -259,11 +260,13 @@ export default class Controller {
     }
   }
 
+  getTickCountNumber() {
+    return EvaluateSingleExpression(this.tickCountLatex);
+  }
+
   isTickCountValid() {
-    return (
-      isValidNumber(this.tickCountLatex) &&
-      EvaluateSingleExpression(this.tickCountLatex) > 0
-    );
+    const tc = this.getTickCountNumber();
+    return Number.isInteger(tc) && tc > 0;
   }
 
   async capture() {
@@ -285,8 +288,9 @@ export default class Controller {
           this.isSliderSettingValid("stepLatex")
         );
       case "action":
-      case "ticks":
         return this.isTickCountValid();
+      case "ticks":
+        return this.isTickCountValid() && this.isTickTimeStepValid();
       default: {
         const exhaustiveCheck: never = this.captureMethod;
         return exhaustiveCheck;

--- a/src/plugins/video-creator/Controller.ts
+++ b/src/plugins/video-creator/Controller.ts
@@ -18,6 +18,7 @@ type FocusedMQ =
   | "capture-slider-max"
   | "capture-slider-step"
   | "capture-tick-count"
+  | "capture-tick-time-step"
   | "capture-width"
   | "capture-height"
   | "export-fps";
@@ -55,6 +56,7 @@ export default class Controller {
 
   currentActionID: string | null = null;
   tickCountLatex: string = "10";
+  tickTimeStepLatex: string = "40";
 
   // ** capture sizing
   captureHeightLatex = "";
@@ -222,6 +224,19 @@ export default class Controller {
   setTickCountLatex(value: string) {
     this.tickCountLatex = value;
     this.updateView();
+  }
+
+  setTickTimeStepLatex(value: string) {
+    this.tickTimeStepLatex = value;
+    this.updateView();
+  }
+
+  getTickTimeStepNumber() {
+    return EvaluateSingleExpression(this.tickTimeStepLatex);
+  }
+
+  isTickTimeStepValid() {
+    return this.getTickTimeStepNumber() > 0;
   }
 
   getMatchingSlider() {

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -108,9 +108,7 @@ function slidersLatexJoined() {
 async function captureActionFrame(controller: Controller, step: () => void) {
   let stepped = false;
   try {
-    const tickCountRemaining = EvaluateSingleExpression(
-      controller.tickCountLatex
-    );
+    const tickCountRemaining = controller.getTickCountNumber();
     if (tickCountRemaining > 0) {
       controller.actionCaptureState = "waiting-for-screenshot";
       await captureAndApplyFrame(controller);

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -190,8 +190,7 @@ export async function capture(controller: Controller) {
     case "ticks": {
       let currTime = performance.now();
       const step = () => {
-        // tick by half a second each tick. Temporary
-        currTime += 500;
+        currTime += controller.getTickTimeStepNumber();
         tickSliders(currTime);
       };
       await captureActionOrSliderTicks(controller, step);

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -1,4 +1,3 @@
-import { Calc } from "../../../globals/window";
 import Controller from "../Controller";
 import { cancelCapture, CaptureMethod } from "../backend/capture";
 import "./CaptureMethod.css";

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -162,7 +162,25 @@ export default class SelectCapture extends Component<{
                   </For>
                 </div>
               ),
-              ticks: () => null,
+              ticks: () => (
+                <div class="dsm-vc-ticks-settings">
+                  {format("video-creator-ticks-step")}
+                  <InlineMathInputView
+                    ariaLabel="time step (ms)"
+                    handleLatexChanged={(v) =>
+                      this.controller.setTickTimeStepLatex(v)
+                    }
+                    hasError={() => !this.controller.isTickTimeStepValid()}
+                    latex={() => this.controller.tickTimeStepLatex}
+                    isFocused={() =>
+                      this.controller.isFocused("capture-tick-time-step")
+                    }
+                    handleFocusChanged={(b) =>
+                      this.controller.updateFocus("capture-tick-time-step", b)
+                    }
+                  />
+                </div>
+              ),
               once: () => null,
             }[this.controller.captureMethod]())
           }


### PR DESCRIPTION
Resolves #508
- Support ticking all playing sliders simultaneously
- Add UI for changing time step
- Avoid stalling on small slider tick sizes
- Handle cancelling in the middle of ticks capture
- Handle UI when action-capture pauses sliders
