### PR TITLE
Intellisense: Fixed intellisense lag with deeply-nested expressions

### DIFF
--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -11,13 +11,16 @@ export function mapAugAST(
       for (const child of x) {
         map(child);
       }
+      return;
     }
 
     if (typeof x === "object") {
-      if (typeof x.type === "string") callback(x);
+      if (typeof x.type === "string") {
+        callback(x);
 
-      for (const [_, v] of Object.entries(x)) {
-        map(v);
+        for (const [_, v] of Object.entries(x)) {
+          map(v);
+        }
       }
     }
   }


### PR DESCRIPTION
This graph (and other ones like it with lots of nesting) crashed with Intellisense enabled: https://www.desmos.com/calculator/kqe1c4xuoi

This PR fixes this.