### PR TITLE
Fix pillbox buttons

### DIFF
--- a/src/plugins/pillbox-menus/components/PillboxContainer.less
+++ b/src/plugins/pillbox-menus/components/PillboxContainer.less
@@ -1,6 +1,7 @@
 .dsm-pillbox-buttons {
   display: flex;
   flex-direction: column;
+  gap: 5px;
   &.dsm-horizontal-pillbox {
     flex-direction: row-reverse;
   }

--- a/src/plugins/pillbox-menus/components/PillboxContainer.tsx
+++ b/src/plugins/pillbox-menus/components/PillboxContainer.tsx
@@ -48,7 +48,7 @@ export default class PillboxContainer extends Component<{
                   class={() =>
                     this.horizontal
                       ? "dcg-icon-btn"
-                      : "dcg-btn-flat-gray dcg-settings-pillbox dcg-action-settings dsm-action-menu"
+                      : "dcg-btn-flat-gray dcg-settings-pillbox dcg-action-settings dcg-pillbox-btn-interior dsm-action-menu"
                   }
                   role="button"
                   onTap={() => this.onTapMenuButton(id)}

--- a/src/plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/plugins/pillbox-menus/pillbox-menus.replacements
@@ -107,19 +107,3 @@ __classes__,
 "dcg-settings-container": this.controller.isNarrowGeometryHeader(),
 "dcg-left": this.controller.isNarrowGeometryHeader()
 ```
-
-## Show pillbox container even without zoom buttons
-
-*Description* `Show pillbox buttons (like the DesModder button) even with zoom disabled`
-
-*Find*
-```js
-shouldShowContainer() {
-    return __ret__
-}
-```
-
-*Replace* `ret` with
-```js
-__ret__ || (!DSM.pillboxMenus?.showHorizontalPillboxMenu())
-```


### PR DESCRIPTION
Removed a replacement that didn't seem to matter anymore (the container no longer has a predicate) and added a new class responsible for pillbox sizing.