### PR TITLE
Reduce parens emitted to raw

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "eslint",
     "lint:eslint": "eslint .",
     "test": "npm run test:jest",
-    "test:jest": "jest --config jest.config.js"
+    "test:jest": "./scripts/test-jest.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/test-jest.sh
+++ b/scripts/test-jest.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+SERVER="https://desmos.com"
+CACHE_FOLDER="node_modules/.cache/desmos"
+CALC_DESKTOP="$CACHE_FOLDER/calculator_desktop.js"
+PREFIX='<script src="/assets/build/calculator_desktop'
+
+if [ ! -f $CALC_DESKTOP ]; then
+  echo "Downloading '$SERVER/calculator' calculator_desktop URL"
+  build=$(wget -nv -O - "$SERVER/calculator" | grep "$PREFIX" | cut -d\" -f 2)
+  js="$SERVER$build"
+  echo "Mkdir cache folder"
+  mkdir -p "$CACHE_FOLDER"
+  echo "Downloading latest calculator_desktop: '$js'"
+  wget "$js" -O "$CALC_DESKTOP"
+  echo "Download finished"
+fi
+
+jest --config jest.config.js "$@"

--- a/src/plugins/text-mode/aug/AugLatex.ts
+++ b/src/plugins/text-mode/aug/AugLatex.ts
@@ -41,7 +41,8 @@ export type AnyChild =
   | BinaryOperator
   | Negative
   | Comparator
-  | DoubleInequality;
+  | DoubleInequality
+  | AssignmentExpression;
 
 export interface Equation {
   type: "Equation";

--- a/src/plugins/text-mode/aug/augNeedsParens.ts
+++ b/src/plugins/text-mode/aug/augNeedsParens.ts
@@ -1,0 +1,118 @@
+import Aug from "./AugState";
+import { isFactorialBang } from "./augToRaw";
+
+export default function augNeedsParens(
+  node: Aug.Latex.AnyChild,
+  parent: Aug.Latex.AnyRootOrChild | null,
+  path: string | undefined
+): boolean {
+  if (node.type === "Seq") return node.parenWrapped;
+
+  if (parent === null) return false;
+
+  switch (parent.type) {
+    case "Integral":
+      return false;
+    case "ListAccess":
+      return path === "list";
+    case "DotAccess":
+    case "OrderedPairAccess":
+      return path === "object";
+    case "RepeatedOperator":
+      return path === "term";
+    case "BinaryOperator":
+      if (parent.name === "Exponent" && path === "right") return false;
+      return power(node) <= power(parent);
+    case "Negative":
+      if (node.type === "Constant" && node.value > 0) return false;
+      return power(node) <= power(parent);
+    case "FunctionCall":
+      return path === "factorial";
+  }
+
+  switch (node.type) {
+    case "Derivative":
+      return true;
+    case "Substitution":
+      return true;
+  }
+
+  return false;
+}
+
+const _precedence = [
+  "top",
+  "seq",
+  "update",
+  "with",
+  "compare",
+  "add",
+  "multiply",
+  "prefix",
+  "factorial",
+  "power",
+  "index",
+  "call",
+  "bottom",
+] as const;
+const _precIndices = _precedence.map((op, index) => [op, index] as const);
+const POWERS = Object.fromEntries(_precIndices) as Record<
+  (typeof _precedence)[number],
+  number
+>;
+
+// Don't worry about left vs right precedence for now. Err on the side of more parens.
+function power(node: Aug.Latex.AnyChild): number {
+  switch (node.type) {
+    case "Constant":
+      return node.value < 0 ? POWERS.prefix : POWERS.bottom;
+    case "Identifier":
+    case "List":
+    case "Range":
+    case "ListComprehension":
+    case "Piecewise":
+      return POWERS.bottom;
+    case "FunctionCall":
+      return isFactorialBang(node.callee, node.args)
+        ? POWERS.factorial
+        : POWERS.call;
+    case "Prime":
+      return POWERS.call;
+    case "ListAccess":
+    case "DotAccess":
+    case "OrderedPairAccess":
+      return POWERS.index;
+    case "Negative":
+      return POWERS.prefix;
+    case "BinaryOperator":
+      switch (node.name) {
+        case "Exponent":
+          return POWERS.power;
+        case "Multiply":
+          return POWERS.multiply;
+        case "Divide":
+          return POWERS.bottom;
+        case "Add":
+        case "Subtract":
+          return POWERS.add;
+      }
+    // eslint-disable-next-line no-fallthrough
+    case "Integral":
+    case "Derivative":
+    case "RepeatedOperator":
+      return POWERS.multiply;
+    case "UpdateRule":
+      return POWERS.update;
+    case "Comparator":
+    case "DoubleInequality":
+    case "AssignmentExpression":
+      return POWERS.compare;
+    case "Seq":
+      return POWERS.seq;
+    case "Substitution":
+      return POWERS.with;
+    default:
+      node satisfies never;
+      throw new Error(`Programming Error: Node type ${(node as any).type}`);
+  }
+}

--- a/src/plugins/text-mode/aug/augToRaw.ts
+++ b/src/plugins/text-mode/aug/augToRaw.ts
@@ -296,7 +296,7 @@ function latexTreeToStringMaybe(e: Aug.Latex.AnyRootOrChild | undefined) {
   return latexTreeToString(e);
 }
 
-function latexTreeToString(e: Aug.Latex.AnyRootOrChild) {
+export function latexTreeToString(e: Aug.Latex.AnyRootOrChild) {
   switch (e.type) {
     case "Equation":
     case "Assignment":

--- a/src/plugins/text-mode/aug/augToRaw.ts
+++ b/src/plugins/text-mode/aug/augToRaw.ts
@@ -1,5 +1,6 @@
 import { isConstant } from "./AugLatex";
 import Aug from "./AugState";
+import rawNeedsParens from "./augNeedsParens";
 import * as Graph from "@desmodder/graph-state";
 import Metadata from "main/metadata/interface";
 import { changeExprInMetadata, isBlankMetadata } from "main/metadata/manage";
@@ -300,20 +301,22 @@ export function latexTreeToString(e: Aug.Latex.AnyRootOrChild) {
   switch (e.type) {
     case "Equation":
     case "Assignment":
-      return childNodeToString(e.left) + "=" + childNodeToString(e.right);
+      return childNodeToString(e.left, e) + "=" + childNodeToString(e.right, e);
     case "FunctionDefinition":
       return (
-        funcToString(e.symbol, e.argSymbols) +
+        funcToString(e.symbol, e.argSymbols, e) +
         "=" +
-        childNodeToString(e.definition)
+        childNodeToString(e.definition, e)
       );
     case "Visualization":
       // Lower case handles "Stats" → "stats" etc
-      return funcToString(e.callee, e.args);
+      return funcToString(e.callee, e.args, e);
     case "Regression":
-      return childNodeToString(e.left) + "\\sim " + childNodeToString(e.right);
+      return (
+        childNodeToString(e.left, e) + "\\sim " + childNodeToString(e.right, e)
+      );
     default:
-      return childNodeToString(e);
+      return childNodeToString(e, null);
   }
 }
 
@@ -322,7 +325,17 @@ function columnEntryToString(e: Aug.Latex.AnyRootOrChild): string {
   return latexTreeToString(e);
 }
 
-function childNodeToString(e: Aug.Latex.AnyChild): string {
+function childNodeToString(
+  e: Aug.Latex.AnyChild,
+  parent: Aug.Latex.AnyRootOrChild | null,
+  path?: string | undefined
+): string {
+  const inner = childNodeToStringNoParen(e);
+  if (rawNeedsParens(e, parent, path)) return wrapParen(inner);
+  return inner;
+}
+
+function childNodeToStringNoParen(e: Aug.Latex.AnyChild): string {
   switch (e.type) {
     case "Constant": {
       const res = e.value.toString();
@@ -331,65 +344,65 @@ function childNodeToString(e: Aug.Latex.AnyChild): string {
     case "Identifier":
       return identifierToString(e);
     case "FunctionCall":
-      return funcToString(e.callee, e.args);
+      return funcToString(e.callee, e.args, e);
     case "Integral":
       return (
-        `\\int_{${childNodeToString(e.start)}}` +
-        `^{${childNodeToString(e.end)}}` +
-        wrapParen(childNodeToString(e.integrand)) +
+        `\\int_{${childNodeToString(e.start, e)}}` +
+        `^{${childNodeToString(e.end, e)}}` +
+        childNodeToString(e.integrand, e, "integrand") +
         "d" +
         identifierToString(e.differential)
       );
     case "Derivative":
       return (
-        `\\left(\\frac{d}{d${identifierToString(e.variable)}}` +
-        childNodeToString(e.arg) +
-        "\\right)"
+        `\\frac{d}{d${identifierToString(e.variable)}}` +
+        childNodeToString(e.arg, e)
       );
     case "Prime":
       return (
         identifierToString(e.arg.callee) +
         "'".repeat(e.order) +
-        wrapParen(childNodeToString(e.arg.args[0]))
+        wrapParen(bareSeq(e.arg.args, e.arg))
       );
     case "List":
-      return wrapBracket(bareSeq(e.args));
+      return wrapBracket(bareSeq(e.args, e));
     case "Range":
-      return wrapBracket(bareSeq(e.start) + "..." + bareSeq(e.end));
+      return wrapBracket(bareSeq(e.start, e) + "..." + bareSeq(e.end, e));
     case "ListAccess":
       return (
-        wrapParen(childNodeToString(e.list)) +
+        childNodeToString(e.list, e, "list") +
         (e.index.type === "Range"
-          ? childNodeToString(e.index)
-          : wrapBracket(childNodeToString(e.index)))
+          ? childNodeToString(e.index, e)
+          : wrapBracket(childNodeToString(e.index, e)))
       );
     case "DotAccess":
       return (
-        wrapParen(childNodeToString(e.object)) +
+        childNodeToString(e.object, e, "object") +
         "." +
-        childNodeToString(e.property)
+        childNodeToString(e.property, e)
       );
     case "OrderedPairAccess":
-      return wrapParen(childNodeToString(e.point)) + "." + e.index;
+      return childNodeToString(e.point, e, "object") + "." + e.index;
     case "Seq":
-      return e.parenWrapped ? wrapParen(bareSeq(e.args)) : bareSeq(e.args);
+      // needsParen handles wrapping in paren for parenWrapped
+      return bareSeq(e.args, e);
     case "UpdateRule":
       return (
         identifierToString(e.variable) +
         "\\to " +
-        childNodeToString(e.expression)
+        childNodeToString(e.expression, e)
       );
     case "ListComprehension":
       return wrapBracket(
-        childNodeToString(e.expr) +
+        childNodeToString(e.expr, e) +
           "\\operatorname{for}" +
           e.assignments.map(assignmentExprToRaw).join(",")
       );
     case "Substitution":
-      return wrapParen(
-        childNodeToString(e.body) +
-          "\\operatorname{with}" +
-          e.assignments.map(assignmentExprToRaw).join(",")
+      return (
+        childNodeToString(e.body, e) +
+        "\\operatorname{with}" +
+        e.assignments.map(assignmentExprToRaw).join(",")
       );
     case "Piecewise": {
       const piecewiseParts: string[] = [];
@@ -399,17 +412,17 @@ function childNodeToString(e: Aug.Latex.AnyChild): string {
           curr = curr.consequent;
           break;
         }
-        let part = childNodeToString(curr.condition);
+        let part = childNodeToString(curr.condition, curr);
         if (!Aug.Latex.isConstant(curr.consequent, 1)) {
-          part += ":" + childNodeToString(curr.consequent);
+          part += ":" + childNodeToString(curr.consequent, curr);
         }
         piecewiseParts.push(part);
         curr = curr.alternate;
       }
       if (!Aug.Latex.isConstant(curr, NaN)) {
         // check handles trivial piecewise such as {else: 1}
-        if (piecewiseParts.length === 0) return childNodeToString(curr);
-        piecewiseParts.push(childNodeToString(curr));
+        if (piecewiseParts.length === 0) return childNodeToString(curr, e);
+        piecewiseParts.push(childNodeToString(curr, e));
       }
       return "\\left\\{" + piecewiseParts.join(",") + "\\right\\}";
     }
@@ -417,46 +430,46 @@ function childNodeToString(e: Aug.Latex.AnyChild): string {
       const prefix = e.name === "Product" ? "\\prod" : "\\sum";
       return (
         prefix +
-        `_{${identifierToString(e.index)}=${childNodeToString(e.start)}}` +
-        `^{${childNodeToString(e.end)}}` +
-        wrapParen(childNodeToString(e.expression))
+        `_{${identifierToString(e.index)}=${childNodeToString(e.start, e)}}` +
+        `^{${childNodeToString(e.end, e)}}` +
+        childNodeToString(e.expression, e, "term")
       );
     }
     case "BinaryOperator": {
-      const binopLeft = childNodeToString(e.left);
-      const binopRight = childNodeToString(e.right);
+      const binopLeft = childNodeToString(e.left, e, "left");
+      const binopRight = childNodeToString(e.right, e, "right");
       switch (e.name) {
         case "Add":
-          return wrapParen(binopLeft) + "+" + wrapParen(binopRight);
+          return binopLeft + "+" + binopRight;
         case "Subtract":
-          return wrapParen(binopLeft) + "-" + wrapParen(binopRight);
+          return binopLeft + "-" + binopRight;
         case "Multiply":
-          return wrapParen(binopLeft) + "\\cdot " + wrapParen(binopRight);
+          return binopLeft + "\\cdot " + binopRight;
         case "Divide":
           return `\\frac{${binopLeft}}{${binopRight}}`;
         case "Exponent":
-          return wrapParen(binopLeft) + "^{" + binopRight + "}";
+          return binopLeft + "^{" + binopRight + "}";
       }
     }
     // eslint-disable-next-line no-fallthrough
     case "Negative":
-      if (e.arg.type === "Constant" && e.arg.value > 0)
-        return "-" + childNodeToString(e.arg);
-      return "-" + wrapParen(childNodeToString(e.arg));
+      return "-" + childNodeToString(e.arg, e);
     case "Comparator":
       return (
-        childNodeToString(e.left) +
+        childNodeToString(e.left, e) +
         comparatorMap[e.operator] +
-        childNodeToString(e.right)
+        childNodeToString(e.right, e)
       );
     case "DoubleInequality":
       return (
-        childNodeToString(e.left) +
+        childNodeToString(e.left, e) +
         comparatorMap[e.leftOperator] +
-        childNodeToString(e.middle) +
+        childNodeToString(e.middle, e) +
         comparatorMap[e.rightOperator] +
-        childNodeToString(e.right)
+        childNodeToString(e.right, e)
       );
+    case "AssignmentExpression":
+      return assignmentExprToRaw(e);
     default:
       e satisfies never;
       throw new Error(
@@ -466,7 +479,9 @@ function childNodeToString(e: Aug.Latex.AnyChild): string {
 }
 
 function assignmentExprToRaw(e: Aug.Latex.AssignmentExpression): string {
-  return identifierToString(e.variable) + "=" + childNodeToString(e.expression);
+  return (
+    identifierToString(e.variable) + "=" + childNodeToString(e.expression, e)
+  );
 }
 
 const comparatorMap = {
@@ -477,34 +492,46 @@ const comparatorMap = {
   ">": ">",
 };
 
-function bareSeq(e: Aug.Latex.AnyChild[]): string {
-  return e.map(childNodeToString).join(",");
+function bareSeq(
+  e: Aug.Latex.AnyChild[],
+  parent: Aug.Latex.AnyRootOrChild
+): string {
+  return e.map((f) => childNodeToString(f, parent)).join(",");
 }
 
 function funcToString(
   callee: Aug.Latex.Identifier,
-  args: Aug.Latex.AnyChild[]
+  args: Aug.Latex.AnyChild[],
+  parent: Aug.Latex.AnyRootOrChild
 ): string {
-  if (callee.symbol === "factorial") {
-    return `\\left(${bareSeq(args)}\\right)!`;
-  } else if (callee.symbol === "abs") {
-    return `\\left|${bareSeq(args)}\\right|`;
-  } else if (callee.symbol === "sqrt") {
-    return `\\sqrt{${bareSeq(args)}}`;
-  } else if (callee.symbol === "nthroot") {
-    if (args.length === 1) return `\\sqrt{${bareSeq(args)}}`;
-    return `\\sqrt[${childNodeToString(args[1])}]{${bareSeq([
-      ...args.slice(0, 1),
-      ...args.slice(2),
-    ])}}`;
-  } else if (callee.symbol === "l_ogbase") {
-    if (args.length === 1) return `\\log\\left(${bareSeq(args)}\\right)`;
-    return `\\log_{${childNodeToString(args[args.length - 1])}}\\left(${bareSeq(
-      args.slice(0, args.length - 1)
-    )}\\right)`;
+  if (isFactorialBang(callee, args)) {
+    return childNodeToString(args[0], parent, "factorial") + "!";
+  } else if (callee.symbol === "abs" && args.length === 1) {
+    return `\\left|${bareSeq(args, parent)}\\right|`;
+  } else if (callee.symbol === "sqrt" && args.length === 1) {
+    return `\\sqrt{${bareSeq(args, parent)}}`;
+  } else if (callee.symbol === "nthroot" && [1, 2].includes(args.length)) {
+    if (args.length === 1) return `\\sqrt{${bareSeq(args, parent)}}`;
+    return `\\sqrt[${childNodeToString(args[1], parent)}]{${bareSeq(
+      [...args.slice(0, 1), ...args.slice(2)],
+      parent
+    )}}`;
+  } else if (callee.symbol === "l_ogbase" && [1, 2].includes(args.length)) {
+    if (args.length === 1) return "\\log" + wrapParen(bareSeq(args, parent));
+    return (
+      `\\log_{${childNodeToString(args[args.length - 1], parent)}}` +
+      wrapParen(bareSeq(args.slice(0, args.length - 1), parent))
+    );
   } else {
-    return identifierToString(callee) + wrapParen(bareSeq(args));
+    return identifierToString(callee) + wrapParen(bareSeq(args, parent));
   }
+}
+
+export function isFactorialBang(
+  callee: Aug.Latex.Identifier,
+  args: Aug.Latex.AnyChild[]
+) {
+  return callee.symbol === "factorial" && args.length === 1;
 }
 
 /**

--- a/src/plugins/text-mode/aug/rawToAug.ts
+++ b/src/plugins/text-mode/aug/rawToAug.ts
@@ -338,7 +338,7 @@ function parseLatex(str: string): Aug.Latex.AnyChild {
   return childNodeToTree(res);
 }
 
-function parseRootLatex(str: string): Aug.Latex.AnyRootOrChild {
+export function parseRootLatex(str: string): Aug.Latex.AnyRootOrChild {
   const parsed = parseDesmosLatex(str);
   switch (parsed.type) {
     case "Equation":

--- a/src/plugins/text-mode/aug/rawToAug.ts
+++ b/src/plugins/text-mode/aug/rawToAug.ts
@@ -331,7 +331,7 @@ function parseMaybeLatex(str: string | undefined) {
   return str !== undefined ? parseLatex(str) : undefined;
 }
 
-function parseLatex(str: string): Aug.Latex.AnyChild {
+export function parseLatex(str: string): Aug.Latex.AnyChild {
   if (str === "") return { type: "Constant", value: NaN };
   const res = parseDesmosLatex(str);
   // childNodeToTree throws an error if res is not a child node

--- a/src/plugins/text-mode/aug/roundTripParse.test.ts
+++ b/src/plugins/text-mode/aug/roundTripParse.test.ts
@@ -9,11 +9,19 @@ console.error = oldConsoleError;
 const { latexTreeToString } = require("./augToRaw");
 const { parseRootLatex } = require("./rawToAug");
 
+function leftRight(s: string) {
+  return s
+    .replace(/[[(]|\\{/g, (x) => "\\left" + x)
+    .replace(/[\])]|\\}/g, (x) => "\\right" + x)
+    .replace(/\*/g, "\\cdot ");
+}
+
 function testRoundTripIdentical(raw: string) {
   test(raw, () => {
-    const aug = parseRootLatex(raw);
+    const raw1 = leftRight(raw);
+    const aug = parseRootLatex(raw1);
     const raw2 = latexTreeToString(aug);
-    expect(raw).toEqual(raw2);
+    expect(raw2).toEqual(raw1);
   });
 }
 
@@ -22,7 +30,7 @@ function testRoundTripParsesSame(raw: string) {
     const aug = parseRootLatex(raw);
     const raw2 = latexTreeToString(aug);
     const aug2 = parseRootLatex(raw2);
-    expect(aug).toEqual(aug2);
+    expect(aug2).toEqual(aug);
   });
 }
 
@@ -30,19 +38,34 @@ const raw = String.raw;
 
 describe("Identical round trips", () => {
   const cases: string[] = [
-    raw`\left(2\right)+\left(3\right)`,
-    raw`\left(x\right)^{2}`,
+    "2+3",
+    "x^{2}",
+    "(-5)^{2}",
+    "(x)!",
+    "(x+2)!",
+    "f''(x)",
+    "(P).x",
+    raw`(L).\operatorname{random}(5)`,
+    "(2+3)*4",
+    "2*3+4",
+    "(0,4)",
+    raw`\frac{(2)}{(3)}*4`,
+    raw`[a+b\operatorname{for}a=[1...5],b=[-3...4]]`,
+    raw`\int_{a}^{b}f(x)dx`,
   ];
   cases.forEach(testRoundTripIdentical);
 });
 
 describe("Same-parse round trips", () => {
   const cases: string[] = [
-    "2+3",
-    "x^2",
     raw`A_{main}\left(d\right)=A_{T}\left(d\right),\ A_{horizScroll}\left(0\right),\ A_{vertScroll}\left(0\right),\left\{Q_{pauseEval}=0:\ \left\{Q_{landscape}=1:\ A_{E}\left(0\right)\right\}\right\},\ A_{drag}\left(0\right),\ A_{scrollbarWidth}\left(0\right)`,
     raw`x_{1}\left(y\right)=1-4^{\operatorname{round}\left(\log_{4}\left(\left|3y-1\right|\right)-0.5b\right)+0.5b}`,
     raw`u=\left\{\frac{1}{3}+\frac{1}{6}\left(-2\right)^{\operatorname{floor}\left(\log_{2}\left(1-x\right)\right)}<y:\left\{0<x,0\right\},0\right\}`,
+    raw`C\left(p\right)=\left(1-t\right)^{3}p\left[1\right]+3t\left(1-t\right)^{2}p\left[2\right]+3t^{2}\left(1-t\right)p\left[3\right]+t^{3}p\left[4\right]`,
+    raw`\left[P\left(C_{1}\left(\left(x_{30},y_{30}\right)\left[1...4\right],\left[1-t,t-1\right]\right)\right),P\left(C_{1}\left(\left(x_{31},y_{31}\right)\left[1...4\right],\left[1-t,t-1\right]\right)\right)\right]+0.25\left(2\cos\left(17\tau t\right),\sin\left(27\tau t\right)\right)t\left(t-1\right)^{2}\left(t-2\right)`,
+    raw`y=-0.8605\sum_{n=1}^{13}\frac{\prod_{i=1}^{n}\left(2i-1\right)^{2}}{0.76075^{2n}\left(2n\right)!\left(2n-1\right)}\left(x-0.36125\right)^{2n}+8.181\left\{-0.1676\le x\le0.225\right\}`,
+    raw`r_{otate}\left(p,\theta\right)=\left(p.x\cos\left(\tau\theta\right)+p.y\sin\left(\tau\theta\right),-p.x\sin\left(\tau\theta\right)+p.y\cos\left(\tau\theta\right)\right)`,
+    raw`\left[\operatorname{polygon}\left(\left(\frac{\left(-2\right)^{i-1}-1}{3},\frac{2-2^{i}3}{2}+2b_{ounce}\left(t+1.1-1.1^{-i}\right)\right)+\frac{\left(\left[-1,1,1,-1\right],\left[-1,-1,1,1\right]\right)}{2^{1-i}}\right)\operatorname{for}i=-\left[0...7\right],t=T+\frac{l}{2}\right]`,
   ];
   cases.forEach(testRoundTripParsesSame);
 });

--- a/src/plugins/text-mode/aug/roundTripParse.test.ts
+++ b/src/plugins/text-mode/aug/roundTripParse.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const oldConsoleError = console.error;
+console.error = () => {};
+require("../../../../node_modules/.cache/desmos/calculator_desktop.js");
+console.error = oldConsoleError;
+
+const { latexTreeToString } = require("./augToRaw");
+const { parseRootLatex } = require("./rawToAug");
+
+function testRoundTripIdentical(raw: string) {
+  test(raw, () => {
+    const aug = parseRootLatex(raw);
+    const raw2 = latexTreeToString(aug);
+    expect(raw).toEqual(raw2);
+  });
+}
+
+function testRoundTripParsesSame(raw: string) {
+  test(raw, () => {
+    const aug = parseRootLatex(raw);
+    const raw2 = latexTreeToString(aug);
+    const aug2 = parseRootLatex(raw2);
+    expect(aug).toEqual(aug2);
+  });
+}
+
+const raw = String.raw;
+
+describe("Identical round trips", () => {
+  const cases: string[] = [
+    raw`\left(2\right)+\left(3\right)`,
+    raw`\left(x\right)^{2}`,
+  ];
+  cases.forEach(testRoundTripIdentical);
+});
+
+describe("Same-parse round trips", () => {
+  const cases: string[] = [
+    "2+3",
+    "x^2",
+    raw`A_{main}\left(d\right)=A_{T}\left(d\right),\ A_{horizScroll}\left(0\right),\ A_{vertScroll}\left(0\right),\left\{Q_{pauseEval}=0:\ \left\{Q_{landscape}=1:\ A_{E}\left(0\right)\right\}\right\},\ A_{drag}\left(0\right),\ A_{scrollbarWidth}\left(0\right)`,
+    raw`x_{1}\left(y\right)=1-4^{\operatorname{round}\left(\log_{4}\left(\left|3y-1\right|\right)-0.5b\right)+0.5b}`,
+    raw`u=\left\{\frac{1}{3}+\frac{1}{6}\left(-2\right)^{\operatorname{floor}\left(\log_{2}\left(1-x\right)\right)}<y:\left\{0<x,0\right\},0\right\}`,
+  ];
+  cases.forEach(testRoundTripParsesSame);
+});

--- a/src/plugins/text-mode/down/TextAST.ts
+++ b/src/plugins/text-mode/down/TextAST.ts
@@ -90,6 +90,7 @@ export type Expression =
   | ListExpression
   | ListComprehension
   | Substitution
+  | AssignmentExpression
   | PiecewiseExpression
   | PrefixExpression
   | SequenceExpression

--- a/src/plugins/text-mode/down/astToAug.ts
+++ b/src/plugins/text-mode/down/astToAug.ts
@@ -718,6 +718,8 @@ export function childExprToAug(
         arg: childExprToAug(expr.expr),
         variable: identifierToAug(expr.variable),
       };
+    case "AssignmentExpression":
+      return assignment(expr);
     default:
       expr satisfies never;
       throw new Error(

--- a/src/plugins/text-mode/up/astToText.ts
+++ b/src/plugins/text-mode/up/astToText.ts
@@ -357,6 +357,10 @@ function exprToTextNoParen(path: NodePath<TextAST.Expression>): Doc {
       return [exprToText(path.withChild(e.expr, "expr")), "!"];
     case "String":
       return stringToText(e.value);
+    case "AssignmentExpression":
+      return assignmentExpressionToText(
+        path as NodePath<TextAST.AssignmentExpression>
+      );
     default:
       e satisfies never;
       throw new Error(

--- a/src/plugins/text-mode/up/augToAST.ts
+++ b/src/plugins/text-mode/up/augToAST.ts
@@ -565,6 +565,8 @@ function childLatexToAST(e: Aug.Latex.AnyChild): TextAST.Expression {
         rightOp: e.rightOperator,
         right: childLatexToAST(e.right),
       };
+    case "AssignmentExpression":
+      return assignmentExprToAST(e);
     default:
       e satisfies never;
       throw new Error(


### PR DESCRIPTION
Adds and uses `augNeedsParens` to determine if parentheses are needed on the emit of an expression to raw. The previous behavior was effectively always returning true. Now, we convert many cases to false, making ronwnor slightly happier.

Also download calculator_desktop before tests, to be able to test against Desmos's parser.
