### PR TITLE
Don't auto-subscript length-1 identifiers

### DIFF
--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -721,6 +721,10 @@ export default class Intellisense extends PluginController<{
         if (this.settings.subscriptify && this.latestMQ) {
           const ident = getCorrectableIdentifier(this.latestMQ);
 
+          // Don't want to auto-subscriptify a length-1 id like "x";
+          // no change but breaks cursor position
+          if (ident.ident.length === 1) return;
+
           if (
             this.latestMQ.__options.autoOperatorNames[
               ident.ident.replace(/_/g, "")

--- a/src/plugins/intellisense/intellisense.int.test.ts
+++ b/src/plugins/intellisense/intellisense.int.test.ts
@@ -155,6 +155,11 @@ describe("Intellisense", () => {
       await driver.keyboard.press("Escape");
       await driver.keyboard.press("Enter");
 
+      await driver.keyboard.type("c(x)=rgb(x,x,x)");
+      await driver.assertSelectedItemLatex(
+        "c\\left(x\\right)=\\operatorname{rgb}\\left(x,x,x\\right)"
+      );
+
       await driver.clean();
     },
     40000


### PR DESCRIPTION
Steps to reproduce:
- Start writing `c(x)=rgb(x,x,x)`
- Before commit: After writing the first comma, the cursor would move after the (ghost) close paren. After commit: the cursor stays where it is
