### PR TITLE
Add confirmation for GLesmos lines

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -15,6 +15,8 @@ menu-desmodder-tooltip = DesModder Menu
 GLesmos-name = GLesmos
 GLesmos-desc = Render implicits on the GPU. Disabled on tab reload. Can cause the UI to slow down or freeze in rare cases; reload the page if you have issues.
 GLesmos-label-toggle-glesmos = Render with GLesmos
+GLesmos-confirm-lines = Are you sure?
+GLesmos-confirm-lines-body = GLesmos line rendering can be slow. Be careful, especially for a list of layers.
 # Missing: error messages
 
 ## Tips

--- a/src/main/Controller.ts
+++ b/src/main/Controller.ts
@@ -578,16 +578,39 @@ export default class Controller {
   isGlesmosMode(id: string) {
     if (!this.pluginsEnabled.get("GLesmos")) return false;
     this.checkForMetadataChange();
-    return this.graphMetadata.expressions[id]?.glesmos;
+    return this.graphMetadata.expressions[id]?.glesmos ?? false;
   }
 
   toggleGlesmos(id: string) {
     this.updateExprMetadata(id, {
       glesmos: !this.isGlesmosMode(id),
     });
+    this.forceWorkerUpdate(id);
+  }
+
+  forceWorkerUpdate(id: string) {
     // force the worker to revisit the expression
     this.toggleExpr(id);
     this.killWorker();
+  }
+
+  /** Returns boolean or undefined (representing "worker has not told me yet") */
+  isInequality(id: string) {
+    const model = Calc.controller.getItemModel(id);
+    if (model?.type !== "expression") return false;
+    return model.formula?.is_inequality;
+  }
+
+  isGLesmosLinesConfirmed(id: string) {
+    this.checkForMetadataChange();
+    return this.graphMetadata.expressions[id]?.glesmosLinesConfirmed ?? false;
+  }
+
+  toggleGLesmosLinesConfirmed(id: string) {
+    this.updateExprMetadata(id, {
+      glesmosLinesConfirmed: !this.isGLesmosLinesConfirmed(id),
+    });
+    this.forceWorkerUpdate(id);
   }
 
   /**

--- a/src/main/metadata/interface.ts
+++ b/src/main/metadata/interface.ts
@@ -9,4 +9,5 @@ export interface Expression {
   pinned?: boolean;
   errorHidden?: boolean;
   glesmos?: boolean;
+  glesmosLinesConfirmed?: boolean;
 }

--- a/src/main/metadata/manage.ts
+++ b/src/main/metadata/manage.ts
@@ -99,22 +99,32 @@ export function changeExprInMetadata(
   /* Mutates metadata by spreading obj into metadata.expressions[id],
   with default values deleted */
   const changed = metadata.expressions[id] ?? {};
-  for (const key in obj) {
-    const value = obj[key as keyof typeof obj];
-    switch (key) {
-      case "pinned":
-      case "errorHidden":
-      case "glesmos":
-        if (value) {
-          changed[key] = true;
-        } else {
-          delete changed[key];
-        }
+  for (const _key in obj) {
+    const key = _key as keyof Expression;
+    const value = obj[key];
+    if (value !== getDefaultValue(key)) {
+      changed[key] = value;
+    } else {
+      delete changed[key];
     }
   }
   if (Object.keys(changed).length === 0) {
     delete metadata.expressions[id];
   } else {
     metadata.expressions[id] = changed;
+  }
+}
+
+function getDefaultValue(key: keyof Expression) {
+  switch (key) {
+    case "pinned":
+    case "errorHidden":
+    case "glesmos":
+    case "glesmosLinesConfirmed":
+      return false;
+    default: {
+      const _exhaustive: never = key;
+      return _exhaustive;
+    }
   }
 }

--- a/src/plugins/GLesmos/glesmos.less
+++ b/src/plugins/GLesmos/glesmos.less
@@ -2,3 +2,11 @@
   // Padding above GLesmos toggle
   padding-top: 5px;
 }
+
+.dsm-gl-lines-confirm {
+  padding-top: 8px;
+}
+
+.dsm-gl-lines-confirm-body {
+  padding-top: 5px;
+}

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -177,7 +177,7 @@ $DCGView.createElement(
   $DCGView.Components.If,
   {
     predicate: () => DesModder.controller.canBeGLesmos($this.id) &&
-      !Calc.controller.getItemModel($this.id)?.formula.is_inequality,
+      !DesModder.controller.isInequality($this.id)
   },
   () => $DCGView.createElement(
     "div",
@@ -229,7 +229,7 @@ $DCGView.createElement(
   $DCGView.Components.If,
   {
     predicate: () => DesModder.controller.canBeGLesmos(this.id) &&
-      !Calc.controller.getItemModel(this.id)?.formula.is_inequality,
+      !DesModder.controller.isInequality(this.id)
   },
   () => $DCGView.createElement(
     "div",
@@ -242,6 +242,124 @@ $DCGView.createElement(
     })
   )
 )
+```
+
+## Add a lines menu option for confirming GLesmos lines
+
+*Module* `expressions/expression-menus/lines`
+
+*Find* => `options`
+```js
+$DCGView.createElement("div",
+  { class: $DCGView.const("dcg-options-flex-container") },
+  $DCGView.createElement("div",
+    { class: $DCGView.const("dcg-options-left-side") },
+    $DCGView.createElement("div", {
+      class: $DCGView.const("dcg-iconed-mathquill-row dcg-line-opacity-row")
+```
+
+*Find_surrounding_template* `options` => `template`
+
+*Find* inside `template`
+```js
+var $this = this;
+```
+
+*Find* inside `template`
+```js
+createElement($ToggleView.ToggleView
+```
+
+Prefix with a child
+
+*Replace* `options` with
+```js
+$DCGView.createElement(
+  $DCGView.Components.If,
+  {
+    predicate: () =>
+      DesModder.controller.isGlesmosMode($this.id) &&
+      DesModder.controller.isInequality($this.id),
+  },
+  () => $DCGView.createElement(
+    "div",
+    { class: $DCGView.const("dcg-options-menu-section-title dsm-gl-lines-confirm") },
+    () => DesModder.controller.format("GLesmos-confirm-lines"),
+    $DCGView.createElement($ToggleView.ToggleView, {
+      ariaLabel: () => DesModder.controller.format("GLesmos-confirm-lines"),
+      toggled: () => window.DesModder?.controller?.isGLesmosLinesConfirmed?.($this.id),
+      onChange: (a) => window.DesModder?.controller?.toggleGLesmosLinesConfirmed?.($this.id),
+    }),
+    $DCGView.createElement(
+      $DCGView.Components.If,
+      {
+        predicate: () => !DesModder?.controller?.isGLesmosLinesConfirmed?.($this.id)
+      },
+      () => $DCGView.createElement("div",
+        { class: $DCGView.const("dsm-gl-lines-confirm-body") },
+        () => DesModder.controller.format("GLesmos-confirm-lines-body")
+      )
+    )
+  )
+),
+__options__
+```
+
+### Alternative
+
+*Module* `expressions/expression-menus/lines`
+
+*Find* => `options`
+```js
+$DCGView.createElement("div",
+  { class: $DCGView.const("dcg-options-flex-container") },
+  $DCGView.createElement("div",
+    { class: $DCGView.const("dcg-options-left-side") },
+    $DCGView.createElement("div", {
+      class: $DCGView.const("dcg-iconed-mathquill-row dcg-line-opacity-row")
+```
+
+*Find_surrounding_template* `options` => `template`
+
+*Find* inside `template`
+```js
+createElement($ToggleView, {
+  ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
+```
+
+Prefix with a child
+
+*Replace* `options` with
+```js
+$DCGView.createElement(
+  $DCGView.Components.If,
+  {
+    predicate: () =>
+      DesModder.controller.isGlesmosMode(this.id) &&
+      DesModder.controller.isInequality(this.id),
+  },
+  () => $DCGView.createElement(
+    "div",
+    { class: $DCGView.const("dcg-options-menu-section-title dsm-gl-lines-confirm") },
+    () => DesModder.controller.format("GLesmos-confirm-lines"),
+    $DCGView.createElement($ToggleView, {
+      ariaLabel: () => DesModder.controller.format("GLesmos-confirm-lines"),
+      toggled: () => window.DesModder?.controller?.isGLesmosLinesConfirmed?.(this.id),
+      onChange: (a) => window.DesModder?.controller?.toggleGLesmosLinesConfirmed?.(this.id),
+    }),
+    $DCGView.createElement(
+      $DCGView.Components.If,
+      {
+        predicate: () => !DesModder?.controller?.isGLesmosLinesConfirmed?.(this.id)
+      },
+      () => $DCGView.createElement("div",
+        { class: $DCGView.const("dsm-gl-lines-confirm-body") },
+        () => DesModder.controller.format("GLesmos-confirm-lines-body")
+      )
+    )
+  )
+),
+__options__
 ```
 
 ## Replace main renderer with glesmos rendering when necessary
@@ -353,7 +471,8 @@ addStatement = function ($stmt) {
 *Replace* `body` with
 ```js
 if ($stmt.type === "statement") {
-  $stmt.glesmos = window.DesModder?.controller?.isGlesmosMode?.($stmt.id);
+  $stmt.glesmos = window.DesModder?.controller?.isGlesmosMode($stmt.id);
+  $stmt.glesmosLinesConfirmed = window.DesModder?.controller?.isGLesmosLinesConfirmed($stmt.id);
 }
 __body__
 ```
@@ -374,7 +493,8 @@ addStatement($stmt) {
 *Replace* `body` with
 ```js
 if ($stmt.type === "statement") {
-  $stmt.glesmos = window.DesModder?.controller?.isGlesmosMode?.($stmt.id);
+  $stmt.glesmos = window.DesModder?.controller?.isGlesmosMode($stmt.id);
+  $stmt.glesmosLinesConfirmed = window.DesModder?.controller?.isGLesmosLinesConfirmed($stmt.id);
 }
 __body__
 ```
@@ -437,7 +557,9 @@ else {
 *Replace* `else` with
 ```js
 else if ($this.userData.glesmos) {
-  const lines = $this.userData.lines !== false;
+  const lines =
+    $this.userData.lines !== false &&
+    (!$this.isInequality() || $this.userData.glesmosLinesConfirmed);
   let derivativeX, derivativeY;
   if (lines) {
     try {
@@ -520,7 +642,9 @@ else {
 *Replace* `else` with
 ```js
 else if (this.userData.glesmos) {
-  const lines = this.userData.lines !== false;
+  const lines =
+    this.userData.lines !== false &&
+    (!this.isInequality() || this.userData.glesmosLinesConfirmed);
   let derivativeX, derivativeY;
   if (lines) {
     try {


### PR DESCRIPTION
This only applies to GLesmos inequalities like `sin(xy)>0`, and not equalities like `sin(xy)=0` since equalities could not be plotted before the outlines update.

The primary purpose of this change is to ensure that graphs created pre-outlines would not suddenly get much slower post-outlines. Adding a new confirmation check avoids the stateful mess of the alternative (version migration, changing the interpretation of the lines property, etc.).

A secondary purpose to this update is to show a little message before people enable lines. This has minor utility and only appears for inequalities.
