### PR TITLE
Add custom-mathquill-config option to reduce spacing around "f"

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -264,7 +264,7 @@ compact-view-opt-noSeparatingLines-desc = Removes the separating lines between e
 compact-view-opt-highlightAlternatingLines-name = Highlight Alternating Lines
 compact-view-opt-highlightAlternatingLines-desc = Highlights alternating expressions so that they can be easily distinguished from one another.
 compact-view-opt-hideEvaluations-name = Collapse Evaluations
-compact-view-opt-hideEvaluations-desc = Puts evaluations off to the side. They can be focused or hovered to be shown. 
+compact-view-opt-hideEvaluations-desc = Puts evaluations off to the side. They can be focused or hovered to be shown.
 
 ## Multiline
 multiline-name = Multiline Expressions
@@ -301,3 +301,5 @@ custom-mathquill-config-opt-leftIntoSubscript-name = Left/Right into Subscripts
 custom-mathquill-config-opt-leftIntoSubscript-desc = Moving the cursor left or right will go into subscript instead of superscript
 custom-mathquill-config-opt-extendedGreek-name = More Greek Letters
 custom-mathquill-config-opt-extendedGreek-desc = Enables replacements for all supported greek letters
+custom-mathquill-config-opt-lessFSpacing-name = Less F spacing
+custom-mathquill-config-opt-lessFSpacing-desc = Reduces extra spacing around "f" characters

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -280,11 +280,11 @@ multiline-opt-multilinifyDelayAfterEdit-desc = Multiline expressions should be u
 custom-mathquill-config-name = Custom MathQuill Config
 custom-mathquill-config-desc = Changes how equation input works.
 custom-mathquill-config-opt-superscriptOperators-name = Operators in Exponents
-custom-mathquill-config-opt-superscriptOperators-desc = Allows you to type operators like '+' in exponents
+custom-mathquill-config-opt-superscriptOperators-desc = Allows you to type operators like "+" in exponents
 custom-mathquill-config-opt-noAutoSubscript-name = Disable Auto Subscripts
 custom-mathquill-config-opt-noAutoSubscript-desc = Disable automatically putting numbers typed after variable names in subscripts
 custom-mathquill-config-opt-noNEquals-name = Disable n= Sums
-custom-mathquill-config-opt-noNEquals-desc = Disable sums automatically placing 'n=' in the lower bound
+custom-mathquill-config-opt-noNEquals-desc = Disable sums automatically placing "n=" in the lower bound
 custom-mathquill-config-opt-subSupWithoutOp-name = Subscripts/Superscripts Without Operand
 custom-mathquill-config-opt-subSupWithoutOp-desc = Allows subscripts and superscripts to be made even if not preceded by anything
 custom-mathquill-config-opt-allowMixedBrackets-name = Allow Mismatched Brackets
@@ -292,7 +292,7 @@ custom-mathquill-config-opt-allowMixedBrackets-desc = Allows all brackets to mat
 custom-mathquill-config-opt-subscriptReplacements-name = Allow Replacements in Subscripts
 custom-mathquill-config-opt-subscriptReplacements-desc = Allows symbols and function names to be typed into subscripts
 custom-mathquill-config-opt-noPercentOf-name = Disable % of
-custom-mathquill-config-opt-noPercentOf-desc = Makes typing '%' insert the percent character instead of '% of'
+custom-mathquill-config-opt-noPercentOf-desc = Makes typing "%" insert the percent character instead of "% of"
 custom-mathquill-config-opt-commaDelimiter-name = Comma Separators
 custom-mathquill-config-opt-commaDelimiter-desc = Inserts commas as delimiters in numbers (purely visual)
 custom-mathquill-config-opt-delimiterOverride-name = Custom Delimiter
@@ -301,5 +301,5 @@ custom-mathquill-config-opt-leftIntoSubscript-name = Left/Right into Subscripts
 custom-mathquill-config-opt-leftIntoSubscript-desc = Moving the cursor left or right will go into subscript instead of superscript
 custom-mathquill-config-opt-extendedGreek-name = More Greek Letters
 custom-mathquill-config-opt-extendedGreek-desc = Enables replacements for all supported greek letters
-custom-mathquill-config-opt-lessFSpacing-name = Less F spacing
-custom-mathquill-config-opt-lessFSpacing-desc = Reduces extra spacing around "f" characters
+custom-mathquill-config-opt-lessFSpacing-name = Less Spacing Around "f"
+custom-mathquill-config-opt-lessFSpacing-desc = Reduces extra spacing around the letter "f"

--- a/src/plugins/custom-mathquill-config/config.ts
+++ b/src/plugins/custom-mathquill-config/config.ts
@@ -60,8 +60,11 @@ export const configList = [
     type: "boolean",
     default: false,
   },
-  // `as const` ensures that the key values can be used as types
-  // instead of the type 'string'
+  {
+    key: "lessFSpacing",
+    type: "boolean",
+    default: false,
+  },
 ] satisfies ConfigItem[];
 
 export interface Config {
@@ -76,4 +79,5 @@ export interface Config {
   subSupWithoutOp: boolean;
   allowMixedBrackets: boolean;
   noPercentOf: boolean;
+  lessFSpacing: boolean;
 }

--- a/src/plugins/custom-mathquill-config/custom-mathquill-config.less
+++ b/src/plugins/custom-mathquill-config/custom-mathquill-config.less
@@ -16,3 +16,10 @@
     margin-right: 0;
   }
 }
+
+.less-f-spacing {
+  .dcg-calculator-api-container .dcg-mq-math-mode var.dcg-mq-f {
+    margin-left: unset;
+    margin-right: 0.05em;
+  }
+}

--- a/src/plugins/custom-mathquill-config/index.ts
+++ b/src/plugins/custom-mathquill-config/index.ts
@@ -32,6 +32,11 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
       config.commaDelimiter
     );
 
+    Calc.controller.rootElt.classList.toggle(
+      "less-f-spacing",
+      config.lessFSpacing
+    );
+
     this.doAutoCommandInjections = config.extendedGreek;
 
     Calc.controller.rootElt.style.setProperty(


### PR DESCRIPTION
The default spacing felt a bit excessive, this PR adds an option to reduce that