### PR TITLE
Add emit config to remove spaces and newlines

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -87,7 +87,9 @@ show-tips-tip-huggy = Huggy!
 text-mode-name = Text Mode BETA
 text-mode-desc = Expect bugs. Temporary documentation:
 text-mode-toggle = Toggle Text Mode
-# Missing: error messages
+text-mode-toggle-spaces = Spaces
+text-mode-toggle-newlines = Newlines
+text-mode-format = Format
 
 ## Debug Mode
 debug-mode-name = Debug Mode

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -88,7 +88,9 @@ text-mode-name = Text Mode BETA
 text-mode-desc = Expect bugs. Temporary documentation:
 text-mode-toggle = Toggle Text Mode
 text-mode-toggle-spaces = Spaces
+text-mode-toggle-spaces-tooltip = Include unnecessary spaces when formatting
 text-mode-toggle-newlines = Newlines
+text-mode-toggle-newlines-tooltip = Include newlines and indentation when formatting
 text-mode-format = Format
 
 ## Debug Mode

--- a/src/plugins/text-mode/lezer/completions.ts
+++ b/src/plugins/text-mode/lezer/completions.ts
@@ -1,6 +1,6 @@
 import TextMode from "..";
 import {
-  exprToTextString,
+  astToText,
   childLatexToAST,
   StyleDefaults as Defaults,
   AnyHydrated,
@@ -171,7 +171,7 @@ function styleCompletionsFromDefaults(defaults: AnyHydrated): Completion[] {
           ? "type" in value
             ? macroExpandWithSelection(
                 key + ": ",
-                exprToTextString(childLatexToAST(value)),
+                astToText(childLatexToAST(value)),
                 ","
               )
             : macroExpandWithSelection(key + ": @{ ", "", " },")

--- a/src/plugins/text-mode/modify.ts
+++ b/src/plugins/text-mode/modify.ts
@@ -5,19 +5,14 @@ import {
   rawToDsmMetadata,
   ProgramAnalysis,
   astItemToTextString,
-  docToString,
   exprToTextString,
-  styleEntryToText,
+  styleEntryToTextString,
   childExprToAug,
   itemAugToAST,
   graphSettingsToText,
   itemToText,
 } from "../../../text-mode-core";
-import TextAST, {
-  NodePath,
-  Settings,
-  Statement,
-} from "../../../text-mode-core/TextAST";
+import TextAST, { Settings, Statement } from "../../../text-mode-core/TextAST";
 import { addRawID } from "./LanguageServer";
 import { ChangeSpec, StateEffect } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
@@ -366,9 +361,7 @@ function itemChange(
           const oldEntry = oldEntries.find(
             (e) => e.property.value === newEntry.property.value
           );
-          const text = docToString(
-            styleEntryToText(new NodePath(newEntry, null))
-          );
+          const text = styleEntryToTextString(newEntry);
           if (oldEntry) return insertWithIndentation(view, oldEntry.pos, text);
           else {
             const prevEnd = oldEntries[oldEntries.length - 1].pos.to;

--- a/src/plugins/text-mode/modify.ts
+++ b/src/plugins/text-mode/modify.ts
@@ -4,9 +4,7 @@ import {
   rawToAugSettings,
   rawToDsmMetadata,
   ProgramAnalysis,
-  astItemToTextString,
-  exprToTextString,
-  styleEntryToTextString,
+  astToText,
   childExprToAug,
   itemAugToAST,
   graphSettingsToText,
@@ -180,7 +178,7 @@ function metadataChange(
   const pos = oldNode.style?.pos ?? { from: afterEnd, to: afterEnd };
   const ast = itemAugToAST(itemAug);
   if (!ast) return [];
-  const fullItem = astItemToTextString(ast);
+  const fullItem = astToText(ast);
   const newStyle = /@\{[^]*/m.exec(fullItem)?.[0];
   const insert = (!oldNode.style && newStyle ? " " : "") + (newStyle ?? "");
   return insertWithIndentation(view, pos, insert);
@@ -208,7 +206,7 @@ function newItemsChange(
       const aug = rawNonFolderToAug(getTextModeConfig(), item, dsmMetadata);
       const ast = itemAugToAST(aug);
       if (!ast) continue;
-      const body = astItemToTextString(ast);
+      const body = astToText(ast);
       function insertPos(item: NonFolderState) {
         if (item.folderId && lastItem?.folderId !== item.folderId) {
           const folder = analysis.mapIDstmt[item.folderId];
@@ -310,11 +308,7 @@ function itemChange(
           "Programming error: expect no fewer new table columns than old"
         );
       return oldNode.columns.map((e, i) =>
-        insertWithIndentation(
-          view,
-          e.expr.pos,
-          exprToTextString(ast.columns[i].expr)
-        )
+        insertWithIndentation(view, e.expr.pos, astToText(ast.columns[i].expr))
       );
     }
     case "latex-only": {
@@ -330,11 +324,7 @@ function itemChange(
       if (childExprAugString(oldNode.expr) === childExprAugString(ast.expr))
         return [];
       return [
-        insertWithIndentation(
-          view,
-          oldNode.expr.pos,
-          exprToTextString(ast.expr)
-        ),
+        insertWithIndentation(view, oldNode.expr.pos, astToText(ast.expr)),
       ];
     }
     case "image-pos": {
@@ -361,7 +351,7 @@ function itemChange(
           const oldEntry = oldEntries.find(
             (e) => e.property.value === newEntry.property.value
           );
-          const text = styleEntryToTextString(newEntry);
+          const text = astToText(newEntry);
           if (oldEntry) return insertWithIndentation(view, oldEntry.pos, text);
           else {
             const prevEnd = oldEntries[oldEntries.length - 1].pos.to;

--- a/src/plugins/text-mode/view/editor.ts
+++ b/src/plugins/text-mode/view/editor.ts
@@ -6,6 +6,7 @@ import "./editor.less";
 import { checkboxPlugin } from "./plugins/checkboxWidget";
 import { collapseStylesAtStart } from "./plugins/collapseStylesAtStart";
 import { footerPlugin } from "./plugins/footerWidget";
+import { formatPanelPlugin } from "./plugins/formatPanelPlugin";
 import { activeStmtGutterHighlighter } from "./plugins/highlightActiveStmtGutter";
 import { stmtNumbers } from "./plugins/stmtNumbers";
 import { styleCircles } from "./plugins/styleCircles";
@@ -121,6 +122,7 @@ export function startState(tm: TextMode, text: string) {
       checkboxPlugin,
       styleMappingPlugin,
       footerPlugin(),
+      formatPanelPlugin(),
     ],
   });
   state = state.update(collapseStylesAtStart(state)).state;

--- a/src/plugins/text-mode/view/plugins/FormatPanel.less
+++ b/src/plugins/text-mode/view/plugins/FormatPanel.less
@@ -1,0 +1,12 @@
+.dsm-text-editor-container {
+  .dsm-cm-format-panel {
+    display: flex;
+    padding: 5px;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .cm-panels {
+    background: white;
+  }
+}

--- a/src/plugins/text-mode/view/plugins/FormatPanel.tsx
+++ b/src/plugins/text-mode/view/plugins/FormatPanel.tsx
@@ -3,7 +3,7 @@ import { analysisStateField } from "../../LanguageServer";
 import "./FormatPanel.less";
 import { EditorView } from "@codemirror/view";
 import { Component, jsx } from "#DCGView";
-import { Button, Checkbox, If } from "#components";
+import { Button, Checkbox, If, Tooltip } from "#components";
 import { format } from "#i18n";
 
 export class FormatPanel extends Component<{
@@ -26,31 +26,42 @@ export class FormatPanel extends Component<{
         <Button color="light-gray" onTap={() => this.format()}>
           {() => format("text-mode-format")}
         </Button>
-        <Checkbox
-          checked={() => this.spaces}
-          onChange={(checked) => {
-            this.spaces = checked;
-            if (this.spaces) this.newlines = true;
-            this.format();
-            this.props.update();
-          }}
-          ariaLabel={() => format("text-mode-toggle-spaces")}
+
+        <Tooltip
+          tooltip={() => format("text-mode-toggle-spaces-tooltip")}
+          gravity="n"
         >
-          {() => format("text-mode-toggle-spaces")}
-        </Checkbox>
+          <Checkbox
+            checked={() => this.spaces}
+            onChange={(checked) => {
+              this.spaces = checked;
+              if (this.spaces) this.newlines = true;
+              this.format();
+              this.props.update();
+            }}
+            ariaLabel={() => format("text-mode-toggle-spaces")}
+          >
+            {() => format("text-mode-toggle-spaces")}
+          </Checkbox>
+        </Tooltip>
         <If predicate={() => !this.spaces}>
           {() => (
-            <Checkbox
-              checked={() => this.newlines}
-              onChange={(checked) => {
-                this.newlines = checked;
-                this.format();
-                this.props.update();
-              }}
-              ariaLabel={() => format("text-mode-toggle-newlines")}
+            <Tooltip
+              tooltip={() => format("text-mode-toggle-newlines-tooltip")}
+              gravity="n"
             >
-              {() => format("text-mode-toggle-newlines")}
-            </Checkbox>
+              <Checkbox
+                checked={() => this.newlines}
+                onChange={(checked) => {
+                  this.newlines = checked;
+                  this.format();
+                  this.props.update();
+                }}
+                ariaLabel={() => format("text-mode-toggle-newlines")}
+              >
+                {() => format("text-mode-toggle-newlines")}
+              </Checkbox>
+            </Tooltip>
           )}
         </If>
       </div>

--- a/src/plugins/text-mode/view/plugins/FormatPanel.tsx
+++ b/src/plugins/text-mode/view/plugins/FormatPanel.tsx
@@ -1,0 +1,75 @@
+import { astToText } from "../../../../../text-mode-core";
+import { analysisStateField } from "../../LanguageServer";
+import "./FormatPanel.less";
+import { EditorView } from "@codemirror/view";
+import { Component, jsx } from "#DCGView";
+import { Button, Checkbox, If } from "#components";
+import { format } from "#i18n";
+
+export class FormatPanel extends Component<{
+  ev: EditorView;
+  update: () => void;
+}> {
+  ev!: EditorView;
+  spaces!: boolean;
+  newlines!: boolean;
+
+  init() {
+    this.spaces = true;
+    this.newlines = true;
+    this.ev = this.props.ev();
+  }
+
+  template() {
+    return (
+      <div class="dsm-cm-format-panel">
+        <Button color="light-gray" onTap={() => this.format()}>
+          {() => format("text-mode-format")}
+        </Button>
+        <Checkbox
+          checked={() => this.spaces}
+          onChange={(checked) => {
+            this.spaces = checked;
+            if (this.spaces) this.newlines = true;
+            this.format();
+            this.props.update();
+          }}
+          ariaLabel={() => format("text-mode-toggle-spaces")}
+        >
+          {() => format("text-mode-toggle-spaces")}
+        </Checkbox>
+        <If predicate={() => !this.spaces}>
+          {() => (
+            <Checkbox
+              checked={() => this.newlines}
+              onChange={(checked) => {
+                this.newlines = checked;
+                this.format();
+                this.props.update();
+              }}
+              ariaLabel={() => format("text-mode-toggle-newlines")}
+            >
+              {() => format("text-mode-toggle-newlines")}
+            </Checkbox>
+          )}
+        </If>
+      </div>
+    );
+  }
+
+  format() {
+    const analysis = this.ev.state.field(analysisStateField);
+    this.ev.dispatch({
+      changes: [
+        {
+          from: 0,
+          to: this.ev.state.doc.length,
+          insert: astToText(analysis.program, {
+            noNewlines: !this.newlines,
+            noOptionalSpaces: !this.spaces,
+          }),
+        },
+      ],
+    });
+  }
+}

--- a/src/plugins/text-mode/view/plugins/footerWidget.ts
+++ b/src/plugins/text-mode/view/plugins/footerWidget.ts
@@ -19,7 +19,7 @@ function getFooters(state: EditorState) {
         side: 1,
         block: true,
       });
-      decorations.push(widget.range(stmt.pos.to));
+      decorations.push(widget.range(state.doc.lineAt(stmt.pos.to).to));
     }
   }
   return RangeSet.of(decorations);

--- a/src/plugins/text-mode/view/plugins/formatPanelPlugin.ts
+++ b/src/plugins/text-mode/view/plugins/formatPanelPlugin.ts
@@ -1,0 +1,26 @@
+import { FormatPanel } from "./FormatPanel";
+import { showPanel, EditorView, Panel } from "@codemirror/view";
+import { DCGView, MountedComponent } from "#DCGView";
+
+function formatPanel(ev: EditorView): Panel {
+  const dom = document.createElement("div");
+  let mount: MountedComponent | undefined;
+  return {
+    dom,
+    mount() {
+      mount = DCGView.mountToNode(FormatPanel, dom, {
+        ev: DCGView.const(ev),
+        update: () => mount?.update(),
+      });
+    },
+    update() {},
+    destroy() {
+      if (dom) DCGView.unmountFromNode(dom);
+    },
+    top: false,
+  };
+}
+
+export function formatPanelPlugin() {
+  return showPanel.of(formatPanel);
+}

--- a/src/plugins/text-mode/view/statementIntersection.unit.test.ts
+++ b/src/plugins/text-mode/view/statementIntersection.unit.test.ts
@@ -1,8 +1,4 @@
-import {
-  parseText,
-  astItemToTextString,
-  buildConfig,
-} from "../../../../text-mode-core";
+import { parseText, astToText, buildConfig } from "../../../../text-mode-core";
 import { Statement } from "../../../../text-mode-core/TextAST";
 import { statementsIntersecting } from "./statementIntersection";
 
@@ -17,7 +13,7 @@ function positionsAndProgram(s: string) {
 }
 
 function toString(s: Statement) {
-  return astItemToTextString(s).replace(/ /g, "");
+  return astToText(s).replace(/ /g, "");
 }
 
 function testIntersection(s: string, stmts: string[]) {

--- a/text-mode-core/TextAST/index.ts
+++ b/text-mode-core/TextAST/index.ts
@@ -327,7 +327,10 @@ export type NonExprNonStatementNode<C extends S = Concrete> =
   | AssignmentExpression<C>
   | PiecewiseBranch<C>;
 
-export type Node<C extends S = Concrete> = NonExprNode<C> | Expression<C>;
+export type Node<C extends S = Concrete> =
+  | NonExprNode<C>
+  | NonExprNonStatementNode<C>
+  | Expression<C>;
 
 export function isExpression<C extends S = Concrete>(
   n: Node<C>

--- a/text-mode-core/index.ts
+++ b/text-mode-core/index.ts
@@ -9,7 +9,7 @@ export {
 } from "./aug/rawToAug";
 export type { ProgramAnalysis } from "./ProgramAnalysis";
 export { parse as parseText } from "./down/textToAST";
-export { astToText } from "./up/astToText";
+export { astToText, type TextEmitOptions } from "./up/astToText";
 export { childExprToAug } from "./down/astToAug";
 export { itemAugToAST, childLatexToAST } from "./up/augToAST";
 export { graphSettingsToText, itemToText, augToText } from "./up/augToText";

--- a/text-mode-core/index.ts
+++ b/text-mode-core/index.ts
@@ -12,7 +12,7 @@ export { parse as parseText } from "./down/textToAST";
 export { astToText } from "./up/astToText";
 export { childExprToAug } from "./down/astToAug";
 export { itemAugToAST, childLatexToAST } from "./up/augToAST";
-export { graphSettingsToText, itemToText } from "./up/augToText";
+export { graphSettingsToText, itemToText, augToText } from "./up/augToText";
 export * as StyleDefaults from "./down/style/defaults";
 export type { AnyHydrated, AnyHydratedValue } from "./down/style/Hydrated";
 export { rawToText } from "./up/rawToText";

--- a/text-mode-core/index.ts
+++ b/text-mode-core/index.ts
@@ -9,11 +9,7 @@ export {
 } from "./aug/rawToAug";
 export type { ProgramAnalysis } from "./ProgramAnalysis";
 export { parse as parseText } from "./down/textToAST";
-export {
-  astItemToTextString,
-  exprToTextString,
-  styleEntryToTextString,
-} from "./up/astToText";
+export { astToText } from "./up/astToText";
 export { childExprToAug } from "./down/astToAug";
 export { itemAugToAST, childLatexToAST } from "./up/augToAST";
 export { graphSettingsToText, itemToText } from "./up/augToText";

--- a/text-mode-core/index.ts
+++ b/text-mode-core/index.ts
@@ -11,7 +11,6 @@ export type { ProgramAnalysis } from "./ProgramAnalysis";
 export { parse as parseText } from "./down/textToAST";
 export {
   astItemToTextString,
-  docToString,
   exprToTextString,
   styleEntryToTextString,
 } from "./up/astToText";

--- a/text-mode-core/index.ts
+++ b/text-mode-core/index.ts
@@ -13,7 +13,7 @@ export {
   astItemToTextString,
   docToString,
   exprToTextString,
-  styleEntryToText,
+  styleEntryToTextString,
 } from "./up/astToText";
 export { childExprToAug } from "./down/astToAug";
 export { itemAugToAST, childLatexToAST } from "./up/augToAST";

--- a/text-mode-core/tests/roundTripEmit.unit.test.ts
+++ b/text-mode-core/tests/roundTripEmit.unit.test.ts
@@ -1,4 +1,4 @@
-import { astItemToTextString, buildConfig } from "..";
+import { astToText, buildConfig } from "..";
 import { parse } from "../down/textToAST";
 import { TextEmitOptions } from "../up/astToText";
 
@@ -10,7 +10,7 @@ function testRoundTripIdenticalViaAST(text: string, emitOpts: TextEmitOptions) {
     const children = analysis.program.children;
     expect(children.length).toEqual(1);
     const item = children[0];
-    const emitted = astItemToTextString(item, emitOpts);
+    const emitted = astToText(item, emitOpts);
     expect(emitted).toBe(text);
   });
 }

--- a/text-mode-core/tests/roundTripEmit.unit.test.ts
+++ b/text-mode-core/tests/roundTripEmit.unit.test.ts
@@ -1,0 +1,148 @@
+import { astItemToTextString, buildConfig } from "..";
+import { parse } from "../down/textToAST";
+import { TextEmitOptions } from "../up/astToText";
+
+/** Round-trip Text code through AST, and make sure you get back what you started. */
+function testRoundTripIdenticalViaAST(text: string, emitOpts: TextEmitOptions) {
+  test(text, () => {
+    const analysis = parse(buildConfig({}), text);
+    expect(analysis.diagnostics).toEqual([]);
+    const children = analysis.program.children;
+    expect(children.length).toEqual(1);
+    const item = children[0];
+    const emitted = astItemToTextString(item, emitOpts);
+    expect(emitted).toBe(text);
+  });
+}
+
+describe("Text Emit round-trips (keeping optional spaces)", () => {
+  const cases: string[] = [
+    `[x for x = [1 ... 5]]`,
+    // TODO: what happens if multiple regression params?
+    `e_1 = a ~ a #{
+      a = 1
+    }`,
+    `image "name" @{
+      url: "data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa",
+      width: 10,
+      height: 10,
+      center: (0, 0),
+    }`,
+    `table {
+      x_1 = [1, 2, 3]
+      
+      y_1 = [4, 5, 6] @{ color: "#2d70b3" }
+    }`,
+    `"asdfasdf"`,
+    `folder "title" {
+      (1, a) @{
+        points: @{
+          opacity: 0.8,
+          style: "OPEN",
+          drag: "NONE",
+          size: 1 + 1 + 1 + 1 + 1 + 1,
+        },
+      }
+
+      y = sin(x ^ 2)
+    }`,
+    `ticker a -> a + 1 @{ minStep: 123 }`,
+    `y = f''''(x)`,
+    `y = arctan(y, x)`,
+    `(d/d x) (x ^ 2)`,
+    `sum n=(1 ... 5) (n ^ 2)`,
+    `[1, 2, 3, 4]`,
+    `[1, 3 ... 11, 13]`,
+    `L[1 ... 5]`,
+    `L[1, 2, 3, 4]`,
+    `L[M]`,
+    `L.x`,
+    // TODO: parentheses are unnecessary here
+    `(uniformdist()).random()`,
+    `(1, 2), (3, 4)`,
+    `a -> a + 1, b -> b - 1`,
+    `[a + 1 for a = [1 ... 5]]`,
+    `[b + a for b = [1 ... 5], a = [1 ... 3]]`,
+    `sin(x) with x = 5`,
+    `x + y with x = 5, y = -5`,
+    `{}`,
+    // TODO: preserve (lack of) `:1` in round-trip
+    `{x > 5: 1}`,
+    `{x > 5: 2}`,
+    `{x > 5: 2, 3}`,
+    // TODO: preserve (lack of) `:1` in round-trip
+    `{x > 5: 1, 3}`,
+    `{x > 5: 1, y < 6: 2}`,
+    `x ^ 2 * sin(x)`,
+    `(x / y) * z`,
+    `2 < x < 5`,
+    `-sin(-x)`,
+    `|(2, x)|`,
+    `sin(x!)!`,
+    `y = 1e99 - 1 / 1e-99`,
+    `y = 100000 - 0.000001`,
+    // TODO: NaN support
+    `y = infty ^ 3 + (-infty) ^ 3`,
+  ].map(dedentString);
+  for (const text of cases) {
+    testRoundTripIdenticalViaAST(text, {});
+  }
+});
+
+describe("Text Emit round-trips (discarding optional spaces)", () => {
+  const cases: string[] = [
+    `[x for x=[1...5]]`,
+    `[x+1 for x=[1...5]]`,
+    `e_1=a~a#{a=1}`,
+    `image"name name"@{url:"data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa",width:10,height:10,center:(0,0)}`,
+    `table{x_1=[1,2,3];y_1=[4,5,6]@{color:"#2d70b3"}}`,
+    `"note note"`,
+    `folder"title title"{(1,a)@{points:@{size:1}};y=sin(x^2)}`,
+    `ticker a->a+1@{minStep:123}`,
+    `ticker|x|`,
+    `y=f''''(x)`,
+    `y=arctan(y,x)`,
+    `(d/d x)(x^2)`,
+    `sum n=(1...5)(n^2)`,
+    `[1,2,3,4]`,
+    `[1,3...11,13]`,
+    `L[1...5]`,
+    `L[1,2,3,4]`,
+    `L[M]`,
+    `L.x`,
+    `(1,2),(3,4)`,
+    `a->a+1,b->b-1`,
+    `[sin(a)for a=[1...5]]`,
+    `[b+a for b=[1...5],a=[1...3]]`,
+    `sin(x)with x=5`,
+    // Why is the next case failing???
+    // `x+y with x=5,y=-5`,
+    `{x>5:2}`,
+    `{x>5:1,y<6:2,3}`,
+    `x^2*sin(x)`,
+    `(x/y)*z`,
+    `2<x<5`,
+    `|(2,x)|`,
+    `sin(x!)!`,
+    `y=1e99-1/1e-99`,
+  ].map(dedentString);
+  for (const text of cases) {
+    testRoundTripIdenticalViaAST(text, { keepOptionalSpaces: false });
+  }
+});
+
+function dedentString(str: string) {
+  const lines = str.split("\n");
+  const trailingLines = lines.slice(1);
+  if (lines.length <= 1) return str;
+  const dedentAmount = Math.min(
+    ...trailingLines
+      .filter((line) => /\S/.test(line))
+      .map((line) => line.match(/^\s*/)![0].length)
+  );
+  let s = lines[0];
+  for (const line of trailingLines) {
+    s += "\n" + (/\S/.test(line) ? line.slice(dedentAmount) : "");
+  }
+  return s;
+}

--- a/text-mode-core/tests/roundTripEmit.unit.test.ts
+++ b/text-mode-core/tests/roundTripEmit.unit.test.ts
@@ -93,11 +93,26 @@ describe("Text Emit round-trips (discarding optional spaces)", () => {
   const cases: string[] = [
     `[x for x=[1...5]]`,
     `[x+1 for x=[1...5]]`,
-    `e_1=a~a#{a=1}`,
-    `image"name name"@{url:"data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa",width:10,height:10,center:(0,0)}`,
-    `table{x_1=[1,2,3];y_1=[4,5,6]@{color:"#2d70b3"}}`,
+    `e_1=a~a#{
+      a=1
+    }`,
+    `image"name name"@{
+      url:"data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa",
+      width:10,
+      height:10,
+      center:(0,0),
+    }`,
+    `table{
+      x_1=[1,2,3]
+      
+      y_1=[4,5,6]@{color:"#2d70b3"}
+    }`,
     `"note note"`,
-    `folder"title title"{(1,a)@{points:@{size:1}};y=sin(x^2)}`,
+    `folder"title title"{
+      (1,a)@{points:@{size:1}}
+      
+      y=sin(x^2)
+    }`,
     `ticker a->a+1@{minStep:123}`,
     `ticker|x|`,
     `y=f''''(x)`,
@@ -115,8 +130,7 @@ describe("Text Emit round-trips (discarding optional spaces)", () => {
     `[sin(a)for a=[1...5]]`,
     `[b+a for b=[1...5],a=[1...3]]`,
     `sin(x)with x=5`,
-    // Why is the next case failing???
-    // `x+y with x=5,y=-5`,
+    `x+y with x=5,y=-5`,
     `{x>5:2}`,
     `{x>5:1,y<6:2,3}`,
     `x^2*sin(x)`,
@@ -127,7 +141,36 @@ describe("Text Emit round-trips (discarding optional spaces)", () => {
     `y=1e99-1/1e-99`,
   ].map(dedentString);
   for (const text of cases) {
-    testRoundTripIdenticalViaAST(text, { keepOptionalSpaces: false });
+    testRoundTripIdenticalViaAST(text, { noOptionalSpaces: true });
+  }
+});
+
+describe("Text Emit round-trips (discarding newlines and optional spaces)", () => {
+  const cases: string[] = [
+    `e_1=a~a#{a=1}`,
+    `image"name name"@{url:"data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa",width:10,height:10,center:(0,0)}`,
+    `table{x_1=[1,2,3];y_1=[4,5,6]@{color:"#2d70b3"}}`,
+    `folder"title title"{(1,a)@{points:@{size:1}};y=sin(x^2)}`,
+    `y=1e99-1/1e-99!`,
+  ].map(dedentString);
+  for (const text of cases) {
+    testRoundTripIdenticalViaAST(text, {
+      noNewlines: true,
+      noOptionalSpaces: true,
+    });
+  }
+});
+
+describe("Text Emit round-trips (discarding newlines)", () => {
+  const cases: string[] = [
+    `e_1 = a ~ a #{ a = 1 }`,
+    `image "name name" @{ url: "data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa", width: 10, height: 10, center: (0, 0) }`,
+    `table {x_1 = [1, 2, 3];y_1 = [4, 5, 6] @{ color: "#2d70b3" }}`,
+    `folder "title title" {(1, a) @{ points: @{ size: 1 } };y = sin(x ^ 2)}`,
+    `y = 1e99 - 1 / 1e-99!`,
+  ].map(dedentString);
+  for (const text of cases) {
+    testRoundTripIdenticalViaAST(text, { noNewlines: true });
   }
 });
 

--- a/text-mode-core/tests/roundTripParse.unit.test.ts
+++ b/text-mode-core/tests/roundTripParse.unit.test.ts
@@ -295,7 +295,20 @@ function roundTrips(cases: string[]) {
   describe("via Text without optional spaces", () =>
     cases.forEach((r) =>
       testRoundTripIdenticalViaText(r, {
-        keepOptionalSpaces: false,
+        noOptionalSpaces: true,
+      })
+    ));
+  describe("via Text without newlines", () =>
+    cases.forEach((r) =>
+      testRoundTripIdenticalViaText(r, {
+        noNewlines: true,
+      })
+    ));
+  describe("via Text without newlines or optional spaces", () =>
+    cases.forEach((r) =>
+      testRoundTripIdenticalViaText(r, {
+        noNewlines: true,
+        noOptionalSpaces: true,
       })
     ));
 }

--- a/text-mode-core/tests/roundTripParse.unit.test.ts
+++ b/text-mode-core/tests/roundTripParse.unit.test.ts
@@ -6,7 +6,7 @@ import { latexTreeToString as _latexTreeToString } from "../aug/augLatexToRaw";
 import { parseRootLatex as _parseRootLatex } from "../aug/rawToAug";
 import { childExprToAug } from "../down/astToAug";
 import { parse as _parse } from "../down/textToAST";
-import { exprToTextString } from "../up/astToText";
+import { TextEmitOptions, exprToTextString } from "../up/astToText";
 import { rootLatexToAST } from "../up/augToAST";
 import "./run_calc_for_tests";
 
@@ -58,12 +58,12 @@ function testRoundTripIdenticalViaAST(raw: string) {
   });
 }
 
-function testRoundTripIdenticalViaText(raw: string) {
+function testRoundTripIdenticalViaText(raw: string, emitOpts: TextEmitOptions) {
   test(raw, () => {
     const raw1 = leftRight(raw);
     const aug = parseRootLatex(raw1);
     const ast = rootLatexToAST(aug);
-    const text = exprToTextString(ast);
+    const text = exprToTextString(ast, emitOpts);
     const analysis = parse(text);
     expect(analysis.diagnostics).toEqual([]);
     const children = analysis.program.children;
@@ -290,7 +290,14 @@ describe("Identifiers round-trip", () => {
 function roundTrips(cases: string[]) {
   describe("via Aug", () => cases.forEach(testRoundTripIdenticalViaAug));
   describe("via AST", () => cases.forEach(testRoundTripIdenticalViaAST));
-  describe("via Text", () => cases.forEach(testRoundTripIdenticalViaText));
+  describe("via Text", () =>
+    cases.forEach((r) => testRoundTripIdenticalViaText(r, {})));
+  describe("via Text without optional spaces", () =>
+    cases.forEach((r) =>
+      testRoundTripIdenticalViaText(r, {
+        keepOptionalSpaces: false,
+      })
+    ));
 }
 
 describe("Same-parse round trips", () => {

--- a/text-mode-core/tests/roundTripParse.unit.test.ts
+++ b/text-mode-core/tests/roundTripParse.unit.test.ts
@@ -6,7 +6,7 @@ import { latexTreeToString as _latexTreeToString } from "../aug/augLatexToRaw";
 import { parseRootLatex as _parseRootLatex } from "../aug/rawToAug";
 import { childExprToAug } from "../down/astToAug";
 import { parse as _parse } from "../down/textToAST";
-import { TextEmitOptions, exprToTextString } from "../up/astToText";
+import { TextEmitOptions, astToText } from "../up/astToText";
 import { rootLatexToAST } from "../up/augToAST";
 import "./run_calc_for_tests";
 
@@ -63,7 +63,7 @@ function testRoundTripIdenticalViaText(raw: string, emitOpts: TextEmitOptions) {
     const raw1 = leftRight(raw);
     const aug = parseRootLatex(raw1);
     const ast = rootLatexToAST(aug);
-    const text = exprToTextString(ast, emitOpts);
+    const text = astToText(ast, emitOpts);
     const analysis = parse(text);
     expect(analysis.diagnostics).toEqual([]);
     const children = analysis.program.children;

--- a/text-mode-core/up/astToText.ts
+++ b/text-mode-core/up/astToText.ts
@@ -39,6 +39,13 @@ export function exprToTextString(
   return docToString(exprToText(new NodePath(expr, null)), emitOpts);
 }
 
+export function styleEntryToTextString(
+  entry: TextAST.MappingEntry,
+  emitOpts?: TextEmitOptions
+) {
+  return docToString(styleEntryToText(new NodePath(entry, null)), emitOpts);
+}
+
 function required(doc: Doc) {
   return label(REQUIRED, doc);
 }
@@ -143,7 +150,7 @@ function styleMapToText(path: NodePath<TextAST.StyleMapping>): Doc {
   return group(["@{", indent([line, join(line, lines)]), line, "}"]);
 }
 
-export function styleEntryToText(path: NodePath<TextAST.MappingEntry>) {
+function styleEntryToText(path: NodePath<TextAST.MappingEntry>) {
   const entry = path.node;
   return [
     entry.property.value,

--- a/text-mode-core/up/augToAST.ts
+++ b/text-mode-core/up/augToAST.ts
@@ -1,6 +1,21 @@
 import TextAST from "../TextAST/Synthetic";
 import Aug from "../aug/AugState";
 
+export function augToTextAST(aug: Aug.State): TextAST.Program {
+  const stmts: TextAST.Statement[] = [graphSettingsToAST(aug.settings)];
+  if (aug.expressions.ticker) {
+    stmts.push(tickerToAST(aug.expressions.ticker));
+  }
+  for (const expr of aug.expressions.list) {
+    const item = itemAugToAST(expr);
+    if (item) stmts.push(item);
+  }
+  return {
+    type: "Program",
+    children: stmts,
+  };
+}
+
 export function graphSettingsToAST(
   settings: Aug.GraphSettings
 ): TextAST.Settings {

--- a/text-mode-core/up/augToText.ts
+++ b/text-mode-core/up/augToText.ts
@@ -1,26 +1,13 @@
 import Aug from "../aug/AugState";
 import { astToText } from "./astToText";
-import { graphSettingsToAST, itemAugToAST, tickerToAST } from "./augToAST";
+import { augToTextAST, graphSettingsToAST, itemAugToAST } from "./augToAST";
 
-export default function augToText(aug: Aug.State): string {
-  const settingsString = graphSettingsToText(aug.settings);
-  const tickerString = aug.expressions.ticker
-    ? "\n\n" + tickerToText(aug.expressions.ticker)
-    : "";
-  const itemStrings = [];
-  for (const item of aug.expressions.list) {
-    const text = "\n\n" + itemToText(item);
-    itemStrings.push(text);
-  }
-  return settingsString + tickerString + itemStrings.join("");
+export function augToText(aug: Aug.State): string {
+  return astToText(augToTextAST(aug));
 }
 
 export function graphSettingsToText(settings: Aug.GraphSettings) {
   return astToText(graphSettingsToAST(settings));
-}
-
-export function tickerToText(ticker: Aug.TickerAug) {
-  return astToText(tickerToAST(ticker));
 }
 
 export function itemToText(item: Aug.ItemAug): string {

--- a/text-mode-core/up/augToText.ts
+++ b/text-mode-core/up/augToText.ts
@@ -1,5 +1,5 @@
 import Aug from "../aug/AugState";
-import { astItemToTextString } from "./astToText";
+import { astToText } from "./astToText";
 import { graphSettingsToAST, itemAugToAST, tickerToAST } from "./augToAST";
 
 export default function augToText(aug: Aug.State): string {
@@ -16,15 +16,15 @@ export default function augToText(aug: Aug.State): string {
 }
 
 export function graphSettingsToText(settings: Aug.GraphSettings) {
-  return astItemToTextString(graphSettingsToAST(settings));
+  return astToText(graphSettingsToAST(settings));
 }
 
 export function tickerToText(ticker: Aug.TickerAug) {
-  return astItemToTextString(tickerToAST(ticker));
+  return astToText(tickerToAST(ticker));
 }
 
 export function itemToText(item: Aug.ItemAug): string {
   const ast = itemAugToAST(item);
   if (ast === null) return "";
-  return astItemToTextString(ast);
+  return astToText(ast);
 }

--- a/text-mode-core/up/augToText.ts
+++ b/text-mode-core/up/augToText.ts
@@ -1,17 +1,23 @@
 import Aug from "../aug/AugState";
-import { astToText } from "./astToText";
+import { TextEmitOptions, astToText } from "./astToText";
 import { augToTextAST, graphSettingsToAST, itemAugToAST } from "./augToAST";
 
-export function augToText(aug: Aug.State): string {
-  return astToText(augToTextAST(aug));
+export function augToText(aug: Aug.State, emitOpts?: TextEmitOptions): string {
+  return astToText(augToTextAST(aug), emitOpts);
 }
 
-export function graphSettingsToText(settings: Aug.GraphSettings) {
-  return astToText(graphSettingsToAST(settings));
+export function graphSettingsToText(
+  settings: Aug.GraphSettings,
+  emitOpts?: TextEmitOptions
+) {
+  return astToText(graphSettingsToAST(settings), emitOpts);
 }
 
-export function itemToText(item: Aug.ItemAug): string {
+export function itemToText(
+  item: Aug.ItemAug,
+  emitOpts?: TextEmitOptions
+): string {
   const ast = itemAugToAST(item);
   if (ast === null) return "";
-  return astToText(ast);
+  return astToText(ast, emitOpts);
 }

--- a/text-mode-core/up/needsParens.ts
+++ b/text-mode-core/up/needsParens.ts
@@ -27,7 +27,11 @@ export default function needsParens(path: NodePath): boolean {
     // is a statement or style mapping (onClick event)
     return parent.type === "MappingEntry";
 
-  if (isNonExpression(node) || isNonExpression(parent)) return false;
+  if (
+    isNonExpression(node) ||
+    (isNonExpression(parent) && parent.type !== "PiecewiseBranch")
+  )
+    return false;
 
   switch (parent.type) {
     // TODO
@@ -96,6 +100,7 @@ export default function needsParens(path: NodePath): boolean {
           // parent should never be arithmetic, but be safe
           return isArithmetic(parent);
         case "PiecewiseExpression":
+        case "PiecewiseBranch":
           // This one can be contentious.
           // {x > 1: x -> 0, x -> 2} is NOT {x > 1: (x -> 0, x -> 2)}
           return false;

--- a/text-mode-core/up/rawToText.ts
+++ b/text-mode-core/up/rawToText.ts
@@ -1,7 +1,7 @@
 import { Config } from "../TextModeConfig";
 import Aug from "../aug/AugState";
 import rawToAug from "../aug/rawToAug";
-import augToText from "./augToText";
+import { augToText } from "./augToText";
 import type { GraphState } from "@desmodder/graph-state";
 
 /**


### PR DESCRIPTION
- `astToText` and related functions now take `TextEmitOptions`, which allows disabling spaces and newlines
- Adds a "Format" button that also lets you toggle "Spaces" and "Newlines" (If spaces is TRUE, then newlines is forced to TRUE)
   ![image](https://github.com/DesModder/DesModder/assets/20214911/a35e8a05-2983-4f8b-8aa2-bf40ac468024)
- Places footers at the end of lines, so they don't interject into the middle of lines
   ![image](https://github.com/DesModder/DesModder/assets/20214911/84c0aa54-bb26-43cd-a3f3-4dcddaef083b)
