### PR TITLE
Show IDs in Text Mode with Debug Mode enabled

### DIFF
--- a/src/plugins/debug-mode/index.ts
+++ b/src/plugins/debug-mode/index.ts
@@ -9,9 +9,11 @@ export default class DebugMode extends PluginController {
     // The displayed indexes are stored in some state somewhere, so
     // update the state first before updating views
     Calc.controller.updateTheComputedWorld();
+    this.dsm.textMode?.updateDebugMode();
   }
 
   afterDisable() {
     Calc.controller.updateTheComputedWorld();
+    this.dsm.textMode?.updateDebugMode();
   }
 }

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -3,7 +3,8 @@ import { DCGView } from "../../DCGView";
 import { Inserter, PluginController } from "../PluginController";
 import { onCalcEvent, analysisStateField } from "./LanguageServer";
 import { TextModeToggle } from "./components/TextModeToggle";
-import { initView, startState } from "./view/editor";
+import { initView, setDebugMode, startState } from "./view/editor";
+import { TransactionSpec } from "@codemirror/state";
 import { EditorView, ViewUpdate } from "@codemirror/view";
 import { Calc } from "globals/window";
 import { keys } from "utils/depUtils";
@@ -17,6 +18,16 @@ export default class TextMode extends PluginController {
   inTextMode: boolean = false;
   view: EditorView | null = null;
   dispatchListenerID: string | null = null;
+
+  updateDebugMode() {
+    this.view?.dispatch(this.updateDebugModeTransaction());
+  }
+
+  updateDebugModeTransaction(): TransactionSpec {
+    return {
+      effects: setDebugMode.of(this.dsm.isPluginEnabled("debug-mode")),
+    };
+  }
 
   afterDisable() {
     if (this.inTextMode) this.toggleTextMode();

--- a/src/plugins/text-mode/view/editor.less
+++ b/src/plugins/text-mode/view/editor.less
@@ -18,3 +18,9 @@
   /* Tooltip position is miscalculated by the same height as the 42 px header */
   transform: translateY(-42px);
 }
+
+.cm-lineNumbers {
+  // This should only come into play with debug mode. Long IDs like `**dcg_geo_folder**`
+  max-width: 80px;
+  overflow-x: scroll;
+}


### PR DESCRIPTION
There might currently be no way to get a difference between IDs and indices while in text mode. 
But merging with https://github.com/DesModder/DesModder/pull/695 allows for actually testing this code:

![image](https://github.com/DesModder/DesModder/assets/20214911/40fb8548-a1c1-4f84-9452-48f285860114)

Fixes #693