### PR TITLE
Intellisense: Fixed documentation

### DIFF
--- a/src/plugins/intellisense/docs/README.md
+++ b/src/plugins/intellisense/docs/README.md
@@ -12,7 +12,7 @@ Function documentation can also contain rendered LaTeX mathematical expressions,
 
 ### Parameter Documentation
 
-You can provide documentation for specific function parameters by typing `@param=PARAMNAME`, where `PARAMNAME` is the name of the function parameter as if it were written in [Text Mode](../../text-mode/docs/intro.md) format.
+You can provide documentation for specific function parameters by typing `@param PARAMNAME`, where `PARAMNAME` is the name of the function parameter as if it were written in [Text Mode](../../text-mode/docs/intro.md) format.
 
 ## Jump to Definition
 


### PR DESCRIPTION
Intellisense documentation accidentally had the old `@param=PARAMNAME` syntax when now it's been changed to `@param PARAMNAME`