### PR TITLE
Intellisense: No more intellisense in arithmetic-only MathQuill inputs

### DIFF
--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -411,7 +411,6 @@ export default class Intellisense extends PluginController {
     let ancestor: Element | null = activeElement;
     while (ancestor) {
       ancestor = ancestor.parentElement;
-      console.log(ancestor);
       if (
         (ancestor?.classList.contains("no-intellisense") ?? false) ||
         (ancestor?.classList.contains("dcg-settings-view-container") ?? false)

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -406,19 +406,13 @@ export default class Intellisense extends PluginController {
 
   // allows mathquill inputs that only allow arithmetic to selectively disable intellisense
   isActiveElementValidForIntellisense() {
-    const activeElement = document.activeElement;
-    if (activeElement === null) return false;
-    let ancestor: Element | null = activeElement;
-    while (ancestor) {
-      ancestor = ancestor.parentElement;
-      if (
-        (ancestor?.classList.contains("no-intellisense") ?? false) ||
-        (ancestor?.classList.contains("dcg-settings-view-container") ?? false)
-      )
-        return false;
-      if (ancestor?.classList.contains("yes-intellisense")) return true;
-    }
-    return true;
+    return (
+      document.activeElement
+        ?.closest(
+          ".yes-intellisense, .no-intellisense, .dcg-settings-view-container"
+        )
+        ?.classList.contains("yes-intellisense") ?? true
+    );
   }
 
   keyDownHandler = (e: KeyboardEvent) => {

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -404,6 +404,24 @@ export default class Intellisense extends PluginController {
     });
   };
 
+  // allows mathquill inputs that only allow arithmetic to selectively disable intellisense
+  isActiveElementValidForIntellisense() {
+    const activeElement = document.activeElement;
+    if (activeElement === null) return false;
+    let ancestor: Element | null = activeElement;
+    while (ancestor) {
+      ancestor = ancestor.parentElement;
+      console.log(ancestor);
+      if (
+        (ancestor?.classList.contains("no-intellisense") ?? false) ||
+        (ancestor?.classList.contains("dcg-settings-view-container") ?? false)
+      )
+        return false;
+      if (ancestor?.classList.contains("yes-intellisense")) return true;
+    }
+    return true;
+  }
+
   keyDownHandler = (e: KeyboardEvent) => {
     this.saveCursorState();
 
@@ -422,7 +440,12 @@ export default class Intellisense extends PluginController {
 
     // if a non arrow key is pressed in an expression,
     // we enable the intellisense window
-    if (!e.key.startsWith("Arrow") && e.key !== "Enter" && e.key !== "Escape") {
+    if (
+      !e.key.startsWith("Arrow") &&
+      e.key !== "Enter" &&
+      e.key !== "Escape" &&
+      this.isActiveElementValidForIntellisense()
+    ) {
       this.canHaveIntellisense = true;
     }
 

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -47,22 +47,24 @@ export default class SelectCapture extends Component<{
               slider: () => (
                 <div>
                   <div class="dsm-vc-slider-settings">
-                    <InlineMathInputView
-                      ariaLabel="slider variable"
-                      handleLatexChanged={(v) =>
-                        this.controller.setSliderSetting("variable", v)
-                      }
-                      hasError={() =>
-                        !this.controller.isSliderSettingValid("variable")
-                      }
-                      latex={() => this.controller.sliderSettings.variable}
-                      isFocused={() =>
-                        this.controller.isFocused("capture-slider-var")
-                      }
-                      handleFocusChanged={(b) =>
-                        this.controller.updateFocus("capture-slider-var", b)
-                      }
-                    />
+                    <span class="yes-intellisense">
+                      <InlineMathInputView
+                        ariaLabel="slider variable"
+                        handleLatexChanged={(v) =>
+                          this.controller.setSliderSetting("variable", v)
+                        }
+                        hasError={() =>
+                          !this.controller.isSliderSettingValid("variable")
+                        }
+                        latex={() => this.controller.sliderSettings.variable}
+                        isFocused={() =>
+                          this.controller.isFocused("capture-slider-var")
+                        }
+                        handleFocusChanged={(b) =>
+                          this.controller.updateFocus("capture-slider-var", b)
+                        }
+                      />
+                    </span>
                     <StaticMathQuillView latex="=" />
                     <InlineMathInputView
                       ariaLabel="slider min"

--- a/src/plugins/video-creator/components/MainPopup.tsx
+++ b/src/plugins/video-creator/components/MainPopup.tsx
@@ -49,7 +49,7 @@ export default class MainPopup extends Component<{
     return IfElse(() => this.controller.isExporting, {
       false: () => this.templateNormal(),
       true: () => (
-        <div class="dcg-popover-interior">
+        <div class="dcg-popover-interior no-intellisense">
           <div class="dsm-vc-export-in-progress">
             {format("video-creator-exporting")}
             <LoadingPie
@@ -77,7 +77,7 @@ export default class MainPopup extends Component<{
 
   templateNormal() {
     return (
-      <div class="dcg-popover-interior">
+      <div class="dcg-popover-interior no-intellisense">
         <div class="dsm-vc-capture-menu">
           <div class="dcg-popover-title">{format("video-creator-capture")}</div>
           <CaptureMethod controller={this.controller} />


### PR DESCRIPTION
The intellisense menu no longer opens in inputs that don't support it. This is accomplished by using two CSS classes `yes-intellisense` and `no-intellisense`. `yes-intellisense` enables intellisense in its descendants that are MathQuill inputs. `no-intellisense` disables intellisense in its MathQuill input descendants. The first ancestor encountered determines whether intellisense is enabled or not. That way, these can override each other as you go down the hierarchy.

By default, intellisense is enabled in all MathQuill inputs except for those in the settings menu. I've also added `no-intellisense` and `yes-intellisense` tags to the Video Creator menu as appropriate.