### PR TITLE
Multiline: Spaces to Newlines

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -281,6 +281,8 @@ multiline-opt-multilinifyDelayAfterEdit-name = Edit Delay (ms)
 multiline-opt-multilinifyDelayAfterEdit-desc = Multiline expressions should be updated after no edits are made for this number of milliseconds.
 multiline-opt-spacesToNewlines-name = Spaces to Newlines
 multiline-opt-spacesToNewlines-desc = Convert groups of 3 spaces into newlines. These can be automatically created with Shift+Enter. Enabling this will also disable automatic multilining!
+multiline-opt-determineLineBreaksAutomatically-name = Auto Determine Linebreaks 
+multiline-opt-determineLineBreaksAutomatically-desc = Automatically figure out where to put line breaks. 
 
 ## Custom MathQuill Config
 custom-mathquill-config-name = Custom MathQuill Config

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -279,6 +279,8 @@ multiline-opt-automaticallyMultilinify-name = Automatically Multilinify
 multiline-opt-automaticallyMultilinify-desc = Automatically splits expressions onto multiple lines.
 multiline-opt-multilinifyDelayAfterEdit-name = Edit Delay (ms)
 multiline-opt-multilinifyDelayAfterEdit-desc = Multiline expressions should be updated after no edits are made for this number of milliseconds.
+multiline-opt-spacesToNewlines-name = Spaces to Newlines
+multiline-opt-spacesToNewlines-desc = Convert groups of 3 spaces into newlines. These can be automatically created with Shift+Enter. Enabling this will also disable automatic multilining!
 
 ## Custom MathQuill Config
 custom-mathquill-config-name = Custom MathQuill Config

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -280,11 +280,11 @@ multiline-opt-automaticallyMultilinify-desc = Automatically splits expressions o
 multiline-opt-multilinifyDelayAfterEdit-name = Edit Delay (ms)
 multiline-opt-multilinifyDelayAfterEdit-desc = Multiline expressions should be updated after no edits are made for this number of milliseconds.
 multiline-opt-spacesToNewlines-name = Spaces to Newlines
-multiline-opt-spacesToNewlines-desc = Convert groups of 3 spaces into newlines. These can be automatically created with Shift+Enter. Enabling this will also disable automatic multilining!
+multiline-opt-spacesToNewlines-desc = Convert groups of 3 spaces into newlines. These can be automatically created with Shift+Enter.
 multiline-opt-determineLineBreaksAutomatically-name = Auto Determine Linebreaks 
 multiline-opt-determineLineBreaksAutomatically-desc = Automatically figure out where to put line breaks. 
-multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-name = Preserve Hand-aligned Exprs
-multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-desc = Don't determine line breaks automatically for expressions that use Shift+Enter for manual multilining.
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-name = Preserve Shift+Enter'd Exprs
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-desc = Don't automatically insert extra line breaks in expressions that have any manually-added line breaks. 
 
 ## Custom MathQuill Config
 custom-mathquill-config-name = Custom MathQuill Config

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -283,6 +283,8 @@ multiline-opt-spacesToNewlines-name = Spaces to Newlines
 multiline-opt-spacesToNewlines-desc = Convert groups of 3 spaces into newlines. These can be automatically created with Shift+Enter. Enabling this will also disable automatic multilining!
 multiline-opt-determineLineBreaksAutomatically-name = Auto Determine Linebreaks 
 multiline-opt-determineLineBreaksAutomatically-desc = Automatically figure out where to put line breaks. 
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-name = Preserve Hand-aligned Exprs
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-desc = Don't determine line breaks automatically for expressions that use Shift+Enter for manual multilining.
 
 ## Custom MathQuill Config
 custom-mathquill-config-name = Custom MathQuill Config

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -272,19 +272,19 @@ compact-view-opt-hideEvaluations-desc = Puts evaluations off to the side. They c
 
 ## Multiline
 multiline-name = Multiline Expressions
