### PR TITLE
Move replacement DCGView chunks to Typescript

### DIFF
--- a/src/components/StaticMathQuillView.tsx
+++ b/src/components/StaticMathQuillView.tsx
@@ -5,6 +5,8 @@ export default class StaticMathquillView extends Component<{
   latex: string;
 }> {
   template() {
-    return <DStaticMathquillView latex={this.props.latex()} config={{}} />;
+    return (
+      <DStaticMathquillView latex={() => this.props.latex()} config={{}} />
+    );
   }
 }

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -208,6 +208,7 @@ interface CalcPrivate {
       workerPoolConnection: {
         killWorker: () => void;
       };
+      notifyWhenSynced: (cb: () => void) => void;
     };
     listModel: {
       // add properties as needed
@@ -242,6 +243,8 @@ interface CalcPrivate {
     expressionSearchOpen: boolean;
     /** Returns a function to call to unsubscribe */
     subToChanges: (cb: () => void) => () => void;
+    getBackgroundColor: () => string;
+    isInEditListMode: () => boolean;
   };
   _calc: {
     globalHotkeys: TopLevelComponents;

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -10,14 +10,15 @@ import {
   SegmentedControlComponent,
   TooltipComponent,
 } from "../components/desmosComponents";
-import { GenericSettings, PluginID, TransparentPlugins } from "../plugins";
+import MainController from "../main/Controller";
+import { GenericSettings, PluginID } from "../plugins";
 import CalcType from "./Calc";
 import { ItemModel } from "./models";
 
 export interface DWindow extends Window {
   Calc: CalcType;
   DesModder: any;
-  DSM: TransparentPlugins;
+  DSM: MainController;
   DesModderPreload?: {
     pluginsForceDisabled: Set<PluginID>;
     pluginsEnabled: Record<PluginID, boolean | undefined>;
@@ -30,7 +31,22 @@ export interface DWindow extends Window {
   Desmos: {
     Private: {
       Fragile: typeof Fragile;
+      Mathtools: Mathtools;
     };
+  };
+}
+
+interface Mathtools {
+  Label: {
+    truncatedLatexLabel: (
+      label: string,
+      labelOptions: {
+        smallCutoff: 0.00001;
+        bigCutoff: 1000000;
+        digits: 5;
+        displayAsFraction: false;
+      }
+    ) => string;
   };
 }
 

--- a/src/main/Controller.ts
+++ b/src/main/Controller.ts
@@ -1,3 +1,4 @@
+import { insertElement, replaceElement } from "../preload/replaceElement";
 import window, { Calc } from "globals/window";
 import {
   plugins,
@@ -131,6 +132,17 @@ export default class MainController extends TransparentPlugins {
     }
   }
 
+  /** Tests only */
+  togglePluginsTo(enabled: string[]) {
+    const goalEnabled = new Set(enabled);
+    for (const id of Object.keys(this.enabledPlugins) as PluginID[]) {
+      if (!goalEnabled.has(id)) this.disablePlugin(id);
+    }
+    for (const id of enabled as PluginID[]) {
+      if (!this.isPluginEnabled(id)) this.enablePlugin(id);
+    }
+  }
+
   isPluginEnabled(id: PluginID) {
     return (
       !this.isPluginForceDisabled(id) && (this.pluginsEnabled.get(id) ?? false)
@@ -193,9 +205,17 @@ export default class MainController extends TransparentPlugins {
     value: boolean | string | number,
     temporary: boolean = false
   ) {
+    this.updatePluginSettings(pluginID, { [key]: value }, temporary);
+  }
+
+  private updatePluginSettings(
+    pluginID: PluginID,
+    value: any,
+    temporary: boolean
+  ) {
     const pluginSettings = this.pluginSettings[pluginID];
     if (!pluginSettings) return;
-    pluginSettings[key] = value;
+    Object.assign(pluginSettings, value);
     if (!temporary) this.enqueueSetPluginSettingsMessage();
     const plugin = this.enabledPlugins[pluginID];
     if (plugin) {
@@ -206,6 +226,13 @@ export default class MainController extends TransparentPlugins {
     this.pillboxMenus?.updateMenuView();
   }
 
+  /** Tests only */
+  setAllPluginSettings(settings: IDToPluginSettings) {
+    for (const [key, value] of Object.entries(settings)) {
+      this.updatePluginSettings(key as PluginID, value, false);
+    }
+  }
+
   commitStateChange(allowUndo: boolean) {
     Calc.controller.updateTheComputedWorld();
     if (allowUndo) {
@@ -213,6 +240,9 @@ export default class MainController extends TransparentPlugins {
     }
     Calc.controller.updateViews();
   }
+
+  insertElement = insertElement;
+  replaceElement = replaceElement;
 }
 
 function getDefaultConfig(id: PluginID) {

--- a/src/plugins/GLesmos/components/ConfirmLines.tsx
+++ b/src/plugins/GLesmos/components/ConfirmLines.tsx
@@ -1,0 +1,28 @@
+import GLesmos from "..";
+import { jsx } from "DCGView";
+import { If } from "components";
+import { format } from "i18n/i18n-core";
+
+export function ConfirmLines(glesmos: GLesmos, id: string, ToggleView: any) {
+  return (
+    <If predicate={() => glesmos.isGlesmosMode(id) && glesmos.isInequality(id)}>
+      {() => (
+        <div class="dcg-options-menu-section-title dsm-gl-lines-confirm">
+          {() => format("GLesmos-confirm-lines")}
+          <ToggleView
+            ariaLabel={() => format("GLesmos-confirm-lines")}
+            toggled={() => glesmos.isGLesmosLinesConfirmed(id)}
+            onChange={() => glesmos.toggleGLesmosLinesConfirmed(id)}
+          />
+          <If predicate={() => !glesmos.isGLesmosLinesConfirmed(id)}>
+            {() => (
+              <div class="dsm-gl-lines-confirm-body">
+                {() => format("GLesmos-confirm-lines-body")}
+              </div>
+            )}
+          </If>
+        </div>
+      )}
+    </If>
+  );
+}

--- a/src/plugins/GLesmos/components/GLesmosToggle.tsx
+++ b/src/plugins/GLesmos/components/GLesmosToggle.tsx
@@ -1,0 +1,31 @@
+import GLesmos from "..";
+import { jsx } from "DCGView";
+import { If } from "components";
+import { format } from "i18n/i18n-core";
+
+export function GLesmosToggle(
+  glesmos: GLesmos,
+  id: string,
+  ToggleView: any,
+  allowInequality: boolean
+) {
+  return (
+    <If
+      predicate={() =>
+        glesmos.canBeGLesmos(id) &&
+        (allowInequality || !glesmos.isInequality(id))
+      }
+    >
+      {() => (
+        <div class="dcg-options-menu-section-title dsm-gl-fill-title">
+          {() => format("GLesmos-label-toggle-glesmos")}
+          <ToggleView
+            ariaLabel={() => format("GLesmos-label-toggle-glesmos")}
+            toggled={() => glesmos.isGlesmosMode(id)}
+            onChange={() => glesmos.toggleGlesmos(id)}
+          />
+        </div>
+      )}
+    </If>
+  );
+}

--- a/src/plugins/GLesmos/index.ts
+++ b/src/plugins/GLesmos/index.ts
@@ -1,4 +1,6 @@
-import { PluginController } from "../PluginController";
+import { Inserter, PluginController } from "../PluginController";
+import { ConfirmLines } from "./components/ConfirmLines";
+import { GLesmosToggle } from "./components/GLesmosToggle";
 import "./glesmos.less";
 import { Calc } from "globals/window";
 
@@ -91,6 +93,18 @@ export default class GLesmos extends PluginController {
       type: "toggle-item-hidden",
       id,
     });
+  }
+
+  confirmLines(id: string, ToggleView: any): Inserter {
+    return () => ConfirmLines(this, id, ToggleView);
+  }
+
+  glesmosToggle(
+    id: string,
+    ToggleView: any,
+    allowInequality: boolean
+  ): Inserter {
+    return () => GLesmosToggle(this, id, ToggleView, allowInequality);
   }
 }
 

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -15,3 +15,6 @@ export class PluginController<
   beforeDisable() {}
   afterDisable() {}
 }
+
+export type Replacer<T = any> = undefined | ((old: T) => any);
+export type Inserter = undefined | (() => any);

--- a/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
@@ -1,0 +1,77 @@
+import { Driver, clean, testWithPage } from "tests/puppeteer-utils";
+
+async function expectEval(driver: Driver, latexExpected: string) {
+  const latexFound = await driver.$eval(
+    ".dcg-evaluation-html .dcg-mq-root-block",
+    (el) => (el as any).mqBlockNode.latex()
+  );
+  expect(latexFound).toBe(latexExpected);
+}
+
+async function expectEvalPlain(driver: Driver, textExpected: string) {
+  const textFound = await driver.$eval(
+    ".dcg-evaluation-html",
+    (el) => (el as HTMLElement).innerText
+  );
+  expect(textFound).toBe(textExpected);
+}
+
+const COLOR_SWATCH = ".dcg-color-swatch";
+
+testWithPage("List", async (driver) => {
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("[1,2,3]");
+  await expectEval(driver, "\\left[1,2,3\\right]");
+
+  // It updates when you edit the latex
+  await driver.setLatexAndSync("[1,2,3,4]");
+  await expectEval(driver, "\\left[1,2,3,4\\right]");
+
+  // It gets reset on disabling lists
+  await driver.setPluginSetting("better-evaluation-view", "lists", false);
+  await expectEvalPlain(driver, "4 element list");
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});
+
+testWithPage("Color", async (driver) => {
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("C=\\operatorname{rgb}\\left(1,2,3\\right)");
+  const exp = "\\operatorname{rgb}\\left(1,2,3\\right)";
+  await expectEval(driver, exp);
+
+  // It doesn't get reset on disabling color lists
+  await driver.setPluginSetting("better-evaluation-view", "colorLists", false);
+  await expectEval(driver, exp);
+
+  // It gets reset on disabling colors
+  await driver.setPluginSetting("better-evaluation-view", "colors", false);
+  await driver.assertSelector(COLOR_SWATCH);
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});
+
+testWithPage("Color List", async (driver) => {
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("C=\\operatorname{rgb}\\left(1,2,[3,4]\\right)");
+  const exp =
+    "\\operatorname{rgb}\\left(\\left[\\left(1,2,3\\right),\\left(1,2,4\\right)\\right]\\right)";
+  await expectEval(driver, exp);
+
+  // It gets reset on disabling color lists
+  await driver.setPluginSetting("better-evaluation-view", "colorLists", false);
+  await driver.assertSelector(COLOR_SWATCH);
+
+  // It gets reset on disabling colors
+  await driver.setPluginSetting("better-evaluation-view", "colorLists", true);
+  await driver.setPluginSetting("better-evaluation-view", "colors", false);
+  await driver.assertSelector(COLOR_SWATCH);
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});

--- a/src/plugins/better-evaluation-view/components/ColorEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ColorEvaluation.tsx
@@ -1,0 +1,42 @@
+import { jsx } from "DCGView";
+import { StaticMathQuillView } from "components";
+
+export function ColorEvaluation(val: () => string | string[]) {
+  return (
+    <StaticMathQuillView
+      latex={() => {
+        const value = val();
+        const length = 6;
+        if (Array.isArray(value)) {
+          const color = value.map(rgb);
+          return (
+            "\\operatorname{rgb}\\left(\\left[" +
+            color
+              .slice(0, length)
+              .map((clist) => `\\left(${clist.join(",")}\\right)`)
+              .join(",") +
+            (color.length > length
+              ? `\\textcolor{gray}{...\\mathit{${
+                  color.length - length
+                }\\ more}}`
+              : "") +
+            "\\right]\\right)"
+          );
+        } else {
+          const color = rgb(value);
+          return "\\operatorname{rgb}\\left(" + color.join(",") + "\\right)";
+        }
+      }}
+    />
+  );
+}
+
+// https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
+function rgb(hex: string) {
+  const result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)!;
+  return [
+    parseInt(result[1], 16),
+    parseInt(result[2], 16),
+    parseInt(result[3], 16),
+  ];
+}

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -1,0 +1,31 @@
+import { truncatedLatexLabel } from "../../../utils/depUtils";
+import { jsx } from "DCGView";
+import { StaticMathQuillView } from "components";
+
+export function ListEvaluation(val: () => string[]) {
+  return (
+    <StaticMathQuillView
+      latex={() => {
+        const values = val();
+        const labelOptions = {
+          smallCutoff: 0.00001,
+          bigCutoff: 1000000,
+          digits: 5,
+          displayAsFraction: false,
+        };
+        const length = 20;
+        const labels = values
+          .slice(0, length)
+          .map((label) => truncatedLatexLabel(label, labelOptions));
+        return (
+          "\\left[" +
+          labels.join(",") +
+          (values.length > length
+            ? `\\textcolor{gray}{...\\mathit{${values.length - length}\\ more}}`
+            : "") +
+          "\\right]"
+        );
+      }}
+    />
+  );
+}

--- a/src/plugins/better-evaluation-view/config.ts
+++ b/src/plugins/better-evaluation-view/config.ts
@@ -22,4 +22,5 @@ export const configList: ConfigItem[] = [
 export interface Config {
   lists: boolean;
   colors: boolean;
+  colorLists: boolean;
 }

--- a/src/plugins/better-evaluation-view/index.ts
+++ b/src/plugins/better-evaluation-view/index.ts
@@ -1,9 +1,24 @@
-import { PluginController } from "../PluginController";
+import { Inserter, PluginController } from "../PluginController";
 import "./better-evaluation-view.less";
+import { ColorEvaluation } from "./components/ColorEvaluation";
+import { ListEvaluation } from "./components/ListEvaluation";
 import { Config, configList } from "./config";
 
 export default class BetterEvaluationView extends PluginController<Config> {
   static id = "better-evaluation-view" as const;
   static enabledByDefault = true;
   static config = configList;
+
+  listEvaluation(val: () => string[]): Inserter {
+    if (!this.settings.lists) return undefined;
+    return () => ListEvaluation(val);
+  }
+
+  colorEvaluation(val: () => string | string[]): Inserter {
+    const settings = this.settings;
+    if (!settings.colors) return undefined;
+    const isArray = Array.isArray(val());
+    if (isArray && !(settings.lists && settings.colorLists)) return undefined;
+    return () => ColorEvaluation(val);
+  }
 }

--- a/src/plugins/find-replace/find-replace.int.test.ts
+++ b/src/plugins/find-replace/find-replace.int.test.ts
@@ -4,7 +4,7 @@ describe("Find-replace", () => {
   testWithPage("Basic find-replace", async (driver) => {
     // Init an expression
     await driver.focusIndex(0);
-    await driver.setLatex("a+b+a");
+    await driver.setLatexAndSync("a+b+a");
     const latex = ((await driver.getState()).expressions.list[0] as any).latex;
     expect(latex).toBe("a+b+a");
 

--- a/src/plugins/hide-errors/components/ErrorTriangle.less
+++ b/src/plugins/hide-errors/components/ErrorTriangle.less
@@ -1,0 +1,3 @@
+.dsm-he-error-hidden {
+  opacity: 0.5;
+}

--- a/src/plugins/hide-errors/components/ErrorTriangle.tsx
+++ b/src/plugins/hide-errors/components/ErrorTriangle.tsx
@@ -1,0 +1,18 @@
+import HideErrors from "..";
+import "./ErrorTriangle.less";
+import { jsx } from "DCGView";
+
+export function ErrorTriangle(hideErrors: HideErrors, id: string, inner: any) {
+  return (
+    <div
+      onTap={(event: MouseEvent) =>
+        event.shiftKey && hideErrors?.toggleErrorHidden(id)
+      }
+      class={() => ({
+        "dsm-he-error-hidden": hideErrors.isErrorHidden(id),
+      })}
+    >
+      {inner}
+    </div>
+  );
+}

--- a/src/plugins/hide-errors/components/HideButton.tsx
+++ b/src/plugins/hide-errors/components/HideButton.tsx
@@ -1,0 +1,26 @@
+import HideErrors from "..";
+import { jsx } from "DCGView";
+import { If } from "components";
+import { format } from "i18n/i18n-core";
+
+export function HideButton(hideErrors: HideErrors, getModel: () => any) {
+  return (
+    <If predicate={() => getModel().type !== "ticker"}>
+      {() => (
+        <div class="dcg-slider-btn-container dsm-hide-errors">
+          <div
+            role="button"
+            tabindex="0"
+            class="dcg-btn-slider dcg-btn-light-gray"
+            onTap={(e: Event) => {
+              hideErrors.hideError(getModel().id);
+              e.stopPropagation();
+            }}
+          >
+            {() => format("hide-errors-hide")}
+          </div>
+        </div>
+      )}
+    </If>
+  );
+}

--- a/src/plugins/hide-errors/hide-errors.int.test.ts
+++ b/src/plugins/hide-errors/hide-errors.int.test.ts
@@ -1,0 +1,55 @@
+import { Driver, clean, testWithPage } from "tests/puppeteer-utils";
+
+const ERROR = ".dcg-icon-error";
+const ERROR_HIDDEN = ".dsm-he-error-hidden";
+const CREATE = ".dcg-create-sliders";
+
+async function errorHidden(driver: Driver) {
+  await driver.assertSelector(ERROR);
+  await driver.assertSelectorNot(CREATE);
+  await driver.assertSelector(ERROR_HIDDEN);
+}
+
+async function errorHiddenNot(driver: Driver) {
+  await driver.assertSelector(ERROR);
+  await driver.assertSelector(CREATE);
+  await driver.assertSelectorNot(ERROR_HIDDEN);
+}
+
+testWithPage("Hide button hides errors", async (driver) => {
+  // Simple error shown
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("asdf");
+  await errorHiddenNot(driver);
+
+  // Hide error by pressing "hide"
+  await driver.click(".dsm-hide-errors [ontap]");
+  await errorHidden(driver);
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});
+
+testWithPage("Shift-click hides errors", async (driver) => {
+  // Simple error shown
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("asdf");
+  await errorHiddenNot(driver);
+
+  // Hide error by shift-clicking error triangle
+  await driver.keyboard.down("Shift");
+  await driver.click(ERROR);
+  await driver.keyboard.up("Shift");
+  await errorHidden(driver);
+
+  // Re-show error by shift-clicking error triangle
+  await driver.keyboard.down("Shift");
+  await driver.click(ERROR);
+  await driver.keyboard.up("Shift");
+  await errorHiddenNot(driver);
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});

--- a/src/plugins/hide-errors/index.ts
+++ b/src/plugins/hide-errors/index.ts
@@ -1,5 +1,7 @@
 import { Fragile } from "../../globals/window";
-import { PluginController } from "../PluginController";
+import { Inserter, PluginController, Replacer } from "../PluginController";
+import { ErrorTriangle } from "./components/ErrorTriangle";
+import { HideButton } from "./components/HideButton";
 import "./hide-errors.less";
 
 let enabled: boolean = false;
@@ -60,5 +62,13 @@ export default class HideErrors extends PluginController {
 
   isErrorHidden(id: string) {
     return this.controller.metadata?.getDsmItemModel(id)?.errorHidden;
+  }
+
+  hideButton(getModel: () => any): Inserter {
+    return () => HideButton(this, getModel);
+  }
+
+  errorTriangle(id: string): Replacer {
+    return (inner: any) => ErrorTriangle(this, id, inner);
   }
 }

--- a/src/plugins/performance-info/index.ts
+++ b/src/plugins/performance-info/index.ts
@@ -33,7 +33,7 @@ export default class PerformanceInfo extends PluginController {
     if (e.type !== "on-evaluator-changes") return;
     this.timingDataHistory?.push(e.timingData);
     if (this.timingDataHistory.length > 10) this.timingDataHistory.shift();
-    this.controller.pillboxMenus?.updateExtraComponents();
+    Calc.controller.updateViews();
   }
 
   getTimingData() {

--- a/src/plugins/pillbox-menus/components/PillboxContainer.tsx
+++ b/src/plugins/pillbox-menus/components/PillboxContainer.tsx
@@ -74,9 +74,9 @@ export default class PillboxContainer extends Component<{
             )}
           </div>
         </For>
-        <If predicate={() => this.controller.pillboxMenuOpen !== null}>
-          {() => this.controller.pillboxMenuView(false)}
-        </If>
+        {this.controller.controller.insertElement(() =>
+          this.controller.pillboxMenuView(false)
+        )}
       </div>
     );
   }

--- a/src/plugins/pillbox-menus/index.ts
+++ b/src/plugins/pillbox-menus/index.ts
@@ -1,8 +1,8 @@
-import { PluginController } from "../PluginController";
+import { Inserter, PluginController } from "../PluginController";
 import { MenuFunc } from "./components/Menu";
 import PillboxContainer from "./components/PillboxContainer";
 import PillboxMenu from "./components/PillboxMenu";
-import { DCGView, MountedComponent } from "DCGView";
+import { DCGView } from "DCGView";
 import { Calc } from "globals/window";
 import { plugins, PluginID, ConfigItem } from "plugins";
 
@@ -36,7 +36,6 @@ export default class PillboxMenus extends PluginController<undefined> {
   // string if open, null if none are open
   pillboxMenuOpen: string | null = null;
   pillboxMenuPinned: boolean = false;
-  extraMountedComponents = new Map<HTMLElement, MountedComponent>();
 
   beforeDisable() {
     throw new Error(
@@ -44,37 +43,24 @@ export default class PillboxMenus extends PluginController<undefined> {
     );
   }
 
-  pillboxButtonsView(horizontal: boolean) {
-    return DCGView.createElement(PillboxContainer as any, {
-      controller: () => this,
-      horizontal: DCGView.const(horizontal),
-    });
+  pillboxButtonsView(horizontal: boolean): Inserter {
+    return () =>
+      DCGView.createElement(PillboxContainer as any, {
+        controller: () => this,
+        horizontal: DCGView.const(horizontal),
+      });
   }
 
-  pillboxMenuView(horizontal: boolean) {
-    return DCGView.createElement("div", {
-      didMount: (div: HTMLElement) => {
-        this.extraMountedComponents.set(
-          div,
-          DCGView.mountToNode(PillboxMenu, div, {
-            controller: () => this,
-            horizontal: DCGView.const(horizontal),
-          })
-        );
-      },
-      willUnmount: (div: HTMLElement) => {
-        this.extraMountedComponents.delete(div);
-        DCGView.unmountFromNode(div);
-      },
-    });
-  }
-
-  updateExtraComponents() {
-    this.extraMountedComponents.forEach((view) => view.update());
+  pillboxMenuView(horizontal: boolean): Inserter {
+    if (this.pillboxMenuOpen === null) return undefined;
+    return () =>
+      DCGView.createElement(PillboxMenu as any, {
+        controller: () => this,
+        horizontal: DCGView.const(horizontal),
+      });
   }
 
   updateMenuView() {
-    this.updateExtraComponents();
     Calc.controller.updateViews();
   }
 

--- a/src/plugins/pin-expressions/components/PinnedPanel.tsx
+++ b/src/plugins/pin-expressions/components/PinnedPanel.tsx
@@ -1,0 +1,40 @@
+import PinExpressions from "..";
+import { jsx } from "DCGView";
+import { For, If } from "components";
+import { ItemModel } from "globals/models";
+import { Calc } from "globals/window";
+
+export interface ListView {
+  makeDragCopyViewForModel: (model: ItemModel) => void;
+}
+
+export function PinnedPanel(
+  pinExpressions: PinExpressions,
+  listView: ListView
+) {
+  return (
+    <For
+      each={() =>
+        pinExpressions.controller.textMode?.inTextMode
+          ? []
+          : Calc.controller?.getAllItemModels?.() ?? []
+      }
+      key={(model) => (model as any).guid}
+    >
+      <div
+        class="dsm-pinned-expressions dcg-exppanel"
+        style={() => ({ background: Calc.controller.getBackgroundColor() })}
+      >
+        {(model: any) => (
+          <If predicate={() => pinExpressions?.isExpressionPinned(model.id)}>
+            {/** marking as a drag copy causes it not to affect the render shells
+             * calculations (all the logic is present already because if the top
+             * expression is dragged to the bottom, it shouldn't cause all
+             * expressions to render from the top) */}
+            {() => listView.makeDragCopyViewForModel(model)}
+          </If>
+        )}
+      </div>
+    </For>
+  );
+}

--- a/src/plugins/pin-expressions/index.ts
+++ b/src/plugins/pin-expressions/index.ts
@@ -1,4 +1,5 @@
-import { PluginController } from "../PluginController";
+import { Inserter, PluginController } from "../PluginController";
+import { ListView, PinnedPanel } from "./components/PinnedPanel";
 import "./pinExpressions.less";
 import { Calc } from "globals/window";
 
@@ -33,5 +34,9 @@ export default class PinExpressions extends PluginController {
       ?.getDsmItemModels()
       .some((v) => v.pinned);
     el?.classList.toggle("dsm-has-pinned-expressions", hasPinnedExpressions);
+  }
+
+  pinnedPanel(listView: ListView): Inserter {
+    return () => PinnedPanel(this, listView);
   }
 }

--- a/src/plugins/pin-expressions/pin-expressions.int.test.ts
+++ b/src/plugins/pin-expressions/pin-expressions.int.test.ts
@@ -1,0 +1,20 @@
+import { clean, testWithPage } from "tests/puppeteer-utils";
+
+testWithPage("Pin", async (driver) => {
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("abc");
+  await driver.assertSelectorNot(".dsm-pinned-expressions [expr-id]");
+
+  // Pin expression
+  await driver.enterEditListMode();
+  await driver.click(".dsm-pin-button");
+  await driver.assertSelector(".dsm-pinned-expressions [expr-id='1']");
+
+  // Unpin expression
+  await driver.click(".dsm-unpin-button");
+  await driver.assertSelectorNot(".dsm-pinned-expressions [expr-id]");
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});

--- a/src/plugins/show-tips/Tip.tsx
+++ b/src/plugins/show-tips/Tip.tsx
@@ -41,7 +41,3 @@ export default class Tip extends Component {
     Calc.controller.updateViews();
   }
 }
-
-export function createTipElement() {
-  return <Tip></Tip>;
-}

--- a/src/plugins/show-tips/index.ts
+++ b/src/plugins/show-tips/index.ts
@@ -1,5 +1,6 @@
-import { PluginController } from "../PluginController";
-import { createTipElement } from "./Tip";
+import { DCGView } from "../../DCGView";
+import { Inserter, PluginController } from "../PluginController";
+import Tip from "./Tip";
 
 function apiContainer() {
   return document.querySelector(".dcg-calculator-api-container");
@@ -17,7 +18,7 @@ export default class ShowTips extends PluginController {
     apiContainer()?.classList.remove("dsm-show-tips");
   }
 
-  createTipElement() {
-    return createTipElement();
+  tipView(): Inserter {
+    return () => DCGView.createElement(Tip as any, {});
   }
 }

--- a/src/plugins/text-mode/components/TextModeToggle.tsx
+++ b/src/plugins/text-mode/components/TextModeToggle.tsx
@@ -1,0 +1,24 @@
+import TextMode from "..";
+import { format } from "../../../i18n/i18n-core";
+import { jsx } from "DCGView";
+import { Tooltip } from "components";
+import { Calc } from "globals/window";
+
+export function TextModeToggle(textMode: TextMode) {
+  return (
+    <Tooltip
+      tooltip={() => format("text-mode-toggle")}
+      gravity={() => (Calc.controller.isNarrow() ? "n" : "s")}
+    >
+      <span
+        class="dcg-icon-btn dsm-text-mode-toggle"
+        handleEvent="true"
+        role="button"
+        tabindex="0"
+        onTap={() => textMode.toggleTextMode()}
+      >
+        <i class="dcg-icon-title" />
+      </span>
+    </Tooltip>
+  );
+}

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -1,5 +1,7 @@
-import { PluginController } from "../PluginController";
+import { DCGView } from "../../DCGView";
+import { Inserter, PluginController } from "../PluginController";
 import { onCalcEvent, analysisStateField } from "./LanguageServer";
+import { TextModeToggle } from "./components/TextModeToggle";
 import getText from "./up/getText";
 import { initView, startState } from "./view/editor";
 import { EditorView, ViewUpdate } from "@codemirror/view";
@@ -58,6 +60,21 @@ export default class TextMode extends PluginController {
         if (this.view) onCalcEvent(this.view, event);
       });
     });
+  }
+
+  editorPanel(): Inserter {
+    if (!this.inTextMode) return undefined;
+    return () =>
+      DCGView.createElement("div", {
+        class: DCGView.const("dsm-text-editor-container"),
+        didMount: (div) => this.mountEditor(div),
+        willUnmount: () => this.unmountEditor(),
+      });
+  }
+
+  textModeToggle(): Inserter {
+    if (Calc.controller.isInEditListMode()) return undefined;
+    return () => TextModeToggle(this);
   }
 
   onSetState() {

--- a/src/plugins/text-mode/text-mode.int.test.ts
+++ b/src/plugins/text-mode/text-mode.int.test.ts
@@ -1,0 +1,21 @@
+import { clean, testWithPage } from "tests/puppeteer-utils";
+
+const TOGGLE = ".dsm-text-mode-toggle";
+const EDITOR = ".cm-editor";
+
+testWithPage("Text Mode Panel", async (driver) => {
+  // Toggle button does not appear at start
+  await driver.assertSelectorNot(TOGGLE);
+  await driver.enablePlugin("text-mode");
+
+  // Panel gets toggled
+  await driver.assertSelectorNot(EDITOR);
+  await driver.click(TOGGLE);
+  await driver.assertSelector(EDITOR);
+  await driver.click(TOGGLE);
+  await driver.assertSelectorNot(EDITOR);
+
+  // Clean up
+  await driver.clean();
+  return clean;
+});

--- a/src/plugins/video-creator/View.ts
+++ b/src/plugins/video-creator/View.ts
@@ -48,5 +48,5 @@ function applyCaptureFrame(controller: VideoCreator) {
 
 export function updateView(vc: VideoCreator) {
   applyCaptureFrame(vc);
-  vc.controller.pillboxMenus?.updateExtraComponents();
+  Calc.controller.updateViews();
 }

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -172,9 +172,9 @@ function forceReloadMenu(controller: MainController) {
   if (!pm) return;
   if (pm.pillboxMenuOpen === "dsm-vc-menu") {
     pm.pillboxMenuOpen = null;
-    pm.updateExtraComponents();
+    Calc.controller.updateViews();
     pm.pillboxMenuOpen = "dsm-vc-menu";
-    pm.updateExtraComponents();
+    Calc.controller.updateViews();
   }
 }
 

--- a/src/preload/moduleOverrides/better-evaluation-view.replacements
+++ b/src/preload/moduleOverrides/better-evaluation-view.replacements
@@ -56,30 +56,10 @@ list: () => $.createElement(__oldList__)
 *Replace* `list` with
 ```js
 ()=>this.getEvaluationType(), {
-list: () => $Dcgview.Components.IfElse(
-    () => DSM.betterEvaluationView?.settings.lists,
-    {
-      true: () => $Dcgview.createElement(
-        $StaticMathquillViewDefault,
-        {
-          latex: () => {
-            let values = this.props.val()
-            let labelOptions = {
-              smallCutoff: 0.00001,
-              bigCutoff: 1000000,
-              digits: 5,
-              displayAsFraction: false
-            }
-            let length = 20
-            let labels = values.slice(0,length).map(label => Desmos.Private.Mathtools.Label.truncatedLatexLabel(label, labelOptions))
-            return "\\left[" + labels.join(",") + (values.length > length ? `\\textcolor{gray}{...\\mathit{${values.length - length}\\ more}}` : "") + "\\right]"
-          },
-          config: $Dcgview.const({})
-        }
-      ),
-      false: () => $Dcgview.createElement(__oldList__)
-    }
-  )
+list: () => DSM.replaceElement(
+  () => $Dcgview.createElement(__oldList__),
+  () => DSM.betterEvaluationView?.listEvaluation(() => this.props.val())
+)
 ```
 
 Show color values
@@ -90,51 +70,10 @@ rgbcolor: () => $.createElement(__swatch__)
 
 *Replace* `color` with
 ```js
-rgbcolor: () => $Dcgview.createElement(
-    "div",
-    {
-      class: $Dcgview.const("dsm-color-container")
-    },
-    $Dcgview.createElement(
-      $Dcgview.Components.If,
-      {
-        predicate: () => {
-          let isEnabled = DSM.betterEvaluationView
-          let pluginSettings = DSM.betterEvaluationView?.settings
-          let isArray = Array.isArray(this.props.val())
-          return isEnabled && pluginSettings.colors && (!isArray || pluginSettings.lists && pluginSettings.colorLists)
-        }
-      },
-      () => $Dcgview.createElement(
-        $StaticMathquillViewDefault,
-        {
-          latex: () => {
-            // allow-ids: rgb, hex
-            let color = this.props.val()
-            // https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb
-            function rgb(hex) {
-              let result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
-              return [
-                parseInt(result[1], 16),
-                parseInt(result[2], 16),
-                parseInt(result[3], 16)
-              ]
-            }
-            let length = 6
-            if (Array.isArray(color)) {
-              color = color.map(rgb)
-              return "\\operatorname{rgb}\\left(\\left[" + color.slice(0,length).map(clist=>`\\left(${clist.join(",")}\\right)`).join(",") + (color.length > length ? `\\textcolor{gray}{...\\mathit{${color.length - length}\\ more}}` : "") + "\\right]\\right)"
-            } else {
-              color = rgb(color)
-              return "\\operatorname{rgb}\\left(" + color.join(",") + "\\right)"
-            }
-          },
-          config: $Dcgview.const({})
-        }
-      )
-    ),
-    $Dcgview.createElement(__swatch__)
-  )
+rgbcolor: () => DSM.replaceElement(
+  () => $Dcgview.createElement(__swatch__),
+  () => DSM.betterEvaluationView?.colorEvaluation(() => this.props.val())
+)
 ```
 
 ## Return more info from numericLabels

--- a/src/preload/moduleOverrides/glesmos.replacements
+++ b/src/preload/moduleOverrides/glesmos.replacements
@@ -49,22 +49,7 @@ Just add one more child.
 *Replace* `__rest__` with
 ```js
 __rest__,
-$DCGView.createElement(
-  $DCGView.Components.If,
-  {
-    predicate: () => DSM.glesmos?.canBeGLesmos(this.id),
-  },
-  () => $DCGView.createElement(
-    "div",
-    { class: $DCGView.const("dcg-options-menu-section-title dsm-gl-fill-title") },
-    () => DesModder.format("GLesmos-label-toggle-glesmos"),
-    $DCGView.createElement($ToggleView, {
-      ariaLabel: () => DesModder.format("GLesmos-label-toggle-glesmos"),
-      toggled: () => DSM.glesmos?.isGlesmosMode?.(this.id),
-      onChange: () => DSM.glesmos?.toggleGlesmos?.(this.id),
-    })
-  )
-)
+DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.id, $ToggleView, true))
 ```
 
 ## Add a lines menu option for switching an expression to glesmos rendering mode
@@ -100,23 +85,7 @@ Just add one more child.
 *Replace* `__rest__` with
 ```js
 __rest__,
-$DCGView.createElement(
-  $DCGView.Components.If,
-  {
-    predicate: () => DSM.glesmos?.canBeGLesmos(this.id) &&
-      !DSM.glesmos?.isInequality(this.id)
-  },
-  () => $DCGView.createElement(
-    "div",
-    { class: $DCGView.const("dcg-options-menu-section-title dsm-gl-fill-title") },
-    () => DesModder.format("GLesmos-label-toggle-glesmos"),
-    $DCGView.createElement($ToggleView, {
-      ariaLabel: () => DesModder.format("GLesmos-label-toggle-glesmos"),
-      toggled: () => DSM.glesmos?.isGlesmosMode?.(this.id),
-      onChange: () => DSM.glesmos?.toggleGlesmos?.(this.id),
-    })
-  )
-)
+DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.id, $ToggleView, false))
 ```
 
 ## Add a lines menu option for confirming GLesmos lines
@@ -145,34 +114,7 @@ Prefix with a child
 
 *Replace* `options` with
 ```js
-$DCGView.createElement(
-  $DCGView.Components.If,
-  {
-    predicate: () =>
-      DSM.glesmos?.isGlesmosMode(this.id) &&
-      DSM.glesmos?.isInequality(this.id),
-  },
-  () => $DCGView.createElement(
-    "div",
-    { class: $DCGView.const("dcg-options-menu-section-title dsm-gl-lines-confirm") },
-    () => DesModder.format("GLesmos-confirm-lines"),
-    $DCGView.createElement($ToggleView, {
-      ariaLabel: () => DesModder.format("GLesmos-confirm-lines"),
-      toggled: () => DSM.glesmos?.isGLesmosLinesConfirmed?.(this.id),
-      onChange: () => DSM.glesmos?.toggleGLesmosLinesConfirmed?.(this.id),
-    }),
-    $DCGView.createElement(
-      $DCGView.Components.If,
-      {
-        predicate: () => !DSM.glesmos?.isGLesmosLinesConfirmed?.(this.id)
-      },
-      () => $DCGView.createElement("div",
-        { class: $DCGView.const("dsm-gl-lines-confirm-body") },
-        () => DesModder.format("GLesmos-confirm-lines-body")
-      )
-    )
-  )
-),
+DSM.insertElement(() => DSM.glesmos?.confirmLines(this.id, $ToggleView)),
 __options__
 ```
 

--- a/src/preload/moduleOverrides/hide-errors.replacements
+++ b/src/preload/moduleOverrides/hide-errors.replacements
@@ -44,42 +44,13 @@ $this.bindFn($this.getIconMode)
 
 *Replace* `from` with
 ```js
-error: () => $DCGView.createElement(
-  "div",
-  {
-    onTap: event => (
-      event.shiftKey &&
-      DSM.hideErrors?.toggleErrorHidden($this.model.id)
-    ),
-    style: () => (
-      DSM.hideErrors?.isErrorHidden($this.model.id)
-        ? "opacity: 0.5"
-        : ""
-    )
-  },
-  $DCGView.createElement($TooltippedError, {
-    error: $e.bindFn($e.getErrorMsg),
-    __opts__
-  })
+error: () => DSM.replaceElement(
+  () => $DCGView.createElement($TooltippedError, {
+      error: $e.bindFn($e.getErrorMsg),
+      __opts__,
+    }),
+  () => DSM.hideErrors?.errorTriangle($this.model.id)
 )
-```
-
-## Trigger DesModder hide instead of `create-sliders-for-item` on tap
-
-*Description* `Run correct code when "hide" button is clicked`
-
-*Find* => `from`
-```js
-let $r = $e.hasClass('dcg-all')
-```
-
-*Replace* `from` with
-```js
-if ($e.hasClass("dsm-hide-errors")) {
-  DSM.hideErrors?.hideError(this.model.id)
-  return;
-}
-__from__
 ```
 
 ## Add a "hide" button to the slider prompts
@@ -100,30 +71,7 @@ Add one more child for the hide button
 *Replace* `children` with
 ```js
 __children__,
-$DCGView.createElement(
-  $DCGView.Components.If,
-  {
-    predicate: () => (
-      this.model.type !== "ticker" &&
-      DSM.hideErrors
-    ),
-  },
-  () => $DCGView.createElement(
-    "div",
-    {
-      class: $DCGView.const("dcg-slider-btn-container dsm-hide-errors")
-    },
-    $DCGView.createElement(
-      "div",
-      {
-        role: $DCGView.const("button"),
-        tabindex: $DCGView.const("0"),
-        class: $DCGView.const("dcg-btn-slider dcg-btn-light-gray")
-      },
-      () => window.DesModder.format("hide-errors-hide")
-    )
-  )
-)
+DSM.insertElement(() => DSM.hideErrors?.hideButton(() => this.model))
 ```
 
 ## Disable slider creation prompt if error is hidden

--- a/src/preload/moduleOverrides/insert-panels.replacements
+++ b/src/preload/moduleOverrides/insert-panels.replacements
@@ -24,49 +24,6 @@ $DCGView.createElement(
 *Replace* `children` with
 ```js
 __children__,
-// pinned expressions
-$DCGView.createElement(
-  $DCGView.Components.For,
-  {
-    each: () => DSM.textMode?.inTextMode
-        ? [] 
-        : this.controller?.getAllItemModels?.() ?? [],
-    key: model => model.guid
-  },
-  $DCGView.createElement(
-    "div",
-    {
-      class: $DCGView.const("dsm-pinned-expressions dcg-exppanel"),
-      style: () => ({
-        background: this.controller.getBackgroundColor()
-      })
-    },
-    model => $DCGView.createElement(
-        $DCGView.Components.If,
-        {
-          predicate: () => DSM.pinExpressions?.isExpressionPinned(model.id)
-        },
-        // marking as a drag copy causes it not to affect the render shells calcuations
-        // (all the logic is present already because if the top expression is dragged
-        // to the bottom, it shouldn't cause all expressions to render from the top)
-        () => this.makeDragCopyViewForModel(model)
-      )
-  )
-),
-// text mode panel
-$DCGView.createElement(
-  $DCGView.Components.If,
-  {
-    predicate: () => DSM.textMode?.inTextMode
-  },
-  () => $DCGView.createElement(
-    "div",
-    {
-      // allow-ids: div
-      class: $DCGView.const("dsm-text-editor-container"),
-      didMount: div => DSM.textMode.mountEditor(div),
-      willUnmount: div => DSM.textMode.unmountEditor(div)
-    }
-  )
-)
+DSM.insertElement(() => DSM.pinExpressions?.pinnedPanel(this)),
+DSM.insertElement(() => DSM.textMode?.editorPanel(this)),
 ```

--- a/src/preload/moduleOverrides/pillbox.replacements
+++ b/src/preload/moduleOverrides/pillbox.replacements
@@ -16,13 +16,7 @@ $DCGView.createElement("div", {
 *Replace* `from` with
 ```js
 __from__
-$DCGView.Components.IfElse(
-    () => window.DesModder,
-    {
-      true: () => DSM.pillboxMenus?.pillboxButtonsView(true),
-      false: null
-    }
-),
+DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonsView(true)),
 ```
 
 ## Insert spot for extra pillbox buttons in regular pillbox view
@@ -38,13 +32,8 @@ $DCGView.createElement($, {
 
 *Replace* `from` with
 ```js
-$DCGView.Components.IfElse(
-    () => window.DesModder,
-    {
-      true: () => DSM.pillboxMenus?.pillboxButtonsView(false),
-      false: null
-    }
-), __from__
+DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonsView(false)),
+__from__
 ```
 
 ## Bottom zero for our pillbox menus
@@ -79,13 +68,7 @@ $DCGView.createElement($If, {
 *Replace* `from` with
 ```js
 __from__,
-$DCGView.Components.IfElse(
-    () => window.DesModder,
-    {
-      true: () => DSM.pillboxMenus?.pillboxMenuView(true),
-      false: null
-    }
-)
+DSM.insertElement(() => DSM.pillboxMenus?.pillboxMenuView(true))
 ```
 
 ## Tweak placement of existing settings menu in geometry

--- a/src/preload/moduleOverrides/show-tips.replacements
+++ b/src/preload/moduleOverrides/show-tips.replacements
@@ -6,7 +6,7 @@
 
 *Description* `Replace "powered by desmos" with tips`
 
-*Find* => `from`
+*Find*
 ```js
 $DCGView.createElement(
   "div",
@@ -18,21 +18,8 @@ $DCGView.createElement(
 )
 ```
 
-*Replace* `from` with
+*Replace* `children` with
 ```js
-$DCGView.createElement(
-  "div",
-  {
-    class: $DCGView.const("dcg-expressions-branding"),
-    __args__
-  },
-  __children__,
-  $DCGView.createElement(
-    $DCGView.Components.If,
-    {
-      predicate: () => DSM.showTips,
-    },
-    () => DSM.showTips?.createTipElement()
-  )
-)
+__children__,
+DSM.insertElement(() => DSM.showTips?.tipView())
 ```

--- a/src/preload/moduleOverrides/text-mode.replacements
+++ b/src/preload/moduleOverrides/text-mode.replacements
@@ -44,38 +44,13 @@ isShowKeypadButtonVisible () {
 
 *Replace* `__children__` with
 ```js
-$DCGView.createElement(
-  $DCGView.Components.If,
-  {
-    predicate: () => DSM.textMode && !this.controller.isInEditListMode()
-  },
-  () => $DCGView.createElement(
-      $Tooltip,
-      {
-        tooltip: () => DesModder.format("text-mode-toggle"),
-        gravity: () => this.controller.isNarrow() ? 'n' : 's'
-      },
-      $DCGView.createElement(
-        'span',
-        {
-          class: $DCGView.const('dcg-icon-btn'),
-          handleEvent: $DCGView.const('true'),
-          role: $DCGView.const('button'),
-          tabindex: $DCGView.const('0'),
-          onTap: () => DSM.textMode?.toggleTextMode()
-        },
-        $DCGView.createElement('i', {
-          class: $DCGView.const('dcg-icon-title')
-        })
-      )
-    )
-),
-$DCGView.Components.IfElse(
-  () => !this.controller.getGraphSettings().config.graphpaper && window.DesModder,
-  {
-    true: () => DSM.pillboxMenus.pillboxButtonsView(true),
-    false: null
-  }
+DSM.insertElement(() => DSM.textMode?.textModeToggle()),
+// This is for pillbox-menus, not text-mode
+DSM.insertElement(
+  () => (
+    !this.controller.getGraphSettings().config.graphpaper
+      && DSM.pillboxMenus.pillboxButtonsView(true)
+  )
 ),
 __children__
 ```

--- a/src/preload/replaceElement.ts
+++ b/src/preload/replaceElement.ts
@@ -1,0 +1,19 @@
+/** This file runs before Desmos is loaded */
+import { Replacer } from "../plugins/PluginController";
+
+export function insertElement(creator: () => undefined | (() => any)) {
+  const DCGView = (Desmos as any).Private.Fragile.DCGView;
+  return DCGView.createElement(
+    DCGView.Components.If,
+    { predicate: () => !!creator() },
+    () => creator()!()
+  );
+}
+
+export function replaceElement<T>(old: () => T, replacer: () => Replacer<T>) {
+  const DCGView = (Desmos as any).Private.Fragile.DCGView;
+  return DCGView.Components.IfElse(() => !!replacer(), {
+    true: () => replacer()!(old()),
+    false: () => old(),
+  });
+}

--- a/src/preload/script.ts
+++ b/src/preload/script.ts
@@ -1,5 +1,6 @@
 import { addForceDisabled } from "../panic/panic";
 import moduleReplacements from "./moduleReplacements";
+import { insertElement, replaceElement } from "./replaceElement";
 import { fullReplacementCached } from "./replacementHelpers/cacheReplacement";
 import window from "globals/window";
 import injectScript from "utils/injectScript";
@@ -62,7 +63,10 @@ listenToMessageDown((message) => {
       pluginSettings: message.pluginSettings,
     };
     // Helps with the case of replacements ran before initialization
-    window.DSM = {} as any;
+    window.DSM = {
+      insertElement,
+      replaceElement,
+    } as any;
     void load(arrayToSet(message.pluginsForceDisabled));
     // cancel listener
     return true;

--- a/src/tests/testing.md
+++ b/src/tests/testing.md
@@ -31,6 +31,6 @@ Return `clean` if you've cleaned up the page (closed all the menus etc). This se
 
 Integration tests are ran in the "node" environment, since they control a browser from a node process but are not inside the browser.
 
-If you want to see what happens during the tests, edit `headless: "new"` to `headless: false` in [`puppeteer-utils.ts`](./puppeteer-utils.ts).
+If you want to see what happens during the tests, edit `headless: "new"` to `headless: false` in setup.js.
 
 If you get an error "TargetCloseError: Protocol error (Runtime.callFunctionOn): Target closed," you probably forgot an `await` somewhere.

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -31,6 +31,8 @@ export const autoCommandNames: string =
 export const autoOperatorNames: string =
   Private.MathquillConfig?.getAutoOperators?.();
 
+export const truncatedLatexLabel = Private.Mathtools.Label.truncatedLatexLabel;
+
 export function getCurrentGraphTitle(): string | undefined {
   return Calc._calc.globalHotkeys?.headerController?.graphsController?.getCurrentGraphTitle?.();
 }


### PR DESCRIPTION
- Move most of the big createElement() trees to
Typescript
- Add some tests

Missing: extra-expression-buttons since it isn't linked directly to a plugin. Just skipped it
