### PR TITLE
Intellisense: Fixed Tab issue + Added to Core Plugins

### DIFF
--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -322,21 +322,20 @@ export default class Intellisense extends PluginController {
           function (key: string, _: KeyboardEvent) {
             if (
               // don't bother overriding keystroke if intellisense is offline
-              !self.canHaveIntellisense
+              !self.canHaveIntellisense ||
+              self.intellisenseOpts.length === 0
             )
               // return nothing to ensure the actual overrideKeystroke runs
               return;
 
             // navigating downward in the intellisense menu
             if (key === "Down") {
-              if (self.intellisenseOpts.length > 0) {
-                self.goToNextIntellisenseCol();
-                self.view?.update();
-                return [false, undefined];
-              }
+              self.goToNextIntellisenseCol();
+              self.view?.update();
+              return [false, undefined];
 
               // navigating upward in the intellisense menu
-            } else if (key === "Up" && self.intellisenseOpts.length > 0) {
+            } else if (key === "Up") {
               self.goToPrevIntellisenseCol();
 
               self.view?.update();
@@ -346,7 +345,6 @@ export default class Intellisense extends PluginController {
               // or jump to def if in row 1
             } else if (
               key === "Enter" &&
-              self.intellisenseIndex >= 0 &&
               self.intellisenseOpts[self.intellisenseIndex] !== undefined
             ) {
               if (self.intellisenseRow === 0) {
@@ -408,7 +406,11 @@ export default class Intellisense extends PluginController {
   keyDownHandler = (e: KeyboardEvent) => {
     this.saveCursorState();
 
-    if (e.key === "Tab" && this.canHaveIntellisense) {
+    if (
+      e.key === "Tab" &&
+      this.canHaveIntellisense &&
+      this.intellisenseOpts.length !== 0
+    ) {
       e.preventDefault();
     }
 

--- a/src/plugins/pillbox-menus/components/Menu.tsx
+++ b/src/plugins/pillbox-menus/components/Menu.tsx
@@ -25,7 +25,13 @@ export function MenuFunc(controller: PillboxMenus) {
 }
 
 const categoryPlugins: Record<string, PluginID[]> = {
-  core: ["builtin-settings", "GLesmos", "video-creator", "text-mode"],
+  core: [
+    "builtin-settings",
+    "GLesmos",
+    "video-creator",
+    "text-mode",
+    "intellisense",
+  ],
   utility: [
     "wolfram2desmos",
     "pin-expressions",


### PR DESCRIPTION
- Intellisense no longer prevents Tab from working when it isn't open.
- Intellisense is now listed in the core plugin list in the settings menu.