### PR TITLE
GL perf improvements

### DIFF
--- a/src/plugins/GLesmos/Controller.ts
+++ b/src/plugins/GLesmos/Controller.ts
@@ -24,7 +24,7 @@ export default class Controller {
     const deps = compiledGL.deps.join("\n");
 
     try {
-      if (!this.canvas?.element) throw glesmosError("WebGL Context Lost!");
+      if (!this.canvas?.element) glesmosError("WebGL Context Lost!");
 
       this.canvas.updateTransforms(transforms); // only do this once
 

--- a/src/plugins/GLesmos/Controller.ts
+++ b/src/plugins/GLesmos/Controller.ts
@@ -24,13 +24,12 @@ export default class Controller {
     const deps = compiledGL.deps.join("\n");
 
     try {
-
-      if( !this.canvas?.element )
-        throw glesmosError("WebGL Context Lost!")
+      if (!this.canvas?.element) throw glesmosError("WebGL Context Lost!");
 
       this.canvas.updateTransforms(transforms); // only do this once
 
-      if( compiledGL.hasOutlines ) // no grouping, perf will suffer
+      if (compiledGL.hasOutlines)
+        // no grouping, perf will suffer
         for (const chunk of compiledGL.chunks) {
           this.canvas?.buildGLesmosFancy(deps, chunk);
           this.canvas?.renderFancy();
@@ -41,14 +40,11 @@ export default class Controller {
         this.canvas?.renderFast();
         ctx.drawImage(this.canvas?.element, 0, 0);
       }
-        
     } catch (e) {
       const model = Calc.controller.getItemModel(id);
       if (model) {
         model.error = e instanceof Error ? e.message : e;
       }
     }
-
-    
   }
 }

--- a/src/plugins/GLesmos/exportAsGLesmos.ts
+++ b/src/plugins/GLesmos/exportAsGLesmos.ts
@@ -51,7 +51,7 @@ export function compileGLesmos(
       hasOutlines = true;
     }
     return {
-      hasOutlines: hasOutlines,
+      hasOutlines,
       deps: functionDeps.map(getDefinition),
       chunks: [
         {

--- a/src/plugins/GLesmos/exportAsGLesmos.ts
+++ b/src/plugins/GLesmos/exportAsGLesmos.ts
@@ -42,14 +42,16 @@ export function compileGLesmos(
     // default values for if there should be no dx, dy
     let dxsource = "return 0.0;";
     let dysource = "return 0.0;";
-    if (lineWidth > 0 && derivativeX && derivativeY) {
+    let hasOutlines = false;
+    if (lineWidth > 0 && lineOpacity > 0 && derivativeX && derivativeY) {
       ({ source: dxsource, deps } = emitChunkGL(derivativeX._chunk));
       deps.forEach((d) => accDeps(functionDeps, d));
       ({ source: dysource, deps } = emitChunkGL(derivativeY._chunk));
       deps.forEach((d) => accDeps(functionDeps, d));
+      hasOutlines = true;
     }
-
     return {
+      hasOutlines: hasOutlines,
       deps: functionDeps.map(getDefinition),
       chunks: [
         {

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -149,19 +149,13 @@ export function initGLesmosCanvas() {
 
   //= ================ WEBGL FUNCTIONS ================
 
-  const buildGLesmosFancy = (
-    deps: string,
-    chunk: GLesmosShaderChunk
-  ) => {
+  const buildGLesmosFancy = (deps: string, chunk: GLesmosShaderChunk) => {
     glesmosCache = glesmosGetCacheShader(gl, chunk, deps);
     glesmosFinalPass = glesmosGetFinalPassShader(gl, chunk);
     glesmosSDF = glesmosGetSDFShader(gl, chunk, deps); // we don't need to build this if we aren't drawing outlines
   };
 
-  const buildGLesmosFast = (
-    deps: string,
-    chunks: GLesmosShaderChunk[]
-  ) => {
+  const buildGLesmosFast = (deps: string, chunks: GLesmosShaderChunk[]) => {
     glesmosFastFill = glesmosGetFastFillShader(gl, chunks, deps);
   };
 
@@ -265,6 +259,6 @@ export function initGLesmosCanvas() {
     buildGLesmosFancy,
     buildGLesmosFast,
     renderFancy,
-    renderFast
+    renderFast,
   };
 }

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -6,6 +6,7 @@ import {
   glesmosGetCacheShader,
   glesmosGetSDFShader,
   glesmosGetFinalPassShader,
+  glesmosGetFastFillShader,
   setUniform,
 } from "./shaders";
 
@@ -84,12 +85,12 @@ export function initGLesmosCanvas() {
 
   let glesmosCache: GLesmosProgram | null;
 
-  let glesmosDoOutlines = true;
-
   let glesmosSDF: GLesmosProgram | null;
   let glesmosSDFrequiredSteps: number;
 
   let glesmosFinalPass: GLesmosProgram | null;
+
+  let glesmosFastFill: GLesmosProgram | null;
 
   //= ================ GRAPH BOUNDS ======================
 
@@ -148,22 +149,20 @@ export function initGLesmosCanvas() {
 
   //= ================ WEBGL FUNCTIONS ================
 
-  const buildGLesmosShaders = (
-    id: string,
+  const buildGLesmosFancy = (
     deps: string,
     chunk: GLesmosShaderChunk
   ) => {
-    glesmosCache = glesmosGetCacheShader(gl, id, chunk, deps);
-    glesmosFinalPass = glesmosGetFinalPassShader(gl, id, chunk);
+    glesmosCache = glesmosGetCacheShader(gl, chunk, deps);
+    glesmosFinalPass = glesmosGetFinalPassShader(gl, chunk);
+    glesmosSDF = glesmosGetSDFShader(gl, chunk, deps); // we don't need to build this if we aren't drawing outlines
+  };
 
-    if (chunk.line_width === 0) {
-      // TODO: this is bad, globals are bad
-      glesmosDoOutlines = false;
-      return;
-    }
-
-    glesmosDoOutlines = true;
-    glesmosSDF = glesmosGetSDFShader(gl, id, chunk, deps); // we don't need to build this if we aren't drawing outlines
+  const buildGLesmosFast = (
+    deps: string,
+    chunks: GLesmosShaderChunk[]
+  ) => {
+    glesmosFastFill = glesmosGetFastFillShader(gl, chunks, deps);
   };
 
   const runCacheShader = () => {
@@ -232,10 +231,23 @@ export function initGLesmosCanvas() {
     gl.drawArrays(gl.TRIANGLES, 0, 6);
   };
 
-  const render = () => {
+  const runFastShader = () => {
+    if (!glesmosFastFill) glesmosError("Fast-fill shader failed.");
+    gl.useProgram(glesmosFastFill);
+    setupGLesmosEnvironment(glesmosFastFill);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+  };
+
+  const renderFancy = () => {
     runCacheShader();
-    if (glesmosDoOutlines) runSDFShader();
+    runSDFShader();
     runFinalPassShader();
+  };
+
+  const renderFast = () => {
+    runFastShader();
   };
 
   //= ================ CLEANUP ================
@@ -250,7 +262,9 @@ export function initGLesmosCanvas() {
     glContext: gl,
     deleteCanvas,
     updateTransforms,
-    buildGLesmosShaders,
-    render,
+    buildGLesmosFancy,
+    buildGLesmosFast,
+    renderFancy,
+    renderFast
   };
 }

--- a/src/plugins/GLesmos/shaders.ts
+++ b/src/plugins/GLesmos/shaders.ts
@@ -8,6 +8,7 @@ export function glesmosError(msg: string): never {
 export interface GLesmosShaderPackage {
   deps: string[];
   chunks: GLesmosShaderChunk[];
+  hasOutlines: boolean
 }
 
 export interface GLesmosShaderChunk {
@@ -74,7 +75,6 @@ function buildShaderProgram(
   gl: WebGL2RenderingContext,
   vert: string,
   frag: string,
-  _id: string
 ) {
   const shaderProgram = gl.createProgram();
   if (shaderProgram === null) {
@@ -95,12 +95,11 @@ function buildShaderProgram(
 const shaderCache = new Map<string, GLesmosProgram>();
 function getShaderProgram(
   gl: WebGL2RenderingContext,
-  id: string,
   vertexSource: string,
   fragmentSource: string
 ) {
-  const key = vertexSource + fragmentSource; // TODO: this is terrible
-  const cachedShader = shaderCache.get(key);
+  const key = vertexSource + fragmentSource;
+  const cachedShader = shaderCache.get(key); // TODO: hashing this whole thing is probably slow
 
   if (cachedShader) return cachedShader;
 
@@ -108,7 +107,6 @@ function getShaderProgram(
     gl,
     vertexSource,
     fragmentSource,
-    id
   ) as GLesmosProgram;
 
   shaderProgram.vertexAttribPos = gl.getAttribLocation(
@@ -183,7 +181,6 @@ export const GLESMOS_SHARED = `
 
 export function glesmosGetCacheShader(
   gl: WebGL2RenderingContext,
-  id: string,
   chunk: GLesmosShaderChunk,
   deps: string
 ): GLesmosProgram {
@@ -203,7 +200,7 @@ export function glesmosGetCacheShader(
     }
   `;
 
-  const shader = getShaderProgram(gl, id, VERTEX_SHADER, source);
+  const shader = getShaderProgram(gl, VERTEX_SHADER, source);
 
   // TODO: set some uniforms here
 
@@ -212,7 +209,6 @@ export function glesmosGetCacheShader(
 
 export function glesmosGetSDFShader(
   gl: WebGL2RenderingContext,
-  id: string,
   chunk: GLesmosShaderChunk,
   deps: string
 ): GLesmosProgram {
@@ -428,14 +424,13 @@ export function glesmosGetSDFShader(
 
     //============== END Shadertoy Buffer A ==============//
   `;
-  const shader = getShaderProgram(gl, id, VERTEX_SHADER, source);
+  const shader = getShaderProgram(gl, VERTEX_SHADER, source);
 
   return shader;
 }
 
 export function glesmosGetFinalPassShader(
   gl: WebGL2RenderingContext,
-  id: string,
   chunk: GLesmosShaderChunk
 ): GLesmosProgram {
   const source = `${GLESMOS_ENVIRONMENT}
@@ -474,10 +469,48 @@ export function glesmosGetFinalPassShader(
     }
   `;
 
-  const shader = getShaderProgram(gl, id, VERTEX_SHADER, source);
+  const shader = getShaderProgram(gl, VERTEX_SHADER, source);
   gl.useProgram(shader);
   setUniform(gl, shader, "iDoOutlines", "1i", chunk.line_width > 0 ? 1 : 0);
   setUniform(gl, shader, "iDoFill", "1i", chunk.fill ? 1 : 0);
 
   return shader;
 }
+
+export function glesmosGetFastFillShader(
+  gl: WebGL2RenderingContext,
+  chunks: GLesmosShaderChunk[],
+  deps: string
+): GLesmosProgram {
+
+  const mains = chunks.map((chunk, id) => {
+    return `float f_xy_${id}(float x, float y){
+      ${chunk.main}
+    }`;
+  }).join("\n");
+
+  const colorCalls = chunks.map((chunk, id) => {
+    return `if( f_xy_${id}( mathCoord.x, mathCoord.y ) > 0.0 ){
+      outColor = mixColor(outColor, ${chunk.color});
+    }`;
+  }).join("\n");
+
+  const source = `${GLESMOS_ENVIRONMENT}
+    ${GLESMOS_SHARED}
+
+    ${deps}
+
+    ${mains}
+
+    void main(){
+      vec2 mathCoord = texCoord * graphSize + graphCorner;
+      ${colorCalls}
+    }
+  `;
+  (window as any).shadersrc = source;
+
+  const shader = getShaderProgram(gl, VERTEX_SHADER, source);
+
+  return shader;
+}
+

--- a/src/plugins/GLesmos/shaders.ts
+++ b/src/plugins/GLesmos/shaders.ts
@@ -482,13 +482,14 @@ export function glesmosGetFastFillShader(
   chunks: GLesmosShaderChunk[],
   deps: string
 ): GLesmosProgram {
-
+  // prettier-ignore
   const mains = chunks.map((chunk, id) => {
     return `float f_xy_${id}(float x, float y){
       ${chunk.main}
     }`;
   }).join("\n");
 
+  // prettier-ignore
   const colorCalls = chunks.map((chunk, id) => {
     return `if( f_xy_${id}( mathCoord.x, mathCoord.y ) > 0.0 ){
       outColor = mixColor(outColor, ${chunk.color});
@@ -507,7 +508,7 @@ export function glesmosGetFastFillShader(
       ${colorCalls}
     }
   `;
-  
+
   const shader = getShaderProgram(gl, VERTEX_SHADER, source);
 
   return shader;

--- a/src/plugins/GLesmos/shaders.ts
+++ b/src/plugins/GLesmos/shaders.ts
@@ -507,8 +507,7 @@ export function glesmosGetFastFillShader(
       ${colorCalls}
     }
   `;
-  (window as any).shadersrc = source;
-
+  
   const shader = getShaderProgram(gl, VERTEX_SHADER, source);
 
   return shader;

--- a/src/plugins/GLesmos/shaders.ts
+++ b/src/plugins/GLesmos/shaders.ts
@@ -8,7 +8,7 @@ export function glesmosError(msg: string): never {
 export interface GLesmosShaderPackage {
   deps: string[];
   chunks: GLesmosShaderChunk[];
-  hasOutlines: boolean
+  hasOutlines: boolean;
 }
 
 export interface GLesmosShaderChunk {
@@ -74,7 +74,7 @@ function compileShader(
 function buildShaderProgram(
   gl: WebGL2RenderingContext,
   vert: string,
-  frag: string,
+  frag: string
 ) {
   const shaderProgram = gl.createProgram();
   if (shaderProgram === null) {
@@ -106,7 +106,7 @@ function getShaderProgram(
   const shaderProgram = buildShaderProgram(
     gl,
     vertexSource,
-    fragmentSource,
+    fragmentSource
   ) as GLesmosProgram;
 
   shaderProgram.vertexAttribPos = gl.getAttribLocation(
@@ -513,4 +513,3 @@ export function glesmosGetFastFillShader(
 
   return shader;
 }
-

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -281,6 +281,7 @@ else if ($this.userData.glesmos) {
   const prev =  $graphs[$graphs.length - 1];
   if (prev?.graphMode === "GLesmos") {
     // merge GLesmos graphs when possible
+    newCompiled.hasOutlines = newCompiled.hasOutlines && prev.hasOutlines
     const prevGL = prev.compiledGL;
     for (let dep of newCompiled.deps) {
       if (!prevGL.deps.includes(dep)) {


### PR DESCRIPTION
When outlines are disabled for an entire group of list implicits (whether it be via 0 width, 0 alpha, or the toggle switch), GLesmos will now use a faster single-pass fill shader.