### PR TITLE
Add footers in Text Mode

### DIFF
--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -1,5 +1,5 @@
-import { ItemModel } from "../globals/models";
-import { ClassComponent, DCGView } from "DCGView";
+import { ExpressionModel, ItemModel } from "../globals/models";
+import { ClassComponent, Component, DCGView } from "DCGView";
 import { DesModderFragile, Calc, Fragile } from "globals/window";
 
 export abstract class CheckboxComponent extends ClassComponent<{
@@ -103,11 +103,55 @@ export abstract class TooltipComponent extends ClassComponent<{
 
 export const Tooltip = Fragile.Tooltip;
 
+export abstract class ExpressionViewComponent extends ClassComponent<
+  ModelAndController & {
+    onDragPending: () => void;
+    isDragCopy: () => boolean;
+  }
+> {}
+
+const ExpressionView = DesModderFragile.ExpressionView;
+
 export abstract class IconViewComponent extends ClassComponent<{
   model: ItemModel;
   controller: typeof Calc.controller;
 }> {}
 
-export const ExpressionIconView = DesModderFragile.ExpressionIconView;
-
 export const ImageIconView = DesModderFragile.ImageIconView;
+
+interface ModelAndController {
+  model: ExpressionModel;
+  controller: typeof Calc.controller;
+}
+
+// <ExpressionIconView ... >
+export class ExpressionIconView extends Component<ModelAndController> {
+  template() {
+    const template = exprTemplate(this);
+    return template.children[1].children[1].children[0];
+  }
+}
+
+// <If predicate={this.shouldShowFooter}>
+//   {() => <div class={this.getFooterClass()}> ...
+export class FooterView extends Component<ModelAndController> {
+  template() {
+    const template = exprTemplate(this);
+    return template.children[0].children[2];
+  }
+}
+
+function exprTemplate(
+  self: InstanceType<typeof Component<ModelAndController>>
+) {
+  const n = new (ExpressionView as any)(
+    {
+      model: () => self.props.model(),
+      controller: () => self.props.controller(),
+      onDragPending: () => {},
+      isDragCopy: () => false,
+    },
+    []
+  );
+  return n.template();
+}

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -28,6 +28,7 @@ export type DispatchedEvent =
         | "duplicate-folder"
         | "duplicate-expression"
         | "convert-image-to-draggable"
+        | "create-sliders-for-item"
         | "toggle-item-hidden";
       id: string;
     }

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -1,53 +1,6 @@
 import { ItemModel } from "./models";
 import { GraphState } from "@desmodder/graph-state";
 
-export const exprMetadata = [
-  "set-expression-properties-from-api",
-  "set-slider-isplaying",
-  "set-slider-dragging",
-  "set-slider-minlatex",
-  "set-slider-maxlatex",
-  "set-slider-steplatex",
-  "set-slider-animationperiod",
-  "set-image-name",
-  "set-image-draggable",
-  "set-image-opacity",
-  "set-image-in-foreground",
-  "set-item-dragmode",
-  "set-item-points",
-  "set-item-pointstyle",
-  "set-item-lines",
-  "set-item-linestyle",
-  "set-item-arrow-mode",
-  "set-item-labelSize",
-  "set-item-labelangle",
-  "set-item-label-orientation",
-  "set-suppress-text-outline",
-  "set-item-interactive-label",
-  "set-item-editable-label-mode",
-  "set-show-cdf",
-  "set-cdf-min",
-  "set-cdf-max",
-  "toggle-item-hidden",
-  "set-item-label",
-  "set-item-showlabel",
-  "set-item-color",
-  "set-item-description",
-  "set-item-fill",
-  "set-item-fillopacity",
-  "set-item-lineopacity",
-  "set-item-pointopacity",
-  "set-item-pointsize",
-  "set-item-linewidth",
-  "set-item-colorlatex",
-  "set-item-secret",
-  "set-item-readonly",
-  "set-visualization-prop",
-  "set-clickableinfo-rule-latex",
-  "set-hovered-image",
-  "set-depressed-image",
-] as const;
-
 export type DispatchedEvent =
   | {
       type:
@@ -75,8 +28,17 @@ export type DispatchedEvent =
         | "duplicate-folder"
         | "duplicate-expression"
         | "convert-image-to-draggable"
-        | (typeof exprMetadata)[number];
+        | "toggle-item-hidden";
       id: string;
+    }
+  | {
+      /** This is somewhat a super type of all the `DispatchedEvent`s. It's here
+       * to avoid annotating tons of types for modify.ts. This should really be
+       * `type: "set-slider-minlatex" | (100 others)`, but that's unmaintainable.
+       * A second best would be `type: "string"`, but that screws with the
+       * other types being useful. */
+      type: "__dummy-IDEvent";
+      id?: string;
     }
   | {
       type: "set-selected-id";

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -2,6 +2,7 @@ import { DCGViewModule } from "../DCGView";
 import {
   CheckboxComponent,
   DStaticMathquillViewComponent,
+  ExpressionViewComponent,
   IconViewComponent,
   InlineMathInputViewComponent,
   MathQuillField,
@@ -23,7 +24,7 @@ interface windowConfig extends Window {
     pluginSettings: Record<PluginID, GenericSettings | undefined>;
   };
   DesModderFragile: {
-    ExpressionIconView: typeof IconViewComponent;
+    ExpressionView: ExpressionViewComponent;
     ImageIconView: typeof IconViewComponent;
   };
 }

--- a/src/plugins/text-mode/LanguageServer.ts
+++ b/src/plugins/text-mode/LanguageServer.ts
@@ -3,9 +3,10 @@
  * The functions in this file manage the interface between codemirror and
  * the Text Mode compiler.
  */
+import { DispatchedEvent } from "../../globals/Calc";
 import { Program, Statement } from "./down/TextAST";
 import textToRaw from "./down/textToRaw";
-import { RelevantEvent, eventSequenceChanges } from "./modify";
+import { eventSequenceChanges } from "./modify";
 import { Diagnostic } from "@codemirror/lint";
 import { StateField, Text, Transaction } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
@@ -23,7 +24,7 @@ export interface ProgramAnalysis {
  * onCalcEvent: when we receive a new event dispatched via Calc (such as a
  * slider value change, or viewport move) which affects the text
  */
-export function onCalcEvent(view: EditorView, event: RelevantEvent) {
+export function onCalcEvent(view: EditorView, event: DispatchedEvent) {
   // should this be a state effect?
   const analysis = view.state.field(analysisStateField);
   if (event.type === "set-selected-id") {

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -1,6 +1,5 @@
 import { PluginController } from "../PluginController";
 import { onCalcEvent, analysisStateField } from "./LanguageServer";
-import { RelevantEvent, relevantEventTypes } from "./modify";
 import getText from "./up/getText";
 import { initView, startState } from "./view/editor";
 import { EditorView, ViewUpdate } from "@codemirror/view";
@@ -57,14 +56,9 @@ export default class TextMode extends PluginController {
         this.toastErrorGraphUndo(
           "Text Mode cannot handle converting image to draggable."
         );
-      if ((relevantEventTypes as readonly string[]).includes(event.type)) {
-        // setTimeout to avoid dispatch-in-dispatch from handlers responding to
-        // calc state changing by dispatching an event
-        setTimeout(
-          () => this.view && onCalcEvent(this.view, event as RelevantEvent),
-          0
-        );
-      }
+      // setTimeout to avoid dispatch-in-dispatch from handlers responding to
+      // calc state changing by dispatching an event
+      setTimeout(() => this.view && onCalcEvent(this.view, event), 0);
     });
   }
 

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -50,15 +50,17 @@ export default class TextMode extends PluginController {
     container.appendChild(this.view.dom);
     this.preventPropagation(container);
     this.dispatchListenerID = Calc.controller.dispatcher.register((event) => {
-      if (event.type === "set-state" && !event.opts.fromTextMode)
-        this.onSetState();
-      if (event.type === "convert-image-to-draggable")
-        this.toastErrorGraphUndo(
-          "Text Mode cannot handle converting image to draggable."
-        );
       // setTimeout to avoid dispatch-in-dispatch from handlers responding to
       // calc state changing by dispatching an event
-      setTimeout(() => this.view && onCalcEvent(this.view, event), 0);
+      setTimeout(() => {
+        if (event.type === "set-state" && !event.opts.fromTextMode)
+          this.onSetState();
+        if (event.type === "convert-image-to-draggable")
+          this.toastErrorGraphUndo(
+            "Text Mode cannot handle converting image to draggable."
+          );
+        if (this.view) onCalcEvent(this.view, event);
+      });
     });
   }
 

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -55,10 +55,6 @@ export default class TextMode extends PluginController {
       setTimeout(() => {
         if (event.type === "set-state" && !event.opts.fromTextMode)
           this.onSetState();
-        if (event.type === "convert-image-to-draggable")
-          this.toastErrorGraphUndo(
-            "Text Mode cannot handle converting image to draggable."
-          );
         if (this.view) onCalcEvent(this.view, event);
       });
     });

--- a/src/plugins/text-mode/modify.ts
+++ b/src/plugins/text-mode/modify.ts
@@ -17,7 +17,7 @@ import { graphSettingsToText, itemToText } from "./up/augToText";
 import { ChangeSpec } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { GraphState } from "@desmodder/graph-state";
-import { DispatchedEvent, exprMetadata } from "globals/Calc";
+import { DispatchedEvent } from "globals/Calc";
 import { Calc } from "globals/window";
 import Metadata from "plugins/manage-metadata/interface";
 
@@ -33,39 +33,26 @@ const settingsEvents = [
   "resize-exp-list", // resize-exp-list can update viewport size
 ] as const;
 
-export const relevantEventTypes = [
-  ...settingsEvents,
-  ...exprMetadata,
-  // sliders, draggable points, action updates, etc.
-  "on-evaluator-changes",
-  // only should affect selection
-  "set-selected-id",
-] as const;
-
-export type RelevantEvent = DispatchedEvent & {
-  type: (typeof relevantEventTypes)[number];
-};
-
 type ToChange = "table-columns" | "latex-only" | "image-pos" | "regression";
 
 export function eventSequenceChanges(
   view: EditorView,
-  event: RelevantEvent,
+  event: DispatchedEvent,
   analysis: ProgramAnalysis
 ): ChangeSpec[] {
   const state = Calc.getState();
   if (event.type === "on-evaluator-changes") {
+    // sliders, draggable points, action updates, etc.
     return evaluatorChange(analysis, state, view, event);
   } else if ((settingsEvents as readonly string[]).includes(event.type)) {
     return [settingsChange(analysis, state)];
-  } else if ((exprMetadata as readonly string[]).includes(event.type)) {
-    const id = (
-      event as RelevantEvent & { type: (typeof exprMetadata)[number] }
-    ).id;
-    const dsmMetadata = rawToDsmMetadata(state);
-    return [metadataChange(analysis, state, dsmMetadata, view, id)];
   } else {
-    return [];
+    const res = [];
+    if ("id" in event && event.id !== undefined) {
+      const dsmMetadata = rawToDsmMetadata(state);
+      res.push(metadataChange(analysis, state, dsmMetadata, view, event.id));
+    }
+    return res;
   }
 }
 
@@ -73,7 +60,7 @@ function evaluatorChange(
   analysis: ProgramAnalysis,
   state: GraphState,
   view: EditorView,
-  event: RelevantEvent & { type: "on-evaluator-changes" }
+  event: DispatchedEvent & { type: "on-evaluator-changes" }
 ): ChangeSpec[] {
   const changes: ChangeSpec[] = [];
   const itemsChanged: Record<string, ToChange> = {};

--- a/src/plugins/text-mode/view/editor.less
+++ b/src/plugins/text-mode/view/editor.less
@@ -4,8 +4,14 @@
   grid-column: 1/2;
 }
 
-.dsm-in-text-mode .dcg-ticker {
-  display: none;
+.dsm-in-text-mode {
+  // used for cqw unit in footerWidget.less: .dsm-tm-footer-wrapper
+  container-type: size;
+
+  .dcg-ticker,
+  .dcg-exppanel {
+    display: none;
+  }
 }
 
 .cm-tooltip {

--- a/src/plugins/text-mode/view/editor.ts
+++ b/src/plugins/text-mode/view/editor.ts
@@ -2,9 +2,10 @@ import TextMode from "..";
 import { analysisStateField, doLint } from "../LanguageServer";
 // Language extension
 import { textMode } from "../lezer/index";
-import "./editor.css";
+import "./editor.less";
 import { checkboxPlugin } from "./plugins/checkboxWidget";
 import { collapseStylesAtStart } from "./plugins/collapseStylesAtStart";
+import { footerPlugin } from "./plugins/footerWidget";
 import { activeStmtGutterHighlighter } from "./plugins/highlightActiveStmtGutter";
 import { stmtNumbers } from "./plugins/stmtNumbers";
 import { styleCircles } from "./plugins/styleCircles";
@@ -15,12 +16,7 @@ import {
   completionKeymap,
   closeBracketsKeymap,
 } from "@codemirror/autocomplete";
-import {
-  history,
-  defaultKeymap,
-  historyKeymap,
-  indentWithTab,
-} from "@codemirror/commands";
+import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
 import {
   indentOnInput,
   foldGutter,
@@ -57,7 +53,6 @@ export function startState(controller: TextMode, text: string) {
       analysisStateField,
       EditorView.updateListener.of(controller.onEditorUpdate.bind(controller)),
       // linter, showing errors
-      // The linter is also the entry point to evaluation
       linter(doLint, { delay: 0 }),
       // line numbers and gutter
       stmtNumbers(),
@@ -103,7 +98,6 @@ export function startState(controller: TextMode, text: string) {
         ...foldKeymap,
         // Ctrl+Space to start completion
         ...completionKeymap,
-        indentWithTab,
       ]),
       scrollTheme,
       // syntax highlighting
@@ -111,6 +105,7 @@ export function startState(controller: TextMode, text: string) {
       // Text mode plugins
       checkboxPlugin,
       styleMappingPlugin,
+      footerPlugin(),
     ],
   });
   return state.update(collapseStylesAtStart(state)).state;

--- a/src/plugins/text-mode/view/plugins/StyleCircle.less
+++ b/src/plugins/text-mode/view/plugins/StyleCircle.less
@@ -1,7 +1,13 @@
 .dsm-text-editor-container .cm-editor {
+  .dsm-style-circle {
+    // anchor for the absolute-positioned slider arrows menu opener
+    position: relative;
+  }
+
   .dcg-expression-icon-container {
     position: static;
     margin: 0;
+    font-size: 65%;
   }
 
   .dcg-tooltipped-error.dcg-white {

--- a/src/plugins/text-mode/view/plugins/footerWidget.less
+++ b/src/plugins/text-mode/view/plugins/footerWidget.less
@@ -1,0 +1,54 @@
+.dsm-text-editor-container .cm-editor .dsm-tm-footer-wrapper {
+  // The container is the div.dcg-exppanel-container.dsm-in-text-mode
+  width: calc(100cqw - var(--dsm-tm-gutter-width));
+  padding-inline: 15px;
+
+  // Unset some codemirror stuff;
+  font-family: arial, sans-serif;
+  word-wrap: normal;
+  white-space: normal;
+
+  .dsm-slider {
+    margin-left: 0;
+  }
+
+  .dcg-display-domain {
+    padding: 0 0 4px;
+  }
+
+  .dcg-visualization-parameters-container,
+  .dcg-cdf-footer-container,
+  .dcg-display-domain,
+  .dcg-evaluation-container {
+    // Codemirror block widgets can't have margin
+    margin: 0;
+  }
+
+  .dcg-parameter-suggestion-container {
+    display: none;
+  }
+
+  .dcg-unresolved {
+    font-size: 80%;
+    color: #666;
+    cursor: default;
+
+    i {
+      font-size: 85%;
+    }
+
+    a {
+      color: #666;
+      margin-left: 5px;
+      text-decoration: underline;
+      &.dcg-hovered {
+        color: #000;
+      }
+    }
+
+    .dcg-btn {
+      padding: 2px 5px;
+      margin-top: 4px;
+    }
+  }
+}

--- a/src/plugins/text-mode/view/plugins/footerWidget.ts
+++ b/src/plugins/text-mode/view/plugins/footerWidget.ts
@@ -56,7 +56,13 @@ class FooterWidget extends WidgetType {
   }
 
   eq(other: FooterWidget) {
-    return this.model === other.model;
+    // TODO-incremental: We need to be stricter than this. This should really
+    // be like GUID or full object equality this.model === other.model.
+    // But the GUID gets updated every setState(), and the model objects
+    // are fairly complicated.
+    return (
+      this.model.id === other.model.id && this.model.latex === other.model.latex
+    );
   }
 
   toDOM() {

--- a/src/plugins/text-mode/view/plugins/footerWidget.ts
+++ b/src/plugins/text-mode/view/plugins/footerWidget.ts
@@ -60,9 +60,12 @@ class FooterWidget extends WidgetType {
     // be like GUID or full object equality this.model === other.model.
     // But the GUID gets updated every setState(), and the model objects
     // are fairly complicated.
-    return (
-      this.model.id === other.model.id && this.model.latex === other.model.latex
-    );
+    const a = this.model;
+    const b = other.model;
+    // Comparing a === getItemModel(a.id) overwrites the widget too often.
+    // This is probably not good since it relies on the order of Codemirror
+    // running the eq() call, but it seems to be a=old, b=new.
+    return a.id === b.id && b === Calc.controller.getItemModel(b.id);
   }
 
   toDOM() {

--- a/src/plugins/text-mode/view/plugins/footerWidget.ts
+++ b/src/plugins/text-mode/view/plugins/footerWidget.ts
@@ -1,0 +1,77 @@
+import { analysisStateField } from "../../LanguageServer";
+import { statementsIntersecting } from "../statementIntersection";
+import "./footerWidget.less";
+import { EditorState, RangeSet } from "@codemirror/state";
+import { EditorView, Decoration, WidgetType } from "@codemirror/view";
+import { DCGView } from "DCGView";
+import { FooterView } from "components";
+import { ExpressionModel } from "globals/models";
+import { Calc } from "globals/window";
+
+function getFooters(state: EditorState) {
+  const program = state.field(analysisStateField).program;
+  const decorations = [];
+  const { from, to } = program.pos;
+  for (const stmt of statementsIntersecting(program, from, to)) {
+    const model = Calc.controller.getItemModel(stmt.id);
+    if (model?.type === "expression") {
+      const widget = Decoration.widget({
+        widget: new FooterWidget(model),
+        side: 1,
+        block: true,
+      });
+      decorations.push(widget.range(stmt.pos.to));
+    }
+  }
+  return RangeSet.of(decorations);
+}
+
+export function footerPlugin() {
+  return [
+    EditorView.decorations.compute([analysisStateField], getFooters),
+    EditorView.updateListener.of((view) => {
+      let width = 0;
+      view.state.facet(EditorView.scrollMargins).forEach((x) => {
+        const rect = x(view.view);
+        width += (rect?.left ?? 0) + (rect?.right ?? 0);
+      });
+      const container = document.querySelector(".dsm-text-editor-container");
+      if (!container) return;
+      (container as HTMLElement).style.setProperty(
+        "--dsm-tm-gutter-width",
+        width.toFixed(1) + "px"
+      );
+    }),
+  ];
+}
+
+// Compare to StyleCircleMarker. Similar mount/div handling
+// If a third similar thing appears, consider some shared logic
+class FooterWidget extends WidgetType {
+  unsub: (() => void) | undefined;
+  div: HTMLElement | undefined;
+
+  constructor(readonly model: ExpressionModel) {
+    super();
+  }
+
+  eq(other: FooterWidget) {
+    return this.model === other.model;
+  }
+
+  toDOM() {
+    this.div = document.createElement("div");
+    this.div.classList.add("dsm-tm-footer-wrapper");
+    const view = DCGView.mountToNode(FooterView, this.div, {
+      model: DCGView.const(this.model),
+      controller: DCGView.const(Calc.controller),
+    });
+    this.unsub = Calc.controller.subToChanges(() => view.update());
+    return this.div;
+  }
+
+  destroy() {
+    this.unsub?.();
+    if (this.div) DCGView.unmountFromNode(this.div);
+  }
+}

--- a/src/plugins/text-mode/view/plugins/styleCircles.ts
+++ b/src/plugins/text-mode/view/plugins/styleCircles.ts
@@ -35,6 +35,8 @@ const styleCircleGutter = gutter({
   },
 });
 
+// Compare to StyleCircleMarker. Similar mount/div handling
+// If a third similar thing appears, consider some shared logic
 class StyleCircleMarker extends GutterMarker {
   unsub: (() => void) | undefined;
   div: HTMLElement | undefined;

--- a/src/plugins/text-mode/view/plugins/styleCircles.ts
+++ b/src/plugins/text-mode/view/plugins/styleCircles.ts
@@ -51,6 +51,7 @@ class StyleCircleMarker extends GutterMarker {
 
   toDOM() {
     this.div = document.createElement("div");
+    this.div.classList.add("dsm-style-circle");
     const view = DCGView.mountToNode(StyleCircle, this.div, {
       id: DCGView.const(this.id),
       model: DCGView.const(this.model),

--- a/src/preload/moduleOverrides/text-mode.replacements
+++ b/src/preload/moduleOverrides/text-mode.replacements
@@ -97,19 +97,23 @@ __children__
 "dsm-in-text-mode": DSM.textMode?.inTextMode
 ```
 
-## Extract ExpressionIconView class
+## Extract ExpressionView class
 
-*Description* `Show style circles for Text Mode statements`
+*Description* `Show style circles and expression footers for Text Mode statements`
 
 *Find*
 
 ```js
-$ = "#000", $ = "#fff", $ExpressionIconView = class
+$ExpressionView = class extends $ {
+  didMount() {
+      this.onItemViewMounted(),
+      this.lastBrailleMode = this.controller.getBrailleMode()
+  }
 ```
 
-*Replace* `ExpressionIconView` with
+*Replace* `ExpressionView` with
 ```js
-$ExpressionIconView = (window.DesModderFragile ??= {}).ExpressionIconView
+$ExpressionView = (window.DesModderFragile ??= {}).ExpressionView
 ```
 
 ## Extract ImageIconView class


### PR DESCRIPTION
- Show expression footers in text mode
- Check for relevant event types later
- Avoid dispatch-in-dispatch from setState in Text Mode (unrelated fix)
- Fix style of slider arrows (really a style circles fix)
