### PR TITLE
Intellisense: Docstring Math Segments now correctly falls back to LaTeX

### DIFF
--- a/src/plugins/text-mode/down/textToRaw.ts
+++ b/src/plugins/text-mode/down/textToRaw.ts
@@ -30,8 +30,7 @@ export default function textToRaw(
 export function textModeExprToLatex(tmExpr: string) {
   const parsedTextMode = parse(tmExpr);
   if (
-    parsedTextMode.program.children.length > 1 ||
-    parsedTextMode.program.children.length === 0 ||
+    parsedTextMode.program.children.length !== 1 ||
     parsedTextMode.diagnostics.length > 0
   )
     return;

--- a/src/plugins/text-mode/down/textToRaw.ts
+++ b/src/plugins/text-mode/down/textToRaw.ts
@@ -29,7 +29,13 @@ export default function textToRaw(
 
 export function textModeExprToLatex(tmExpr: string) {
   const parsedTextMode = parse(tmExpr);
-  const parsedExpr = parsedTextMode.mapIDstmt[1];
+  if (
+    parsedTextMode.program.children.length > 1 ||
+    parsedTextMode.program.children.length === 0 ||
+    parsedTextMode.diagnostics.length > 0
+  )
+    return;
+  const parsedExpr = parsedTextMode.program.children[0];
   if (parsedExpr && parsedExpr.type === "ExprStatement") {
     const aug = childExprToAug(parsedExpr.expr);
     const latex = latexTreeToString(aug);


### PR DESCRIPTION
Docstring math segments no longer allow partial Text Mode parses and instead fall back to LaTeX when a full Text Mode parse isn't possible. 