### PR TITLE
Update to TypeScript 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "less": "^4.1.3",
         "minimist-lite": "^2.2.1",
         "ts-jest": "^28.0.5",
-        "typescript": "^4.7.4"
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8766,16 +8766,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/unbox-primitive": {
@@ -15401,9 +15401,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "less": "^4.1.3",
     "minimist-lite": "^2.2.1",
     "ts-jest": "^28.0.5",
-    "typescript": "^4.7.4"
+    "typescript": "^5.0.4"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.4.2",

--- a/src/plugins/GLesmos/colorParsing.ts
+++ b/src/plugins/GLesmos/colorParsing.ts
@@ -176,9 +176,10 @@ function parseCSSFunc(color: string): ColorType | null {
 
   const [, funcName = "", argSet = ""] =
     color.trim().match(matchSignature) ?? [];
-  let args = argSet.match(matchArgs);
-  if (args === null) return null;
-  const alphaStr: string | undefined = (args = args.slice(1)).pop();
+  const args0 = argSet.match(matchArgs);
+  if (args0 === null) return null;
+  const args = args0.slice(1);
+  const alphaStr: string | undefined = args.pop();
   const alpha = parseFloat(alphaStr ?? "");
   // truthy map if argument evaluates as NaN (means number contains css units)
   const pType: boolean[] = args.map((t) => isNaN(Number(t)));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "strict": true,
     "baseUrl": "src",
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "skipLibCheck": true
   },
   "include": ["./src/", "./loaders/", "./esbuild.mjs"]
 }


### PR DESCRIPTION
Add skipLibCheck for minimist-lite. Eventually, we should go back and disable skipLibCheck.
