### PR TITLE
Distinguish NaN, +∞, -∞ in lists.

### DIFF
--- a/src/preload/moduleOverrides/better-evaluation-view.replacements
+++ b/src/preload/moduleOverrides/better-evaluation-view.replacements
@@ -194,3 +194,38 @@ if ($val === 0) {
   }
 }
 ```
+
+## Distinguish NaN, +∞, -∞ in lists.
+
+*Description* `Distinguish NaN, +∞, -∞ in lists.`
+
+I'm really confused. The match doesn't work without *worker_only*, but the code
+runs on the main page, not the worker.
+
+*worker_only*
+
+*Find* => `truncatedLatexLabelDef`
+```js
+function $truncatedLatexLabel($e, $t) {
+    let $r = $numericLabel($e, $t);
+    switch ($r.type) {
+    case "undefined":
+        return "undefined";
+    case "decimal":
+        return $r.value;
+    case "scientific":
+        return $r.mantissa + "\\times10^{" + $r.exponent + "}";
+```
+
+*Replace* `truncatedLatexLabelDef` with
+```js
+function $truncatedLatexLabel($e, $t) {
+    let $r = $numericLabel($e, $t);
+    switch ($r.type) {
+    case "undefined":
+        return DSM.betterEvaluationView ? $r.value : 'undefined';
+    case "decimal":
+        return $r.value;
+    case "scientific":
+        return $r.mantissa + "\\times10^{" + $r.exponent + "}";
+```


### PR DESCRIPTION
This code was deleted a while ago in mistake (it failed to replace successfully, and I thought it wasn't needed because I didn't check lists).

Props to @FenyLabs for spotting the mistake.