### PR TITLE
Compact View/Multiline: Various CSS Fixes

### DIFF
--- a/src/plugins/compact-view/compact.less
+++ b/src/plugins/compact-view/compact.less
@@ -152,8 +152,6 @@
 
     // "x" icon to the right of the expressions
     .dcg-icon-remove {
-      // transform: translate(.lerp2(0px, 5px) [], .lerp2(0px, -5px) [])
-      //   scale(.lerp2(1, 0.6) []);
       padding: 0;
       opacity: 0.5;
       margin-top: 3px;

--- a/src/plugins/compact-view/compact.less
+++ b/src/plugins/compact-view/compact.less
@@ -130,6 +130,11 @@
       border-left-color: #000000aa;
     }
 
+    // fix authorfeatures toggle problem
+    .dcg-component-checkbox.dcg-action-toggle-secret-folder.dcg-do-not-blur {
+      margin-bottom: .lerp2(-5px, 0px) [];
+    }
+
     // icons to the left of the expressions bar
     .dcg-expression-icon-container {
       right: .lerp2(0%, -10%) [];
@@ -147,11 +152,18 @@
 
     // "x" icon to the right of the expressions
     .dcg-icon-remove {
-      transform: translate(.lerp2(0px, 5px) [], .lerp2(0px, -5px) [])
-        scale(.lerp2(1, 0.6) []);
+      // transform: translate(.lerp2(0px, 5px) [], .lerp2(0px, -5px) [])
+      //   scale(.lerp2(1, 0.6) []);
+      padding: 0;
       opacity: 0.5;
+      margin-top: 3px;
+      margin-right: 3px;
+      &::before {
+        font-size: var(--math-font-size) !important;
+        vertical-align: top;
+      }
     }
-    .dcg-icon-remove:hover {
+    .dcg-top-level-icon:hover .dcg-icon-remove {
       opacity: 1;
     }
 

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -81,6 +81,8 @@ export default class Multiline extends PluginController<Config> {
 
   dequeueAllMultilinifications() {
     for (const f of this.pendingMultilinifications) {
+      if (f.closest(".dcg-evaluation")) continue;
+
       // revert everything to its original state so we have proper width calculations
       unverticalify(f);
 


### PR DESCRIPTION
- AuthorFeatures popup no longer causes overflow in Compact View.
- "X" button no longer overflows with small font sizes.
- Evaluations are no longer multilined to prevent them flying off the expression they're from.

Fixes #643