### PR TITLE
Code Golf: Text Expressions for easy Byte Count-based Golfing

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -240,12 +240,7 @@ interface CalcPrivate {
     };
     listModel: {
       // add properties as needed
-      __itemModelArray: {
-        id: string;
-        colorLatex: string;
-        folderId: string;
-        type: "folder" | "expression";
-      }[];
+      __itemModelArray: ItemModel[];
       __itemIdToModel: Record<string, ItemModel>;
 
       drawOrder: string[];

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -28,7 +28,8 @@ export type DispatchedEvent =
         | "commit-geo-objects"
         | "upward-delete-selected-expression"
         | "downward-delete-selected-expression"
-        | "ui/container-resized";
+        | "ui/container-resized"
+        | "stop-dragdrop";
     }
   | {
       type: "keypad/set-minimized";
@@ -101,7 +102,13 @@ export type DispatchedEvent =
     }
   | { type: "set-folder-collapsed"; id: string; isCollapsed: boolean }
   | { type: "set-item-colorLatex"; id: string; colorLatex: string }
-  | { type: "set-note-text"; id: string; text: string };
+  | { type: "set-note-text"; id: string; text: string }
+  | {
+      type: "start-dragdrop";
+      dragTarget: { type: "expression"; calcId: string };
+      grabPt: { x: number; y: number };
+      mousePt: { x: number; y: number };
+    };
 
 /**
  * Evaluator change: a change set associated with a single id, passed back from

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -80,3 +80,22 @@ $DCGView2.createElement("div", {
 __rest2note__,
 DSM.insertElement(() => (DSM.codeGolf?.noteCostPanel(this.model)))
 ```
+
+*Description* `Override dragdrop to properly deal with note-expression pairs`
+
+*Find* => `handleDispatchedAction`
+```js
+handleDispatchedAction($DesmosEvent) {
+```
+
+*Find* => `dragdropHandlerParams`
+```js
+                        firstItemId: $firstItem.id,
+                        numberOfItems: $numOfItems,
+                        expandFolder: $shouldExpandFolder,
+```
+
+*Replace* `$numOfItems` with
+```js
+DSM.codeGolf?.getDragCount($firstItem.id, $numOfItems) ?? $numOfItems
+```

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -2,9 +2,9 @@
 
 *plugin* `code-golf`
 
-## Add a character count to each expression in the exppanel
+## Add golfing stats to expressions in exppanel
 
-*Description* `Show how many characters used by an expression in the exppanel`
+*Description* `Show total expression width and symbol count`
 
 *Find* => `math expression item`
 ```js
@@ -29,7 +29,7 @@ __rest3__,
 DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this._rootNode)  ))
 ```
 
-## Add total counts to folders in exppanel
+## Add total golf stats counts to folders in exppanel
 
 *Description* `Show golfing stats for an entire folder`
 
@@ -53,4 +53,30 @@ $DCGView2.createElement("div", {
 ```js
 __rest2folder__,
 DSM.insertElement(() => (DSM.codeGolf?.folderCostPanel(this.model)))
+```
+
+## Add character count stats to note expressions
+
+*Description* `Show golfing stats for a note representing codegolf`
+
+*Find* => `note expression item`
+```js
+$DCGView2.createElement("div", {
+    class: () => ({
+        "dcg-do-not-blur": !0,
+        "dcg-expressionitem": !0,
+        "dcg-readonly": this.controller.isItemReadonly(this.id),
+        "dcg-expressiontext": !0,
+        __classesAfterNote__
+    }),
+    __rest1note__
+}, $DCGView2.createElement("div", {
+    class: $DCGView2.const("dcg-fade-container")
+}, __rest2note__), __rest3note__)
+```
+
+*Replace* `__rest2note__` with
+```js
+__rest2note__,
+DSM.insertElement(() => (DSM.codeGolf?.noteCostPanel(this.model)))
 ```

--- a/src/plugins/code-golf/index.tsx
+++ b/src/plugins/code-golf/index.tsx
@@ -398,22 +398,25 @@ export default class CodeGolf extends PluginController {
       }
 
       if (e.type === "stop-dragdrop") {
-        for (const { noteID, exprID } of this.knownNoteExprPairs) {
-          const note = Calc.controller.getItemModel(noteID);
-          const expr = Calc.controller.getItemModel(exprID);
+        setTimeout(() => {
+          for (const { noteID, exprID } of this.knownNoteExprPairs) {
+            const note = Calc.controller.getItemModel(noteID);
+            const expr = Calc.controller.getItemModel(exprID);
 
-          if (!note || !expr) continue;
+            if (!note || !expr) continue;
 
-          Calc.controller.listModel.__itemModelArray.splice(expr.index, 1);
+            Calc.controller.listModel.__itemModelArray.splice(expr.index, 1);
 
-          Calc.controller.listModel.__itemModelArray.splice(
-            note.index + 1,
-            0,
-            expr
-          );
-        }
+            Calc.controller.listModel.__itemModelArray.splice(
+              note.index + 1,
+              0,
+              expr
+            );
+          }
 
-        Calc.controller.updateTheComputedWorld();
+          Calc.controller.updateTheComputedWorld();
+          Calc.controller.updateViews();
+        }, 0);
       }
     });
   }

--- a/src/plugins/code-golf/index.tsx
+++ b/src/plugins/code-golf/index.tsx
@@ -280,6 +280,16 @@ export default class CodeGolf extends PluginController {
       return 2;
     }
 
+    const prevModel = Calc.controller.getItemModelByIndex(model.index - 1);
+
+    if (
+      prevModel &&
+      prevModel.type === "text" &&
+      prevModel.text?.startsWith("@codegolf")
+    ) {
+      return 0;
+    }
+
     return defaultCount;
   }
 
@@ -335,6 +345,28 @@ export default class CodeGolf extends PluginController {
 
       if (e.type === "set-state") {
         this.updateTextExprGolfMappings(e.state);
+      }
+
+      if (e.type === "start-dragdrop") {
+        const model = Calc.controller.getItemModel(
+          e.dragTarget.calcId
+        ) as ItemModel;
+
+        if (model.type !== "expression") return;
+
+        const prevModel = Calc.controller.getItemModelByIndex(model.index - 1);
+
+        if (
+          prevModel &&
+          prevModel.type === "text" &&
+          prevModel.text?.startsWith("@codegolf")
+        ) {
+          setTimeout(() => {
+            Calc.controller.dispatch({
+              type: "stop-dragdrop",
+            });
+          });
+        }
       }
     });
   }

--- a/src/plugins/code-golf/index.tsx
+++ b/src/plugins/code-golf/index.tsx
@@ -4,7 +4,13 @@ import { Inserter, PluginController } from "../PluginController";
 import "./index.less";
 import { format } from "localization/i18n-core";
 import { IfElse, InlineMathInputView } from "src/components";
-import { Calc, ExpressionModel, FolderModel, TextModel } from "src/globals";
+import {
+  Calc,
+  ExpressionModel,
+  FolderModel,
+  ItemModel,
+  TextModel,
+} from "src/globals";
 
 function calcWidthInPixels(domNode?: HTMLElement) {
   const rootblock = domNode?.querySelector(".dcg-mq-root-block");
@@ -265,6 +271,16 @@ export default class CodeGolf extends PluginController {
 
   noteCostPanel(model: TextModel) {
     return () => <NoteCostPanel model={() => model}></NoteCostPanel>;
+  }
+
+  getDragCount(id: string, defaultCount: number) {
+    const model = Calc.controller.getItemModel(id) as ItemModel;
+
+    if (model.type === "text" && model.text?.startsWith("@codegolf")) {
+      return 2;
+    }
+
+    return defaultCount;
   }
 
   afterConfigChange(): void {}

--- a/src/plugins/code-golf/index.tsx
+++ b/src/plugins/code-golf/index.tsx
@@ -398,25 +398,23 @@ export default class CodeGolf extends PluginController {
       }
 
       if (e.type === "stop-dragdrop") {
-        setTimeout(() => {
-          for (const { noteID, exprID } of this.knownNoteExprPairs) {
-            const note = Calc.controller.getItemModel(noteID);
-            const expr = Calc.controller.getItemModel(exprID);
+        for (const { noteID, exprID } of this.knownNoteExprPairs) {
+          const note = Calc.controller.getItemModel(noteID);
+          const expr = Calc.controller.getItemModel(exprID);
 
-            if (!note || !expr) continue;
+          if (!note || !expr) continue;
 
-            Calc.controller.listModel.__itemModelArray.splice(expr.index, 1);
+          Calc.controller.listModel.__itemModelArray.splice(expr.index, 1);
 
-            Calc.controller.listModel.__itemModelArray.splice(
-              note.index + 1,
-              0,
-              expr
-            );
-          }
+          Calc.controller.listModel.__itemModelArray.splice(
+            note.index + 1,
+            0,
+            expr
+          );
 
           Calc.controller.updateTheComputedWorld();
-          Calc.controller.updateViews();
-        }, 0);
+        }
+        Calc.controller.updateViews();
       }
     });
   }

--- a/src/plugins/code-golf/index.tsx
+++ b/src/plugins/code-golf/index.tsx
@@ -1,9 +1,10 @@
 import { Component, jsx, mountToNode } from "#DCGView";
+import { GraphState } from "@desmodder/graph-state";
 import { Inserter, PluginController } from "../PluginController";
 import "./index.less";
 import { format } from "localization/i18n-core";
 import { IfElse, InlineMathInputView } from "src/components";
-import { Calc, ExpressionModel, FolderModel } from "src/globals";
+import { Calc, ExpressionModel, FolderModel, TextModel } from "src/globals";
 
 function calcWidthInPixels(domNode?: HTMLElement) {
   const rootblock = domNode?.querySelector(".dcg-mq-root-block");
@@ -210,6 +211,43 @@ export class FolderCostPanel extends Component<{
   }
 }
 
+function extractCodegolfedTextString(text: string): string | undefined {
+  if (!text.startsWith("@codegolf")) return undefined;
+
+  return text.slice(text.match(/@codegolf\s*/g)?.[0]?.length ?? 0);
+}
+
+export class NoteCostPanel extends Component<{
+  model: () => TextModel;
+}> {
+  template() {
+    return (
+      <div class="dsm-code-golf-char-count-container">
+        {IfElse(
+          () => this.props.model().text?.startsWith("@codegolf") ?? false,
+          {
+            true: () => (
+              <div class="dsm-code-golf-char-count">
+                {() =>
+                  format("code-golf-note-latex-byte-count", {
+                    chars:
+                      (new Blob([this.props.model().text ?? ""])?.size ?? 0) -
+                      (new Blob([
+                        this.props.model().text?.match(/@codegolf\s*/g)?.[0] ??
+                          "",
+                      ]).size ?? 0),
+                  })
+                }
+              </div>
+            ),
+            false: () => <div></div>,
+          }
+        )}
+      </div>
+    );
+  }
+}
+
 export default class CodeGolf extends PluginController {
   static id = "code-golf" as const;
   static enabledByDefault = false;
@@ -225,11 +263,80 @@ export default class CodeGolf extends PluginController {
     return () => <FolderCostPanel model={() => model}></FolderCostPanel>;
   }
 
+  noteCostPanel(model: TextModel) {
+    return () => <NoteCostPanel model={() => model}></NoteCostPanel>;
+  }
+
   afterConfigChange(): void {}
 
   dispatcher!: string;
 
-  afterEnable() {}
+  prevNoteLatex = new Map<string, string>();
 
-  afterDisable() {}
+  afterEnable() {
+    this.updateTextExprGolfMappings(Calc.getState());
+
+    this.dispatcher = Calc.controller.dispatcher.register((e) => {
+      if (e.type === "set-note-text") {
+        const latex = extractCodegolfedTextString(e.text);
+
+        if (!latex) return;
+
+        const model = Calc.controller.getItemModel(e.id) as TextModel;
+
+        const nextModel = Calc.controller.getItemModelByIndex(model.index + 1);
+
+        setTimeout(() => {
+          if (
+            !nextModel ||
+            nextModel.type !== "expression" ||
+            this.prevNoteLatex.get(e.id) !== nextModel.latex
+          ) {
+            Calc.setExpression({
+              type: "expression",
+              latex,
+            });
+
+            const newExpr = Calc.controller.listModel.__itemModelArray.pop();
+
+            Calc.controller.listModel.__itemModelArray.splice(
+              model.index + 1,
+              0,
+              newExpr as (typeof Calc.controller.listModel.__itemModelArray)[0]
+            );
+
+            Calc.controller.updateTheComputedWorld();
+          } else {
+            Calc.controller.dispatch({
+              type: "set-item-latex",
+              latex,
+              id: nextModel.id,
+            });
+          }
+          this.prevNoteLatex.set(e.id, latex);
+        });
+      }
+
+      if (e.type === "set-state") {
+        this.updateTextExprGolfMappings(e.state);
+      }
+    });
+  }
+
+  updateTextExprGolfMappings(state: GraphState) {
+    const list = state.expressions.list;
+    for (let i = 0; i < list.length; i++) {
+      const note = list[i];
+      if (note.type === "text") {
+        const latex = extractCodegolfedTextString(note.text ?? "");
+        if (latex) {
+          this.prevNoteLatex.set(note.id, latex);
+        }
+      }
+    }
+  }
+
+  afterDisable() {
+    Calc.controller.dispatcher.unregister(this.dispatcher);
+  }
 }


### PR DESCRIPTION
Adds in a feature where you can use text expressions/notes to specify the LaTeX of other expressions, enabling easy golfing based on byte count.
![image](https://github.com/DesModder/DesModder/assets/70352880/7ef86228-415c-40c9-b9dd-40f43c31b83b)