-multiline-desc = Splits expressions onto multiple lines to better make use of available space. Can be triggered manually with Ctrl+M.
+multiline-desc = Splits expressions onto multiple lines to better make use of available space.
 multiline-opt-widthBeforeMultiline-name = Width Threshold (%)
 multiline-opt-widthBeforeMultiline-desc = Minimum width (as a percent of the viewport size) at which point wrapping will occur. On mobile, this value is tripled.
-multiline-opt-automaticallyMultilinify-name = Automatically Multilinify
-multiline-opt-automaticallyMultilinify-desc = Automatically splits expressions onto multiple lines.
+multiline-opt-automaticallyMultilinify-name = Insert Linebreaks while Typing
+multiline-opt-automaticallyMultilinify-desc = Automatically splits expressions onto multiple lines while you type, bypassing the need to use Ctrl+M.
 multiline-opt-multilinifyDelayAfterEdit-name = Edit Delay (ms)
 multiline-opt-multilinifyDelayAfterEdit-desc = Multiline expressions should be updated after no edits are made for this number of milliseconds.
 multiline-opt-spacesToNewlines-name = Spaces to Newlines
 multiline-opt-spacesToNewlines-desc = Convert groups of 3 spaces into newlines. These can be automatically created with Shift+Enter.
-multiline-opt-determineLineBreaksAutomatically-name = Auto Determine Linebreaks 
-multiline-opt-determineLineBreaksAutomatically-desc = Automatically figure out where to put line breaks. 
-multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-name = Preserve Shift+Enter'd Exprs
-multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-desc = Don't automatically insert extra line breaks in expressions that have any manually-added line breaks. 
+multiline-opt-determineLineBreaksAutomatically-name = Auto Insert Linebreaks 
+multiline-opt-determineLineBreaksAutomatically-desc = Automatically figure out where to put line breaks. Use Ctrl+M to trigger this.
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-name = Skip expressions with triple spaces
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-desc = Don't automatically insert extra line breaks in expressions that have any manually-added line breaks (triple spaces). 
 
 ## Custom MathQuill Config
 custom-mathquill-config-name = Custom MathQuill Config

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -29,6 +29,10 @@ import Wakatime from "./wakatime";
 import WolframToDesmos from "./wolfram2desmos";
 
 interface ConfigItemGeneric {
+  // indentation level for hierarchical relationships in settings
+  // usually for when several settings only become relevant when another is enabled
+  // default 0
+  indentationLevel?: number;
   key: string;
   // TODO proper type here
   shouldShow?: (current: any) => boolean;

--- a/src/plugins/multiline/config.ts
+++ b/src/plugins/multiline/config.ts
@@ -12,6 +12,11 @@ export const configList = [
   {
     type: "boolean",
     default: true,
+    key: "determineLineBreaksAutomatically",
+  },
+  {
+    type: "boolean",
+    default: true,
     key: "automaticallyMultilinify",
   },
   {
@@ -35,6 +40,7 @@ export const configList = [
 export interface Config {
   widthBeforeMultiline: number;
   automaticallyMultilinify: boolean;
+  determineLineBreaksAutomatically: boolean;
   multilinifyDelayAfterEdit: number;
   spacesToNewlines: boolean;
 }

--- a/src/plugins/multiline/config.ts
+++ b/src/plugins/multiline/config.ts
@@ -14,6 +14,9 @@ export const configList = [
     max: Infinity,
     step: 1,
     key: "widthBeforeMultiline",
+    shouldShow(current) {
+      return current.determineLineBreaksAutomatically;
+    },
   },
   {
     indentationLevel: 1,

--- a/src/plugins/multiline/config.ts
+++ b/src/plugins/multiline/config.ts
@@ -2,6 +2,12 @@ import { ConfigItem } from "#plugins/index.ts";
 
 export const configList = [
   {
+    type: "boolean",
+    default: true,
+    key: "determineLineBreaksAutomatically",
+  },
+  {
+    indentationLevel: 1,
     type: "number",
     default: 30,
     min: 0,
@@ -10,11 +16,7 @@ export const configList = [
     key: "widthBeforeMultiline",
   },
   {
-    type: "boolean",
-    default: true,
-    key: "determineLineBreaksAutomatically",
-  },
-  {
+    indentationLevel: 1,
     type: "boolean",
     default: true,
     key: "disableAutomaticLineBreaksForHandAlignedExpressions",
@@ -23,6 +25,7 @@ export const configList = [
     },
   },
   {
+    indentationLevel: 1,
     type: "boolean",
     default: true,
     key: "automaticallyMultilinify",
@@ -32,6 +35,7 @@ export const configList = [
     },
   },
   {
+    indentationLevel: 2,
     type: "number",
     default: 1000,
     min: 0,

--- a/src/plugins/multiline/config.ts
+++ b/src/plugins/multiline/config.ts
@@ -18,6 +18,10 @@ export const configList = [
     type: "boolean",
     default: true,
     key: "automaticallyMultilinify",
+
+    shouldShow(current) {
+      return current.determineLineBreaksAutomatically;
+    },
   },
   {
     type: "number",
@@ -27,7 +31,10 @@ export const configList = [
     step: 1,
     key: "multilinifyDelayAfterEdit",
     shouldShow(current) {
-      return current.automaticallyMultilinify;
+      return (
+        current.automaticallyMultilinify &&
+        current.determineLineBreaksAutomatically
+      );
     },
   },
   {

--- a/src/plugins/multiline/config.ts
+++ b/src/plugins/multiline/config.ts
@@ -17,6 +17,14 @@ export const configList = [
   {
     type: "boolean",
     default: true,
+    key: "disableAutomaticLineBreaksForHandAlignedExpressions",
+    shouldShow(current) {
+      return current.determineLineBreaksAutomatically;
+    },
+  },
+  {
+    type: "boolean",
+    default: true,
     key: "automaticallyMultilinify",
 
     shouldShow(current) {
@@ -39,7 +47,7 @@ export const configList = [
   },
   {
     type: "boolean",
-    default: false,
+    default: true,
     key: "spacesToNewlines",
   },
 ] satisfies ConfigItem[];
@@ -50,4 +58,5 @@ export interface Config {
   determineLineBreaksAutomatically: boolean;
   multilinifyDelayAfterEdit: number;
   spacesToNewlines: boolean;
+  disableAutomaticLineBreaksForHandAlignedExpressions: boolean;
 }

--- a/src/plugins/multiline/config.ts
+++ b/src/plugins/multiline/config.ts
@@ -25,10 +25,16 @@ export const configList = [
       return current.automaticallyMultilinify;
     },
   },
+  {
+    type: "boolean",
+    default: false,
+    key: "spacesToNewlines",
+  },
 ] satisfies ConfigItem[];
 
 export interface Config {
   widthBeforeMultiline: number;
   automaticallyMultilinify: boolean;
   multilinifyDelayAfterEdit: number;
+  spacesToNewlines: boolean;
 }

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -326,6 +326,15 @@ export default class Multiline extends PluginController<Config> {
         this.multilineExpressions(e);
       }
 
+      // undo/redo operations should keep manually-added newlines multilined
+      if (
+        e.type === "undo" ||
+        (e.type === "redo" && this.settings.spacesToNewlines)
+      ) {
+        this.unmultilineExpressions();
+        this.dequeueAllMultilinifications();
+      }
+
       if (e.type === "ui/container-resized") {
         this.afterConfigChange();
       }

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -154,7 +154,7 @@ export default class Multiline extends PluginController<Config> {
           determineLineBreaksAutomatically:
             this.settings.automaticallyMultilinify &&
             (this.settings.disableAutomaticLineBreaksForHandAlignedExpressions
-              ? (mathfield?.latex?.() ?? "").includes("\\ \\ \\ ")
+              ? !(mathfield?.latex?.() ?? "").includes("\\ \\ \\ ")
               : true),
         }
       );

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -3,7 +3,7 @@ import { Config, configList } from "./config";
 import "./multiline.less";
 import { CollapseMode, unverticalify, verticalify } from "./verticalify";
 import { MathQuillField, MathQuillView } from "#components";
-import { Calc, DispatchedEvent } from "#globals";
+import { Calc, DispatchedEvent, ItemModel } from "#globals";
 import {
   getController,
   mqKeystroke,
@@ -146,7 +146,12 @@ export default class Multiline extends PluginController<Config> {
           maxPriority: 1,
           spacesToNewlines: this.settings.spacesToNewlines,
           determineLineBreaksAutomatically:
-            this.settings.automaticallyMultilinify,
+            this.settings.automaticallyMultilinify &&
+            (this.settings.disableAutomaticLineBreaksForHandAlignedExpressions
+              ? !(
+                  f?.parentElement?._mqMathFieldInstance?.latex?.() as string
+                ).match(/\\ \\ \\/g)
+              : true),
         }
       );
 

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -185,7 +185,7 @@ export default class Multiline extends PluginController<Config> {
       const remove = hookIntoOverrideKeystroke(
         this.calc.focusedMathQuill.mq,
         (key, _) => {
-          const mq = Calc.focusedMathQuill?.mq;
+          const mq = this.calc.focusedMathQuill?.mq;
 
           if (key === "Shift-Enter" && this.settings.spacesToNewlines) {
             if (mq) {

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -83,7 +83,13 @@ export default class Multiline extends PluginController<Config> {
       if (!(f instanceof HTMLElement)) continue;
 
       // don't re-verticalify everything unless editing
-      if (f.dataset.isVerticalified && e.type !== "set-item-latex") continue;
+      if (
+        f.dataset.isVerticalified &&
+        e.type !== "set-item-latex" &&
+        e.type !== "undo" &&
+        e.type !== "redo"
+      )
+        continue;
 
       // add to a queue of expressions that need to be verticalified
       this.enqueueVerticalifyOperation(f);
@@ -331,8 +337,11 @@ export default class Multiline extends PluginController<Config> {
         e.type === "undo" ||
         (e.type === "redo" && this.settings.spacesToNewlines)
       ) {
-        this.unmultilineExpressions();
-        this.dequeueAllMultilinifications();
+        setTimeout(() => {
+          this.unmultilineExpressions(true);
+          this.multilineExpressions(e);
+          this.dequeueAllMultilinifications();
+        });
       }
 
       if (e.type === "ui/container-resized") {

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -460,7 +460,7 @@ export default class Multiline extends PluginController<Config> {
       if (
         (next instanceof HTMLElement &&
           // is the element a line break?
-          next.dataset.isLineBreak !== undefined) ||
+          next.dataset.isAutoLineBreak !== undefined) ||
         next === nextFromBefore
       ) {
         mqKeystroke(focusedmq, arrowdir);

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -201,11 +201,24 @@ export default class Multiline extends PluginController<Config> {
             return false;
           }
 
-          if (mq && key === "Backspace" && this.settings.spacesToNewlines) {
+          if (
+            mq &&
+            key.endsWith("Backspace") &&
+            this.settings.spacesToNewlines
+          ) {
             if (isNextToTripleSpaceLineBreak(mq, L)) {
               mq.keystroke("Backspace");
               mq.keystroke("Backspace");
               mq.keystroke("Backspace");
+              return false;
+            }
+          }
+
+          if (mq && key.endsWith("Del") && this.settings.spacesToNewlines) {
+            if (isNextToTripleSpaceLineBreak(mq, R)) {
+              mq.keystroke("Del");
+              mq.keystroke("Del");
+              mq.keystroke("Del");
               return false;
             }
           }
@@ -217,7 +230,7 @@ export default class Multiline extends PluginController<Config> {
             this.settings.spacesToNewlines
           ) {
             const right = key.endsWith("Right");
-            const shift = key.startsWith("Shift");
+            const shift = key.includes("Shift");
 
             const arrowDir =
               (shift ? "Shift-" : "") + (right ? "Right" : "Left");
@@ -237,7 +250,7 @@ export default class Multiline extends PluginController<Config> {
             return false;
           }
         },
-        0,
+        1,
         "multiline"
       );
       if (remove) this.customHandlerRemovers.push(remove);

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -14,11 +14,16 @@ import {
   registerCustomDispatchOverridingHandler,
 } from "#utils/listenerHelpers.ts";
 
+export const R = 1;
+export const L = -1;
+
+type Dir = 1 | -1;
+
 function focusmq(mq: MathQuillField | undefined) {
   mq?.focus();
 }
 
-function isNextToTripleSpaceLineBreak(mq: MathQuillField, dir: 1 | -1) {
+function isNextToTripleSpaceLineBreak(mq: MathQuillField, dir: Dir) {
   return (
     getController(mq).cursor[dir]?._el?.dataset.isManualLineBreak &&
     getController(mq).cursor[dir]?.[dir]?._el?.dataset.isManualLineBreak &&
@@ -197,7 +202,7 @@ export default class Multiline extends PluginController<Config> {
           }
 
           if (mq && key === "Backspace" && this.settings.spacesToNewlines) {
-            if (isNextToTripleSpaceLineBreak(mq, -1)) {
+            if (isNextToTripleSpaceLineBreak(mq, L)) {
               mq.keystroke("Backspace");
               mq.keystroke("Backspace");
               mq.keystroke("Backspace");
@@ -216,7 +221,7 @@ export default class Multiline extends PluginController<Config> {
 
             const arrowDir =
               (shift ? "Shift-" : "") + (right ? "Right" : "Left");
-            const dir = right ? 1 : -1;
+            const dir = right ? R : L;
 
             // check for three consecutive spaces
             if (isNextToTripleSpaceLineBreak(mq, dir)) {
@@ -415,7 +420,7 @@ export default class Multiline extends PluginController<Config> {
       // get cursor and adjacent element so we can figure out
       // if it's a line break
       const ctrlr = getController(focusedmq);
-      let next = ctrlr.cursor?.[up ? -1 : 1]?._el;
+      let next = ctrlr.cursor?.[up ? L : R]?._el;
 
       // are we getting the right side or the left side
       // of the element? (e.g. the bounding client rect "left" or "right" property)
@@ -427,7 +432,7 @@ export default class Multiline extends PluginController<Config> {
       // if we can't directly get the next element (e.g. end of a parenthesis block),
       // shift the cursor so that we can get access to it from the "other side"
       if (!next) {
-        next = ctrlr.cursor?.[up ? 1 : -1]?._el;
+        next = ctrlr.cursor?.[up ? R : L]?._el;
         isNextRight = !isNextRight;
       }
 

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -3,7 +3,7 @@ import { Config, configList } from "./config";
 import "./multiline.less";
 import { CollapseMode, unverticalify, verticalify } from "./verticalify";
 import { MathQuillField, MathQuillView } from "#components";
-import { Calc, DispatchedEvent, ItemModel } from "#globals";
+import { Calc, DispatchedEvent } from "#globals";
 import {
   getController,
   mqKeystroke,
@@ -121,6 +121,12 @@ export default class Multiline extends PluginController<Config> {
         indent: 20,
       }));
 
+      const mathfield = (
+        f?.parentElement as unknown as {
+          _mqMathFieldInstance: MathQuillField;
+        }
+      )?._mqMathFieldInstance;
+
       // add line breaks
       verticalify(
         f,
@@ -148,9 +154,7 @@ export default class Multiline extends PluginController<Config> {
           determineLineBreaksAutomatically:
             this.settings.automaticallyMultilinify &&
             (this.settings.disableAutomaticLineBreaksForHandAlignedExpressions
-              ? !(
-                  f?.parentElement?._mqMathFieldInstance?.latex?.() as string
-                ).match(/\\ \\ \\/g)
+              ? (mathfield?.latex?.() ?? "").includes("\\ \\ \\ ")
               : true),
         }
       );

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -18,6 +18,14 @@ function focusmq(mq: MathQuillField | undefined) {
   mq?.focus();
 }
 
+function isNextToTripleSpaceLineBreak(mq: MathQuillField, dir: 1 | -1) {
+  return (
+    getController(mq).cursor[dir]?._el?.dataset.isManualLineBreak &&
+    getController(mq).cursor[dir]?.[dir]?._el?.dataset.isManualLineBreak &&
+    getController(mq).cursor[dir]?.[dir]?.[dir]?._el?.dataset.isManualLineBreak
+  );
+}
+
 export default class Multiline extends PluginController<Config> {
   static id = "multiline" as const;
   static enabledByDefault = false;
@@ -179,6 +187,15 @@ export default class Multiline extends PluginController<Config> {
             return false;
           }
 
+          if (mq && key === "Backspace" && this.settings.spacesToNewlines) {
+            if (isNextToTripleSpaceLineBreak(mq, -1)) {
+              mq.keystroke("Backspace");
+              mq.keystroke("Backspace");
+              mq.keystroke("Backspace");
+              return false;
+            }
+          }
+
           // handle arrow nav with spaces2newlines
           if (
             mq &&
@@ -193,14 +210,7 @@ export default class Multiline extends PluginController<Config> {
             const dir = right ? 1 : -1;
 
             // check for three consecutive spaces
-            if (
-              getController(mq).cursor[dir]?._el?.dataset.isManualLineBreak &&
-              getController(mq).cursor[dir]?.[dir]?._el?.dataset
-                .isManualLineBreak &&
-              getController(mq).cursor[dir]?.[dir]?.[dir]?._el?.dataset
-                .isManualLineBreak
-            ) {
-              console.log("three conseuctive spaces");
+            if (isNextToTripleSpaceLineBreak(mq, dir)) {
               mq.keystroke(arrowDir);
               mq.keystroke(arrowDir);
               mq.keystroke(arrowDir);

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -137,6 +137,8 @@ export default class Multiline extends PluginController<Config> {
           minPriority: 0,
           maxPriority: 1,
           spacesToNewlines: this.settings.spacesToNewlines,
+          determineLineBreaksAutomatically:
+            this.settings.automaticallyMultilinify,
         }
       );
 
@@ -166,6 +168,9 @@ export default class Multiline extends PluginController<Config> {
           if (key === "Shift-Enter" && this.settings.spacesToNewlines) {
             if (mq) {
               mq.typedText("   ");
+              this.enqueueVerticalifyOperation(
+                mq.__controller.container.querySelector(".dcg-mq-root-block")!
+              );
               setTimeout(() => {
                 this.dequeueAllMultilinifications();
               });
@@ -174,12 +179,12 @@ export default class Multiline extends PluginController<Config> {
             return false;
           }
 
+          // handle arrow nav with spaces2newlines
           if (
             mq &&
             (key.endsWith("Left") || key.endsWith("Right")) &&
             this.settings.spacesToNewlines
           ) {
-            console.log("arrow keys");
             const right = key.endsWith("Right");
             const shift = key.startsWith("Shift");
 
@@ -251,6 +256,7 @@ export default class Multiline extends PluginController<Config> {
     document.addEventListener("mousedown", this.mousedownHandler);
 
     this.afterConfigChange();
+    this.dequeueAllMultilinifications();
 
     this.multilineIntervalID = setInterval(() => {
       if (

--- a/src/plugins/multiline/verticalify.ts
+++ b/src/plugins/multiline/verticalify.ts
@@ -304,7 +304,10 @@ export function verticalify(
     const width = child.getBoundingClientRect().width;
 
     // verticalify child
-    if (width > options.skipWidth || options.spacesToNewlines) {
+    if (
+      (options.determineLineBreaksAutomatically && width > options.skipWidth) ||
+      options.spacesToNewlines
+    ) {
       verticalify(
         child,
         beforeEquals

--- a/src/plugins/multiline/verticalify.ts
+++ b/src/plugins/multiline/verticalify.ts
@@ -115,10 +115,10 @@ export function unverticalify(elem: Element, force?: boolean) {
       delete child.dataset.isMultiline;
 
       // revert linebreaks to original symbol to get rid of <br>
-      if (child.dataset.isLineBreak ?? child.dataset.isManualLineBreak) {
+      if (child.dataset.isAutoLineBreak ?? child.dataset.isManualLineBreak) {
         child.innerHTML = child.dataset.originalSymbol ?? "";
       }
-      delete child.dataset.isLineBreak;
+      delete child.dataset.isAutoLineBreak;
       delete child.dataset.isManualLineBreak;
     }
   }
@@ -175,11 +175,11 @@ export function verticalify(
   for (const child of children) {
     if (
       child instanceof HTMLElement &&
-      (child.dataset.isLineBreak ?? child.dataset.isManualLineBreak)
+      (child.dataset.isAutoLineBreak ?? child.dataset.isManualLineBreak)
     ) {
       context.domManipHandlers.push(() => {
         child.innerHTML = child.dataset.originalSymbol ?? "";
-        delete child.dataset.isLineBreak;
+        delete child.dataset.isAutoLineBreak;
         delete child.dataset.isManualLineBreak;
       });
     }
@@ -218,7 +218,7 @@ export function verticalify(
 
       context.domManipHandlers.push(() => {
         child.style.display = "inline";
-        child.dataset.isLineBreak = "true";
+        child.dataset.isAutoLineBreak = "true";
         child.dataset.originalSymbol = "\u00A0";
         child.innerHTML = "<br />";
         child.style.setProperty("--line-break-indent", `0px`);
@@ -271,7 +271,7 @@ export function verticalify(
             // add a line break to this element
             context.domManipHandlers.push(() => {
               child.style.display = "inline";
-              child.dataset.isLineBreak = "true";
+              child.dataset.isAutoLineBreak = "true";
               child.dataset.originalSymbol = s.symbol;
               child.innerHTML = s.symbol + "<br />";
               child.style.setProperty("--line-break-indent", `${s.indent}px`);

--- a/src/plugins/pillbox-menus/components/Menu.less
+++ b/src/plugins/pillbox-menus/components/Menu.less
@@ -194,3 +194,9 @@
     cursor: pointer !important;
   }
 }
+
+.dsm-settings-indentation {
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 1px solid rgba(0, 0, 0, 0.2);
+}

--- a/src/plugins/pillbox-menus/components/Menu.tsx
+++ b/src/plugins/pillbox-menus/components/Menu.tsx
@@ -8,6 +8,7 @@ import {
   Match,
   IfElse,
   IconButton,
+  Switch,
 } from "#components";
 import { format } from "#i18n";
 import {
@@ -180,22 +181,43 @@ export default class Menu extends Component<{
         {plugin.config.map((item: ConfigItem) => (
           <If predicate={() => item.shouldShow?.(pluginSettings) ?? true}>
             {() =>
-              Match(() => item, {
-                boolean: () =>
-                  booleanOption(this.pm, item, plugin, pluginSettings),
-                string: () =>
-                  stringOption(this.pm, item, plugin, pluginSettings),
-                number: () =>
-                  numberOption(this.pm, item, plugin, pluginSettings),
-                "color-list": () =>
-                  colorListOption(this.pm, item, plugin, pluginSettings),
-              })
+              indentation(
+                item.indentationLevel ?? 0,
+                Match(() => item, {
+                  boolean: () =>
+                    booleanOption(this.pm, item, plugin, pluginSettings),
+                  string: () =>
+                    stringOption(this.pm, item, plugin, pluginSettings),
+                  number: () =>
+                    numberOption(this.pm, item, plugin, pluginSettings),
+                  "color-list": () =>
+                    colorListOption(this.pm, item, plugin, pluginSettings),
+                })
+              )
             }
           </If>
         ))}
       </div>
     );
   }
+}
+
+function indentation(level: number, inner: any) {
+  return (
+    <Switch key={() => level}>
+      {() => {
+        if (level === 0) {
+          return inner;
+        } else {
+          return (
+            <div class="dsm-settings-indentation">
+              {indentation(level - 1, inner)}
+            </div>
+          );
+        }
+      }}
+    </Switch>
+  );
 }
 
 function colorListOption(


### PR DESCRIPTION
Adds a setting to the Multiline plugin that converts all instances of three consecutive spaces `   ` to newlines. Also adds a setting to disable the default automatic multilining behavior. In other words, stuff like this is now possible:
![image](https://github.com/DesModder/DesModder/assets/70352880/fa05ee2b-a16d-43be-a017-2fa8ceef57bc)
