### PR TITLE
Pass around Calc

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -1,5 +1,5 @@
 import { insertElement, replaceElement } from "./preload/replaceElement";
-import window, { Calc } from "#globals";
+import window, { CalcType } from "#globals";
 import {
   plugins,
   pluginList,
@@ -12,6 +12,7 @@ import {
 import { postMessageUp, mapToRecord, recordToMap } from "#utils/messages.ts";
 
 export default class DSM extends TransparentPlugins {
+  cc = this.calc.controller;
   /**
    * pluginsEnabled keeps track of what plugins the user wants enabled,
    * regardless of forceDisabled settings.
@@ -24,7 +25,7 @@ export default class DSM extends TransparentPlugins {
     )
   ) as IDToPluginSettings;
 
-  constructor() {
+  constructor(public calc: CalcType) {
     super();
     // default values
     this.forceDisabled = window.DesModderPreload!.pluginsForceDisabled;
@@ -97,7 +98,7 @@ export default class DSM extends TransparentPlugins {
         this.setPluginEnabled(id, false);
         this.pillboxMenus?.updateMenuView();
         plugin?.afterDisable();
-        Calc.controller.updateViews();
+        this.cc.updateViews();
       }
     }
   }
@@ -112,7 +113,7 @@ export default class DSM extends TransparentPlugins {
       this.setPluginEnabled(id, true);
       res.afterEnable();
       this.pillboxMenus?.updateMenuView();
-      Calc.controller.updateViews();
+      this.cc.updateViews();
     }
   }
 
@@ -220,7 +221,7 @@ export default class DSM extends TransparentPlugins {
     if (plugin) {
       plugin.settings = pluginSettings;
       plugin.afterConfigChange();
-      Calc.controller.updateViews();
+      this.cc.updateViews();
     }
     this.pillboxMenus?.updateMenuView();
   }
@@ -233,11 +234,11 @@ export default class DSM extends TransparentPlugins {
   }
 
   commitStateChange(allowUndo: boolean) {
-    Calc.controller.updateTheComputedWorld();
+    this.cc.updateTheComputedWorld();
     if (allowUndo) {
-      Calc.controller.commitUndoRedoSynchronously({ type: "dsm-blank" });
+      this.cc.commitUndoRedoSynchronously({ type: "dsm-blank" });
     }
-    Calc.controller.updateViews();
+    this.cc.updateViews();
   }
 
   insertElement = insertElement;

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -1,5 +1,5 @@
 import { insertElement, replaceElement } from "./preload/replaceElement";
-import window, { CalcType } from "#globals";
+import window, { type Calc } from "#globals";
 import {
   plugins,
   pluginList,
@@ -25,7 +25,7 @@ export default class DSM extends TransparentPlugins {
     )
   ) as IDToPluginSettings;
 
-  constructor(public calc: CalcType) {
+  constructor(public calc: Calc) {
     super();
     // default values
     this.forceDisabled = window.DesModderPreload!.pluginsForceDisabled;

--- a/src/components/InlineMathInputView.tsx
+++ b/src/components/InlineMathInputView.tsx
@@ -1,22 +1,13 @@
 import { Component, jsx } from "../DCGView";
-import { Calc } from "../globals/window";
 import { InlineMathInputViewGeneral } from "./desmosComponents";
 
-/** InlineMathInputViewGeneral, but fills in defaults
- * readonly: false, controller: Calc.controller */
+/** InlineMathInputViewGeneral, but fills in default `readonly: false` */
 export default class InlineMathInputView extends Component<
-  Omit<
-    ConstructorParameters<typeof InlineMathInputViewGeneral>[0],
-    "readonly" | "controller"
-  >
+  Omit<ConstructorParameters<typeof InlineMathInputViewGeneral>[0], "readonly">
 > {
   template() {
     return (
-      <InlineMathInputViewGeneral
-        {...(this.props as any)}
-        readonly={false}
-        controller={Calc.controller}
-      />
+      <InlineMathInputViewGeneral {...(this.props as any)} readonly={false} />
     );
   }
 }

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -6,7 +6,7 @@ import {
   ComponentTemplate,
   DCGView,
 } from "#DCGView";
-import window, { Calc, Fragile } from "#globals";
+import window, { CalcController, Fragile } from "#globals";
 
 export abstract class CheckboxComponent extends ClassComponent<{
   checked: boolean;
@@ -125,7 +125,7 @@ export abstract class InlineMathInputViewComponent extends ClassComponent<{
   handleFocusChanged?: (isFocused: boolean) => void;
   noFadeout?: boolean;
   readonly: boolean;
-  controller: typeof Calc.controller;
+  controller: CalcController;
 }> {}
 
 /** General InlineMathInputView, without any defaults filled in */
@@ -174,14 +174,14 @@ const ExpressionView = window.DesModderFragile.ExpressionView;
 
 export abstract class IconViewComponent extends ClassComponent<{
   model: ItemModel;
-  controller: typeof Calc.controller;
+  controller: CalcController;
 }> {}
 
 export const ImageIconView = window.DesModderFragile.ImageIconView;
 
 interface ModelAndController {
   model: ExpressionModel;
-  controller: typeof Calc.controller;
+  controller: CalcController;
 }
 
 // <ExpressionIconView ... >

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -290,6 +290,5 @@ interface CalcPrivate {
   ) => void;
 }
 
-type Calc = CalcPrivate & Desmos.Calculator;
-export default Calc;
+export type Calc = CalcPrivate & Desmos.Calculator;
 export type CalcController = Calc["controller"];

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -168,7 +168,7 @@ export interface TopLevelComponents {
   };
 }
 
-interface Toast {
+export interface Toast {
   message: string;
   undoCallback?: () => void;
   toastStyle?: "error";
@@ -292,3 +292,4 @@ interface CalcPrivate {
 
 type Calc = CalcPrivate & Desmos.Calculator;
 export default Calc;
+export type CalcController = Calc["controller"];

--- a/src/globals/index.ts
+++ b/src/globals/index.ts
@@ -1,5 +1,6 @@
 import window from "./window";
 export default window;
 export * from "./Calc";
+export type { default as CalcType } from "./Calc";
 export * from "./models";
 export * from "./window";

--- a/src/globals/index.ts
+++ b/src/globals/index.ts
@@ -1,6 +1,5 @@
 import window from "./window";
 export default window;
 export * from "./Calc";
-export type { default as CalcType } from "./Calc";
 export * from "./models";
 export * from "./window";

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -3,6 +3,7 @@
  * These have more information than the graph state related to getState and setState.
  */
 import { ClassComponent } from "#DCGView";
+import { CalcController } from ".";
 
 interface BasicSetExpression {
   id: string;
@@ -48,6 +49,7 @@ interface ItemModelBase {
     is_inequality: boolean;
     action_value?: Record<string, string>;
   };
+  controller: CalcController;
   dcgView?: ClassComponent;
 }
 
@@ -137,6 +139,7 @@ export interface FolderModel {
   secret?: boolean;
   error?: any;
   index: number;
+  controller: CalcController;
 }
 
 export type ItemModel =

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -13,14 +13,14 @@ import {
   MathQuillConfig,
 } from "../components/desmosComponents";
 import { GenericSettings, PluginID } from "../plugins";
-import CalcType from "./Calc";
+import type { Calc } from "./Calc";
 import { ItemModel } from "./models";
 import { GraphState } from "@desmodder/graph-state";
 
 export interface DWindow extends Window {
   /** @deprecated Don't use Calc directly, unless you're doing global setup for
    * the whole extension. Reference a specific `calc` object instead. */
-  Calc: CalcType;
+  Calc: Calc;
   DesModder: any;
   DSM: DSM;
   DesModderPreload?: {
@@ -61,20 +61,6 @@ interface Mathtools {
 declare let window: DWindow;
 
 export default window;
-
-// defer access of Calc.controller, Calc.observe, etc. to when they are called
-// avoid Calc === undefined but window.Calc !== undefined
-export const Calc = new Proxy(
-  {},
-  {
-    get(_target, prop) {
-      if (window.Calc === undefined) return undefined;
-      if (prop in window.Calc) {
-        return window.Calc[prop as keyof typeof window.Calc];
-      }
-    },
-  }
-) as CalcType;
 
 export const Fragile = new Proxy(
   {},

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -18,6 +18,8 @@ import { ItemModel } from "./models";
 import { GraphState } from "@desmodder/graph-state";
 
 export interface DWindow extends Window {
+  /** @deprecated Don't use Calc directly, unless you're doing global setup for
+   * the whole extension. Reference a specific `calc` object instead. */
   Calc: CalcType;
   DesModder: any;
   DSM: DSM;

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -13,14 +13,10 @@ import {
   MathQuillConfig,
 } from "../components/desmosComponents";
 import { GenericSettings, PluginID } from "../plugins";
-import type { Calc } from "./Calc";
 import { ItemModel } from "./models";
 import { GraphState } from "@desmodder/graph-state";
 
 export interface DWindow extends Window {
-  /** @deprecated Don't use Calc directly, unless you're doing global setup for
-   * the whole extension. Reference a specific `calc` object instead. */
-  Calc: Calc;
   DesModder: any;
   DSM: DSM;
   DesModderPreload?: {

--- a/src/plugins/GLesmos/drawGLesmosSketchToCtx.ts
+++ b/src/plugins/GLesmos/drawGLesmosSketchToCtx.ts
@@ -1,7 +1,7 @@
 import ViewportTransforms from "./ViewportTransforms";
 import { initGLesmosCanvas, GLesmosCanvas } from "./glesmosCanvas";
 import { glesmosError, GLesmosShaderPackage } from "./shaders";
-import { Calc } from "#globals";
+import { CalcController } from "#globals";
 
 let canvas: GLesmosCanvas | null = null;
 
@@ -24,6 +24,7 @@ interface DrawCtx {
  * not just when the plugin is enabled, but also the time when the plugin
  * has just been disabled but the new sketch has not been received */
 export function drawGLesmosSketchToCtx(
+  cc: CalcController,
   drawCtx: DrawCtx,
   { id, branches }: GLesmosSketch
 ) {
@@ -40,10 +41,11 @@ export function drawGLesmosSketchToCtx(
     hasOutlines: glBranches.reduce((a, b) => a && b.hasOutlines, true),
   };
 
-  drawOneGLesmosSketchToCtx?.(drawCtx, compiledGL, id);
+  drawOneGLesmosSketchToCtx?.(cc, drawCtx, compiledGL, id);
 }
 
 function drawOneGLesmosSketchToCtx(
+  cc: CalcController,
   { ctx, projection }: DrawCtx,
   compiledGL: GLesmosShaderPackage,
   id: string
@@ -52,7 +54,7 @@ function drawOneGLesmosSketchToCtx(
   // re-use the old canvas on a re-enable. This is a hacky fix.
   // There should be a way to clean up the GLesmos code
   // to avoid needing this.
-  canvas = canvas ?? initGLesmosCanvas();
+  canvas = canvas ?? initGLesmosCanvas(cc);
 
   const deps = compiledGL.deps.join("\n");
 
@@ -74,7 +76,7 @@ function drawOneGLesmosSketchToCtx(
       ctx.drawImage(canvas?.element, 0, 0);
     }
   } catch (e) {
-    const model = Calc.controller.getItemModel(id);
+    const model = cc.getItemModel(id);
     if (model) model.error = e instanceof Error ? e.message : e;
   }
 }

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -141,8 +141,7 @@ if (!$ee.branches || !$ee.branches.length) return;
 
 ```js
 __guard__
-// allow-ids: of
-DesModder.drawGLesmosSketchToCtx?.($drawCtx, $sketch);
+DesModder.drawGLesmosSketchToCtx?.(window.Calc.controller, $drawCtx, $sketch);
 ```
 
 ## Pass GLesmos flag to worker

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -9,7 +9,7 @@ import {
   glesmosGetFastFillShader,
   setUniform,
 } from "./shaders";
-import window, { Calc } from "#globals";
+import window, { CalcController } from "#globals";
 import { format } from "#i18n";
 
 export type GLesmosCanvas = ReturnType<typeof initGLesmosCanvas>;
@@ -29,7 +29,7 @@ const FULLSCREEN_QUAD = new Float32Array([
   -1, 1, 1, 1, 1, -1, -1, 1, 1, -1, -1, -1,
 ]);
 
-export function initGLesmosCanvas() {
+export function initGLesmosCanvas(cc: CalcController) {
   //= ================ INIT ELEMENTS =======================
 
   const c: HTMLCanvasElement = document.createElement("canvas");
@@ -40,7 +40,7 @@ export function initGLesmosCanvas() {
     antialias: true,
   }) as WebGL2RenderingContext;
   if (!gl) {
-    Calc.controller._showToast({
+    cc._showToast({
       // eslint-disable-next-line rulesdir/no-format-in-ts
       message: format("GLesmos-no-support"),
     });

--- a/src/plugins/GLesmos/index.ts
+++ b/src/plugins/GLesmos/index.ts
@@ -2,7 +2,6 @@ import { Inserter, PluginController } from "../PluginController";
 import { ConfirmLines } from "./components/ConfirmLines";
 import { GLesmosToggle } from "./components/GLesmosToggle";
 import "./glesmos.less";
-import { Calc } from "#globals";
 
 export default class GLesmos extends PluginController {
   static id = "GLesmos" as const;
@@ -24,14 +23,14 @@ export default class GLesmos extends PluginController {
       .map((v) => v.id);
     if (glesmosIDs && glesmosIDs.length > 0) {
       glesmosIDs.map((id) => this.toggleExpr(id));
-      killWorker();
+      this.killWorker();
     }
   }
 
   canBeGLesmos(id: string) {
     let model;
     return !!(
-      (model = Calc.controller.getItemModel(id)) &&
+      (model = this.cc.getItemModel(id)) &&
       model.type === "expression" &&
       model.formula &&
       model.formula.expression_type === "IMPLICIT"
@@ -53,12 +52,12 @@ export default class GLesmos extends PluginController {
   forceWorkerUpdate(id: string) {
     // force the worker to revisit the expression
     this.toggleExpr(id);
-    killWorker();
+    this.killWorker();
   }
 
   /** Returns boolean or undefined (representing "worker has not told me yet") */
   isInequality(id: string) {
-    const model = Calc.controller.getItemModel(id);
+    const model = this.cc.getItemModel(id);
     if (model?.type !== "expression") return false;
     return !!model.formula?.is_inequality;
   }
@@ -82,13 +81,13 @@ export default class GLesmos extends PluginController {
    * un-hidden
    */
   toggleExpr(id: string) {
-    const model = Calc.controller.getItemModel(id);
+    const model = this.cc.getItemModel(id);
     if (!model || model.type !== "expression" || !model.shouldGraph) return;
-    Calc.controller.dispatch({
+    this.cc.dispatch({
       type: "toggle-item-hidden",
       id,
     });
-    Calc.controller.dispatch({
+    this.cc.dispatch({
       type: "toggle-item-hidden",
       id,
     });
@@ -105,8 +104,8 @@ export default class GLesmos extends PluginController {
   ): Inserter {
     return () => GLesmosToggle(this, id, ToggleView, allowInequality);
   }
-}
 
-function killWorker() {
-  Calc.controller.evaluator.workerPoolConnection.killWorker();
+  killWorker() {
+    this.cc.evaluator.workerPoolConnection.killWorker();
+  }
 }

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -7,6 +7,8 @@ export class PluginController<
   static descriptionLearnMore?: string = undefined;
   static forceEnabled?: boolean = undefined;
   static config: readonly ConfigItem[] | undefined = undefined;
+  calc = this.dsm.calc;
+  cc = this.calc.controller;
 
   constructor(readonly dsm: DSM, public settings: Settings) {}
 

--- a/src/plugins/builtin-settings/index.ts
+++ b/src/plugins/builtin-settings/index.ts
@@ -1,19 +1,8 @@
 import { PluginController } from "../PluginController";
 import { Config, configList } from "./config";
-import { Calc } from "#globals";
 import { getQueryParams } from "#utils/depUtils.ts";
 
 const managedKeys = configList.map((e) => e.key);
-
-function updateSettings(config: Config) {
-  let { graphpaper, zoomButtons } = config;
-  zoomButtons &&= graphpaper;
-  // Deal with zoomButtons needing to be off before graphpaper is disabled
-  // But graphpaper needs to be on before zoomButtons is enabled.
-  if (graphpaper) Calc.updateSettings({ graphpaper });
-  if (!zoomButtons) Calc.updateSettings({ zoomButtons });
-  Calc.updateSettings({ ...config, zoomButtons, graphpaper });
-}
 
 export default class BuiltinSettings extends PluginController<Config> {
   static id = "builtin-settings" as const;
@@ -27,7 +16,7 @@ export default class BuiltinSettings extends PluginController<Config> {
     for (const key of managedKeys) {
       this.initialSettings[key] =
         (
-          Calc.settings as typeof Calc.settings & {
+          this.calc.settings as typeof this.calc.settings & {
             advancedStyling: boolean;
             authorFeatures: boolean;
           }
@@ -42,14 +31,25 @@ export default class BuiltinSettings extends PluginController<Config> {
         queryConfig[key] = false;
       }
     }
-    updateSettings(this.settings);
+    this.updateSettings(this.settings);
   }
 
   afterDisable() {
-    if (this.initialSettings !== null) updateSettings(this.initialSettings);
+    if (this.initialSettings !== null)
+      this.updateSettings(this.initialSettings);
   }
 
   afterConfigChange() {
-    updateSettings(this.settings);
+    this.updateSettings(this.settings);
+  }
+
+  updateSettings(config: Config) {
+    let { graphpaper, zoomButtons } = config;
+    zoomButtons &&= graphpaper;
+    // Deal with zoomButtons needing to be off before graphpaper is disabled
+    // But graphpaper needs to be on before zoomButtons is enabled.
+    if (graphpaper) this.calc.updateSettings({ graphpaper });
+    if (!zoomButtons) this.calc.updateSettings({ zoomButtons });
+    this.calc.updateSettings({ ...config, zoomButtons, graphpaper });
   }
 }

--- a/src/plugins/compact-view/index.ts
+++ b/src/plugins/compact-view/index.ts
@@ -2,7 +2,6 @@ import { PluginController } from "../PluginController";
 import "./compact.css";
 import "./compact.less";
 import { Config, configList } from "./config";
-import { Calc } from "#globals";
 
 function toggleBodyClass(className: string, bool: boolean) {
   document.body.classList.toggle(className, bool);
@@ -95,7 +94,7 @@ export default class CompactView extends PluginController<Config> {
   dispatcherID: string | undefined;
 
   afterEnable() {
-    this.dispatcherID = Calc.controller.dispatcher.register(() => {
+    this.dispatcherID = this.cc.dispatcher.register(() => {
       if (!this.settings.hideEvaluations) return;
       this.updateHiddenEvaluations();
     });
@@ -104,8 +103,7 @@ export default class CompactView extends PluginController<Config> {
   }
 
   afterDisable() {
-    if (this.dispatcherID)
-      Calc.controller.dispatcher.unregister(this.dispatcherID);
+    if (this.dispatcherID) this.cc.dispatcher.unregister(this.dispatcherID);
     document.body.classList.remove("compact-view-enabled");
   }
 }

--- a/src/plugins/custom-mathquill-config/index.ts
+++ b/src/plugins/custom-mathquill-config/index.ts
@@ -2,7 +2,7 @@
 import { Config, configList } from "./config";
 import "./custom-mathquill-config.less";
 import { MathQuillConfig, MathQuillField } from "#components";
-import { Calc, DWindow } from "#globals";
+import { DWindow } from "#globals";
 import { PluginController } from "#plugins/PluginController.ts";
 
 const defaultConfig: MathQuillConfig = {
@@ -21,25 +21,19 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
   static enabledByDefault = false;
   static config = configList;
 
-  oldConfig = Calc.controller.getMathquillConfig;
+  oldConfig = this.cc.getMathquillConfig;
   doAutoCommandInjections = false;
   autoCommandInjections =
     " gamma Gamma delta Delta epsilon zeta eta Theta iota kappa lambda Lambda mu Xi xi Pi rho sigma Sigma upsilon Upsilon Phi chi psi Psi omega Omega";
 
   updateConfig(config: Config) {
-    Calc.controller.rootElt.classList.toggle(
-      "commaizer",
-      config.commaDelimiter
-    );
+    this.cc.rootElt.classList.toggle("commaizer", config.commaDelimiter);
 
-    Calc.controller.rootElt.classList.toggle(
-      "less-f-spacing",
-      config.lessFSpacing
-    );
+    this.cc.rootElt.classList.toggle("less-f-spacing", config.lessFSpacing);
 
     this.doAutoCommandInjections = config.extendedGreek;
 
-    Calc.controller.rootElt.style.setProperty(
+    this.cc.rootElt.style.setProperty(
       "--delimiter-override",
       `"${CSS.escape(config.delimiterOverride)}"`
     );
@@ -75,8 +69,8 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
   }
 
   afterEnable() {
-    Calc.controller.getMathquillConfig = (e) => {
-      const currentConfig = this.oldConfig.call(Calc.controller, e);
+    this.cc.getMathquillConfig = (e) => {
+      const currentConfig = this.oldConfig.call(this.cc, e);
       if (this.doAutoCommandInjections) {
         currentConfig.autoCommands += this.autoCommandInjections;
       }
@@ -88,9 +82,9 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
 
   afterDisable() {
     this.doAutoCommandInjections = false;
-    Calc.controller.rootElt.classList.remove("commaizer");
+    this.cc.rootElt.classList.remove("commaizer");
     (window as any as DWindow).Desmos.MathQuill.config(defaultConfig);
-    Calc.controller.getMathquillConfig = this.oldConfig;
+    this.cc.getMathquillConfig = this.oldConfig;
     this.updateAllMathquill();
   }
 

--- a/src/plugins/debug-mode/index.ts
+++ b/src/plugins/debug-mode/index.ts
@@ -1,5 +1,4 @@
 import { PluginController } from "../PluginController";
-import { Calc } from "#globals";
 
 export default class DebugMode extends PluginController {
   static id = "debug-mode" as const;
@@ -8,12 +7,12 @@ export default class DebugMode extends PluginController {
   afterEnable() {
     // The displayed indexes are stored in some state somewhere, so
     // update the state first before updating views
-    Calc.controller.updateTheComputedWorld();
+    this.cc.updateTheComputedWorld();
     this.dsm.textMode?.updateDebugMode();
   }
 
   afterDisable() {
-    Calc.controller.updateTheComputedWorld();
+    this.cc.updateTheComputedWorld();
     this.dsm.textMode?.updateDebugMode();
   }
 }

--- a/src/plugins/duplicate-hotkey/index.ts
+++ b/src/plugins/duplicate-hotkey/index.ts
@@ -1,5 +1,4 @@
 import { PluginController } from "../PluginController";
-import { Calc } from "#globals";
 import { keys } from "#utils/depUtils.ts";
 
 export default class DuplicateHotkey extends PluginController {
@@ -11,14 +10,14 @@ export default class DuplicateHotkey extends PluginController {
   onKeydown = this._onKeydown.bind(this);
   _onKeydown(e: KeyboardEvent) {
     if (e.ctrlKey && keys.lookupChar(e) === "Q") {
-      const selectedItem = Calc.controller.getSelectedItem();
+      const selectedItem = this.cc.getSelectedItem();
       if (!selectedItem) return;
-      Calc.controller.dispatch({
+      this.cc.dispatch({
         type:
           selectedItem.type === "folder"
             ? "duplicate-folder"
             : "duplicate-expression",
-        id: Calc.selectedExpressionId,
+        id: this.calc.selectedExpressionId,
       });
     }
   }

--- a/src/plugins/find-replace/ReplaceBar.tsx
+++ b/src/plugins/find-replace/ReplaceBar.tsx
@@ -2,7 +2,6 @@ import FindReplace from ".";
 import "./ReplaceBar.less";
 import { Component, jsx } from "#DCGView";
 import { MathQuillView } from "#components";
-import { Calc } from "#globals";
 import { format } from "#i18n";
 import { autoOperatorNames } from "#utils/depUtils.ts";
 
@@ -64,7 +63,7 @@ export default class ReplaceBar extends Component<{
   }
 
   closeReplace() {
-    Calc.controller.dispatch({
+    this.fr.cc.dispatch({
       type: "close-expression-search",
     });
   }

--- a/src/plugins/find-replace/backend.ts
+++ b/src/plugins/find-replace/backend.ts
@@ -1,4 +1,4 @@
-import { CalcType } from "#globals";
+import type { Calc } from "#globals";
 import { satisfiesType } from "#parsing/nodeTypes.ts";
 import { Identifier } from "#parsing/parsenode.ts";
 import traverse, { Path } from "#parsing/traverse.ts";
@@ -34,7 +34,7 @@ export const nestedKeyContainers = [
 
 export const nestedKeys = ["max", "min", "step"] as const;
 
-function replace(calc: CalcType, replaceLatex: (s: string) => string) {
+function replace(calc: Calc, replaceLatex: (s: string) => string) {
   // replaceString is applied to stuff like labels
   // middle group in regex accounts for 1 layer of braces, sufficient for `Print ${a+2}`
   function replaceString(s: string) {
@@ -169,7 +169,7 @@ function getReplacements(
   return [];
 }
 
-export function refactor(calc: CalcType, from: string, to: string) {
+export function refactor(calc: Calc, from: string, to: string) {
   const fromParsed = parseDesmosLatex(from.trim());
   if (satisfiesType(fromParsed, "Identifier")) {
     // trim `from` to prevent inputs such as "  a" messing up matches that depend on `from` itself.

--- a/src/plugins/find-replace/index.ts
+++ b/src/plugins/find-replace/index.ts
@@ -1,7 +1,7 @@
 import { PluginController } from "../PluginController";
 import View from "./View";
 import { refactor } from "./backend";
-import { Calc, Console } from "#globals";
+import { Console } from "#globals";
 
 export default class FindReplace extends PluginController {
   static id = "find-and-replace" as const;
@@ -11,24 +11,22 @@ export default class FindReplace extends PluginController {
   view = new View();
 
   afterEnable() {
-    if (Calc.controller.getExpressionSearchOpen()) {
+    if (this.cc.getExpressionSearchOpen()) {
       this.tryInitView();
     }
-    this.dispatchListenerID = Calc.controller.dispatcher.register(
-      ({ type }) => {
-        if (type === "open-expression-search") {
-          this.tryInitView();
-        } else if (type === "close-expression-search") {
-          this.view.destroyView();
-        }
-        // may want to listen to update-expression-search-str
+    this.dispatchListenerID = this.cc.dispatcher.register(({ type }) => {
+      if (type === "open-expression-search") {
+        this.tryInitView();
+      } else if (type === "close-expression-search") {
+        this.view.destroyView();
       }
-    );
+      // may want to listen to update-expression-search-str
+    });
   }
 
   afterDisable() {
     if (this.dispatchListenerID !== undefined)
-      Calc.controller.dispatcher.unregister(this.dispatchListenerID);
+      this.cc.dispatcher.unregister(this.dispatchListenerID);
     this.view.destroyView();
   }
 
@@ -53,11 +51,11 @@ export default class FindReplace extends PluginController {
   }
 
   refactorAll() {
-    refactor(Calc.controller.getExpressionSearchStr(), this.replaceLatex);
+    refactor(this.calc, this.cc.getExpressionSearchStr(), this.replaceLatex);
   }
 
   focusSearch() {
-    Calc.controller.dispatch({
+    this.cc.dispatch({
       type: "set-focus-location",
       location: { type: "search-expressions" },
     });

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -11,9 +11,8 @@ import { pendingIntellisenseTimeouts, setIntellisenseTimeout } from "./utils";
 import { JumpToDefinitionMenuInfo, View } from "./view";
 import { DCGView, MountedComponent, unmountFromNode } from "#DCGView";
 import { MathQuillField, MathQuillView } from "#components";
-import { ItemModel, TextModel, Calc } from "#globals";
+import { ItemModel, TextModel } from "#globals";
 import { PluginController } from "#plugins/PluginController.ts";
-import { getMetadata } from "#plugins/manage-metadata/sync.ts";
 import { hookIntoOverrideKeystroke } from "#utils/listenerHelpers.ts";
 import { isDescendant } from "#utils/utils.ts";
 
@@ -47,21 +46,6 @@ export function getMQCursorPosition(focusedMQ: MathQuillField) {
   return getController(
     focusedMQ
   ).cursor?.cursorElement?.getBoundingClientRect();
-}
-
-export function getSelectedExpressionID(): string | undefined {
-  return Calc.controller.getSelectedItem()?.id;
-}
-
-export function getExpressionIndex(id: string): number | undefined {
-  return Calc.controller.listModel.__itemIdToModel[id]?.index;
-}
-export function getExpressionLatex(id: string): string | undefined {
-  return (
-    Calc.controller.listModel.__itemIdToModel[id] as ItemModel & {
-      latex: string | undefined;
-    }
-  ).latex;
 }
 
 export default class Intellisense extends PluginController<{
@@ -101,7 +85,7 @@ export default class Intellisense extends PluginController<{
   partialFunctionCallIdent: BoundIdentifierFunction | undefined;
   partialFunctionCallDoc: string | undefined;
 
-  intellisenseState = new IntellisenseState(getMetadata());
+  intellisenseState = new IntellisenseState(this.calc);
 
   canHaveIntellisense = false;
 
@@ -111,6 +95,22 @@ export default class Intellisense extends PluginController<{
   jumpToDefIndex: number = 0;
 
   specialIdentifierNames: string[] = [];
+
+  getSelectedExpressionID(): string | undefined {
+    return this.cc.getSelectedItem()?.id;
+  }
+
+  getExpressionIndex(id: string): number | undefined {
+    return this.cc.listModel.__itemIdToModel[id]?.index;
+  }
+
+  getExpressionLatex(id: string): string | undefined {
+    return (
+      this.cc.listModel.__itemIdToModel[id] as ItemModel & {
+        latex: string | undefined;
+      }
+    ).latex;
+  }
 
   async waitForCurrentIntellisenseTimeoutsToFinish() {
     await new Promise<void>((resolve) => {
@@ -157,7 +157,7 @@ export default class Intellisense extends PluginController<{
 
       // if the user is in a partial function call,
       // find its documentation if it exists
-      const models = Calc.controller.getAllItemModels();
+      const models = this.cc.getAllItemModels();
       this.partialFunctionCallDoc = (
         models.find((current, i) => {
           if (
@@ -196,7 +196,7 @@ export default class Intellisense extends PluginController<{
               !this.intellisenseState.getIdentDoc(g)?.includes("@private") &&
               // don't include private expressions based on per-folder docs
               // unless you're in the same folder
-              (Calc.controller.getSelectedItem()?.folderId ===
+              (this.cc.getSelectedItem()?.folderId ===
                 this.intellisenseState.getIdentFolderId(g) ||
                 !this.intellisenseState
                   .getIdentFolderDoc(g)
@@ -223,12 +223,12 @@ export default class Intellisense extends PluginController<{
         );
 
         // sort the intellisense options so that closer ones appear first
-        const listModel = Calc.controller.listModel;
+        const listModel = this.cc.listModel;
         const orderMap = new Map<string, number>();
         for (let i = 0; i < listModel.drawOrder.length; i++) {
           orderMap.set(listModel.drawOrder[i], i);
         }
-        const myindex = Calc.controller.getSelectedItem()?.index;
+        const myindex = this.cc.getSelectedItem()?.index;
         if (myindex !== undefined) {
           this.intellisenseOpts.sort((a, b) => {
             const aMin = Math.min(
@@ -346,10 +346,15 @@ export default class Intellisense extends PluginController<{
 
   focusInHandler = () => {
     setIntellisenseTimeout(() => {
-      if (Calc.focusedMathQuill && this.specialIdentifierNames.length === 0) {
+      if (
+        this.calc.focusedMathQuill &&
+        this.specialIdentifierNames.length === 0
+      ) {
         this.specialIdentifierNames = [
-          ...Object.keys(Calc.focusedMathQuill.mq.__options.autoOperatorNames),
-          ...Object.keys(Calc.focusedMathQuill.mq.__options.autoCommands),
+          ...Object.keys(
+            this.calc.focusedMathQuill.mq.__options.autoOperatorNames
+          ),
+          ...Object.keys(this.calc.focusedMathQuill.mq.__options.autoCommands),
         ];
       }
 
@@ -357,10 +362,10 @@ export default class Intellisense extends PluginController<{
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const self = this;
 
-      if (Calc.focusedMathQuill) {
+      if (this.calc.focusedMathQuill) {
         // monkeypatch in a function to wrap overrideKeystroke
         const remove = hookIntoOverrideKeystroke(
-          Calc.focusedMathQuill.mq,
+          this.calc.focusedMathQuill.mq,
           function (key: string, _: KeyboardEvent) {
             if (
               // don't bother overriding keystroke if intellisense is offline
@@ -536,11 +541,11 @@ export default class Intellisense extends PluginController<{
     this.jumpToDefState = undefined;
 
     // jump to definition
-    Calc.controller.dispatch({
+    this.cc.dispatch({
       type: "set-selected-id",
       id,
     });
-    Calc.controller.dispatch({
+    this.cc.dispatch({
       type: "set-focus-location",
       location: {
         type: "expression",
@@ -550,9 +555,9 @@ export default class Intellisense extends PluginController<{
 
     // if we jumped to an expression with a folder, open the folder
     // and then re-scroll the expression into view
-    const model = Calc.controller.getItemModel(id);
+    const model = this.cc.getItemModel(id);
     if (model && model.type !== "folder" && model.folderId) {
-      Calc.controller.dispatch({
+      this.cc.dispatch({
         type: "set-folder-collapsed",
         id: model.folderId,
         isCollapsed: false,
@@ -580,7 +585,7 @@ export default class Intellisense extends PluginController<{
     if (identDsts.length === 1) {
       this.jumpToDefinitionById(identDsts[0].exprId);
     } else if (identDsts.length > 1) {
-      Calc.controller.dispatch({
+      this.cc.dispatch({
         type: "set-none-selected",
       });
 
@@ -592,8 +597,8 @@ export default class Intellisense extends PluginController<{
           return {
             ident: dst,
             sourceExprId: dst.exprId,
-            sourceExprIndex: getExpressionIndex(dst.exprId) ?? 0,
-            sourceExprLatex: getExpressionLatex(dst.exprId) ?? "",
+            sourceExprIndex: this.getExpressionIndex(dst.exprId) ?? 0,
+            sourceExprLatex: this.getExpressionLatex(dst.exprId) ?? "",
           };
         }),
       };
@@ -634,11 +639,11 @@ export default class Intellisense extends PluginController<{
     this.updateIntellisense();
     this.view?.update();
 
-    const selectedid = getSelectedExpressionID();
+    const selectedid = this.getSelectedExpressionID();
 
     // force calc to realize something's changed
     if (this.intellisenseReturnMQ && selectedid) {
-      Calc.controller.dispatch({
+      this.cc.dispatch({
         type: "set-item-latex",
         id: selectedid,
         latex: this.intellisenseReturnMQ.latex(),
@@ -684,10 +689,10 @@ export default class Intellisense extends PluginController<{
       plugin: () => this,
     });
 
-    this.dispatcher = Calc.controller.dispatcher.register((e) => {
+    this.dispatcher = this.cc.dispatcher.register((e) => {
       if (e.type === "set-focus-location" || e.type === "set-none-selected") {
         setIntellisenseTimeout(() => {
-          if (!Calc.focusedMathQuill) {
+          if (!this.calc.focusedMathQuill) {
             this.canHaveIntellisense = false;
             this.view?.update();
           }
@@ -704,7 +709,7 @@ export default class Intellisense extends PluginController<{
 
       if (e.type === "set-note-text") {
         this.updateCSSForDocstringExpression(
-          Calc.controller.getSelectedItem() as TextModel | undefined
+          this.cc.getSelectedItem() as TextModel | undefined
         );
       }
 
@@ -749,7 +754,7 @@ export default class Intellisense extends PluginController<{
   }
 
   updateCSSForAllDocstringExpressions() {
-    for (const m of Calc.controller.getAllItemModels()) {
+    for (const m of this.cc.getAllItemModels()) {
       if (m.type !== "text") continue;
       this.updateCSSForDocstringExpression(m);
     }
@@ -786,6 +791,6 @@ export default class Intellisense extends PluginController<{
       document.body.removeChild(this.intellisenseMountPoint);
     }
 
-    if (this.dispatcher) Calc.controller.dispatcher.unregister(this.dispatcher);
+    if (this.dispatcher) this.cc.dispatcher.unregister(this.dispatcher);
   }
 }

--- a/src/plugins/intellisense/state.tsx
+++ b/src/plugins/intellisense/state.tsx
@@ -1,6 +1,8 @@
 import { BoundIdentifier } from ".";
-import { parseRootLatex } from "../../../text-mode-core";
-import { getTextModeConfig } from "../text-mode";
+import {
+  buildConfigFromGlobals,
+  parseRootLatex,
+} from "../../../text-mode-core";
 import { mapAugAST } from "./latex-parsing";
 import { CalcType, ItemModel } from "#globals";
 import { rootKeys } from "#plugins/find-replace/backend.ts";
@@ -57,7 +59,7 @@ export class IntellisenseState {
     return this.cc.getItemModel(ident.exprId)?.folderId;
   }
 
-  readonly cfg = getTextModeConfig();
+  readonly cfg = buildConfigFromGlobals(Desmos, this.calc);
 
   constructor(public calc: CalcType) {
     this.metadata = getMetadata(calc);

--- a/src/plugins/intellisense/state.tsx
+++ b/src/plugins/intellisense/state.tsx
@@ -4,7 +4,7 @@ import {
   parseRootLatex,
 } from "../../../text-mode-core";
 import { mapAugAST } from "./latex-parsing";
-import { CalcType, ItemModel } from "#globals";
+import type { Calc, ItemModel } from "#globals";
 import { rootKeys } from "#plugins/find-replace/backend.ts";
 import Metadata from "metadata/interface";
 import { get } from "#utils/utils.ts";
@@ -61,7 +61,7 @@ export class IntellisenseState {
 
   readonly cfg = buildConfigFromGlobals(Desmos, this.calc);
 
-  constructor(public calc: CalcType) {
+  constructor(public calc: Calc) {
     this.metadata = getMetadata(calc);
     this.cc.dispatcher.register((e) => {
       if (e.type === "on-evaluator-changes") {

--- a/src/plugins/manage-metadata/index.ts
+++ b/src/plugins/manage-metadata/index.ts
@@ -4,7 +4,6 @@ import GraphMetadata, {
 } from "#metadata/interface.ts";
 import { getBlankMetadata, changeExprInMetadata } from "#metadata/manage.ts";
 import { getMetadata, setMetadata } from "./sync";
-import { Calc } from "#globals";
 
 export default class ManageMetadata extends PluginController {
   static id = "manage-metadata" as const;
@@ -13,7 +12,7 @@ export default class ManageMetadata extends PluginController {
   graphMetadata: GraphMetadata = getBlankMetadata();
 
   afterEnable() {
-    Calc.observeEvent("change.dsm-main-controller", () => {
+    this.calc.observeEvent("change.dsm-main-controller", () => {
       this.checkForMetadataChange();
     });
     this.checkForMetadataChange();
@@ -26,7 +25,7 @@ export default class ManageMetadata extends PluginController {
   }
 
   checkForMetadataChange() {
-    const newMetadata = getMetadata();
+    const newMetadata = getMetadata(this.calc);
     if (!this.dsm.glesmos) {
       if (
         Object.entries(newMetadata.expressions).some(
@@ -35,7 +34,7 @@ export default class ManageMetadata extends PluginController {
         )
       ) {
         // list of glesmos expressions changed
-        Calc.controller._showToast({
+        this.cc._showToast({
           message:
             "Enable the GLesmos plugin to improve the performance of some implicits in this graph",
         });
@@ -47,7 +46,7 @@ export default class ManageMetadata extends PluginController {
 
   _updateExprMetadata(id: string, obj: Partial<MetadataExpression>) {
     changeExprInMetadata(this.graphMetadata, id, obj);
-    setMetadata(this.graphMetadata);
+    setMetadata(this.calc, this.graphMetadata);
   }
 
   duplicateMetadata(toID: string, fromID: string) {

--- a/src/plugins/manage-metadata/sync.ts
+++ b/src/plugins/manage-metadata/sync.ts
@@ -1,7 +1,7 @@
 import Metadata from "#metadata/interface.ts";
 import migrateToLatest from "#metadata/migrate.ts";
 import { getBlankMetadata, isBlankMetadata } from "#metadata/manage.ts";
-import { Calc, Console, FolderModel, TextModel } from "#globals";
+import { CalcType, Console, FolderModel, TextModel } from "#globals";
 import { List } from "#utils/depUtils.ts";
 
 /*
@@ -27,12 +27,12 @@ The text content of dsm-metadata is in JSON format
 const ID_METADATA = "dsm-metadata";
 const ID_METADATA_FOLDER = "dsm-metadata-folder";
 
-function getMetadataExpr() {
-  return Calc.controller.getItemModel(ID_METADATA);
+function getMetadataExpr(calc: CalcType) {
+  return calc.controller.getItemModel(ID_METADATA);
 }
 
-export function getMetadata() {
-  const expr = getMetadataExpr();
+export function getMetadata(calc: CalcType) {
+  const expr = getMetadataExpr(calc);
   if (expr === undefined) return getBlankMetadata();
   if (expr.type === "text" && expr.text !== undefined) {
     const parsed = JSON.parse(expr.text);
@@ -43,23 +43,26 @@ export function getMetadata() {
 }
 
 function addItemToEnd(
-  state: Omit<FolderModel, "index"> | Omit<TextModel, "index">
+  calc: CalcType,
+  state:
+    | Omit<FolderModel, "index" | "controller">
+    | Omit<TextModel, "index" | "controller">
 ) {
-  Calc.controller._addItemToEndFromAPI(Calc.controller.createItemModel(state));
+  calc.controller._addItemToEndFromAPI(calc.controller.createItemModel(state));
 }
 
-export function setMetadata(metadata: Metadata) {
-  cleanMetadata(metadata);
-  List.removeItemById(Calc.controller.listModel, ID_METADATA);
-  List.removeItemById(Calc.controller.listModel, ID_METADATA_FOLDER);
+export function setMetadata(calc: CalcType, metadata: Metadata) {
+  cleanMetadata(calc, metadata);
+  List.removeItemById(calc.controller.listModel, ID_METADATA);
+  List.removeItemById(calc.controller.listModel, ID_METADATA_FOLDER);
   if (!isBlankMetadata(metadata)) {
-    addItemToEnd({
+    addItemToEnd(calc, {
       type: "folder",
       id: ID_METADATA_FOLDER,
       secret: true,
       title: "DesModder Metadata",
     });
-    addItemToEnd({
+    addItemToEnd(calc, {
       type: "text",
       id: ID_METADATA,
       folderId: ID_METADATA_FOLDER,
@@ -68,10 +71,10 @@ export function setMetadata(metadata: Metadata) {
   }
 }
 
-function cleanMetadata(metadata: Metadata) {
-  /* Mutates metadata by removing expressions that no longer exist */
+/* Mutate metadata by removing expressions that no longer exist */
+function cleanMetadata(calc: CalcType, metadata: Metadata) {
   for (const id in metadata.expressions) {
-    if (Calc.controller.getItemModel(id) === undefined) {
+    if (calc.controller.getItemModel(id) === undefined) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete metadata.expressions[id];
     }

--- a/src/plugins/manage-metadata/sync.ts
+++ b/src/plugins/manage-metadata/sync.ts
@@ -1,7 +1,7 @@
 import Metadata from "#metadata/interface.ts";
 import migrateToLatest from "#metadata/migrate.ts";
 import { getBlankMetadata, isBlankMetadata } from "#metadata/manage.ts";
-import { CalcType, Console, FolderModel, TextModel } from "#globals";
+import { type Calc, Console, FolderModel, TextModel } from "#globals";
 import { List } from "#utils/depUtils.ts";
 
 /*
@@ -27,11 +27,11 @@ The text content of dsm-metadata is in JSON format
 const ID_METADATA = "dsm-metadata";
 const ID_METADATA_FOLDER = "dsm-metadata-folder";
 
-function getMetadataExpr(calc: CalcType) {
+function getMetadataExpr(calc: Calc) {
   return calc.controller.getItemModel(ID_METADATA);
 }
 
-export function getMetadata(calc: CalcType) {
+export function getMetadata(calc: Calc) {
   const expr = getMetadataExpr(calc);
   if (expr === undefined) return getBlankMetadata();
   if (expr.type === "text" && expr.text !== undefined) {
@@ -43,7 +43,7 @@ export function getMetadata(calc: CalcType) {
 }
 
 function addItemToEnd(
-  calc: CalcType,
+  calc: Calc,
   state:
     | Omit<FolderModel, "index" | "controller">
     | Omit<TextModel, "index" | "controller">
@@ -51,7 +51,7 @@ function addItemToEnd(
   calc.controller._addItemToEndFromAPI(calc.controller.createItemModel(state));
 }
 
-export function setMetadata(calc: CalcType, metadata: Metadata) {
+export function setMetadata(calc: Calc, metadata: Metadata) {
   cleanMetadata(calc, metadata);
   List.removeItemById(calc.controller.listModel, ID_METADATA);
   List.removeItemById(calc.controller.listModel, ID_METADATA_FOLDER);
@@ -72,7 +72,7 @@ export function setMetadata(calc: CalcType, metadata: Metadata) {
 }
 
 /* Mutate metadata by removing expressions that no longer exist */
-function cleanMetadata(calc: CalcType, metadata: Metadata) {
+function cleanMetadata(calc: Calc, metadata: Metadata) {
   for (const id in metadata.expressions) {
     if (calc.controller.getItemModel(id) === undefined) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -245,13 +245,17 @@ export default class Multiline extends PluginController<Config> {
       }
     });
 
-    this.customDispatcherID = registerCustomDispatchOverridingHandler((evt) => {
-      if (evt.type === "on-special-key-pressed") {
-        if (evt.key === "Up" || evt.key === "Down") {
-          if (!this.doMultilineVerticalNav(evt.key)) return false;
+    this.customDispatcherID = registerCustomDispatchOverridingHandler(
+      this.calc,
+      (evt) => {
+        if (evt.type === "on-special-key-pressed") {
+          if (evt.key === "Up" || evt.key === "Down") {
+            if (!this.doMultilineVerticalNav(evt.key)) return false;
+          }
         }
-      }
-    }, 0);
+      },
+      0
+    );
   }
 
   afterDisable() {
@@ -267,7 +271,10 @@ export default class Multiline extends PluginController<Config> {
       clearInterval(this.multilineIntervalID);
 
     if (this.customDispatcherID)
-      deregisterCustomDispatchOverridingHandler(this.customDispatcherID);
+      deregisterCustomDispatchOverridingHandler(
+        this.calc,
+        this.customDispatcherID
+      );
 
     for (const remover of this.customHandlerRemovers) {
       remover();

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -3,7 +3,7 @@ import { Config, configList } from "./config";
 import "./multiline.less";
 import { CollapseMode, unverticalify, verticalify } from "./verticalify";
 import { MathQuillField, MathQuillView } from "#components";
-import { Calc, DispatchedEvent } from "#globals";
+import { DispatchedEvent } from "#globals";
 import {
   getController,
   mqKeystroke,
@@ -90,7 +90,7 @@ export default class Multiline extends PluginController<Config> {
 
       const minWidth =
         ((window.innerWidth * this.settings.widthBeforeMultiline) / 100) *
-        (Calc.controller.isNarrow() ? 3 : 1);
+        (this.cc.isNarrow() ? 3 : 1);
 
       // settings for where and how to put line breaks
       const domManipHandlers: (() => void)[] = [];
@@ -156,9 +156,9 @@ export default class Multiline extends PluginController<Config> {
       this.dequeueAllMultilinifications();
     }
 
-    if (Calc.focusedMathQuill) {
+    if (this.calc.focusedMathQuill) {
       const remove = hookIntoOverrideKeystroke(
-        Calc.focusedMathQuill.mq,
+        this.calc.focusedMathQuill.mq,
         (key, _) => {
           if (key === "Shift-Up" || key === "Shift-Down") {
             this.doMultilineVerticalNav(key);
@@ -178,14 +178,14 @@ export default class Multiline extends PluginController<Config> {
       this.lastRememberedCursorX = cursor.getBoundingClientRect().left;
     } else {
       let xpos =
-        Calc.focusedMathQuill?.mq.__controller.cursor?.[
+        this.calc.focusedMathQuill?.mq.__controller.cursor?.[
           -1
         ]?._el?.getBoundingClientRect()?.right;
       if (xpos !== undefined) {
         this.lastRememberedCursorX = xpos;
       } else {
         xpos =
-          Calc.focusedMathQuill?.mq.__controller.cursor?.[1]?._el?.getBoundingClientRect()
+          this.calc.focusedMathQuill?.mq.__controller.cursor?.[1]?._el?.getBoundingClientRect()
             ?.left;
         this.lastRememberedCursorX = xpos;
       }
@@ -220,7 +220,7 @@ export default class Multiline extends PluginController<Config> {
       this.dequeueAllMultilinifications();
     }, 0);
 
-    this.dispatcherID = Calc.controller.dispatcher.register((e) => {
+    this.dispatcherID = this.cc.dispatcher.register((e) => {
       if (
         e.type === "set-item-latex" ||
         e.type === "undo" ||
@@ -261,8 +261,7 @@ export default class Multiline extends PluginController<Config> {
     this.unmultilineExpressions(true);
     document.body.classList.remove("multiline-expression-enabled");
 
-    if (this.dispatcherID)
-      Calc.controller.dispatcher.unregister(this.dispatcherID);
+    if (this.dispatcherID) this.cc.dispatcher.unregister(this.dispatcherID);
 
     if (this.multilineIntervalID !== undefined)
       clearInterval(this.multilineIntervalID);

--- a/src/plugins/performance-info/index.ts
+++ b/src/plugins/performance-info/index.ts
@@ -1,6 +1,6 @@
 import { PluginController } from "../PluginController";
 import { MainPopupFunc } from "./PerformanceView";
-import { Calc, DispatchedEvent, TimingData } from "#globals";
+import { DispatchedEvent, TimingData } from "#globals";
 
 export default class PerformanceInfo extends PluginController {
   static id = "performance-info" as const;
@@ -16,7 +16,7 @@ export default class PerformanceInfo extends PluginController {
       iconClass: "dsm-icon-pie-chart",
       popup: () => MainPopupFunc(this, this.dsm),
     });
-    this.dispatchListenerID = Calc.controller.dispatcher.register((e) => {
+    this.dispatchListenerID = this.cc.dispatcher.register((e) => {
       if (e.type === "on-evaluator-changes") {
         this.onEvaluatorChanges(e);
       }
@@ -24,7 +24,7 @@ export default class PerformanceInfo extends PluginController {
   }
 
   afterDisable() {
-    Calc.controller.dispatcher.unregister(this.dispatchListenerID);
+    this.cc.dispatcher.unregister(this.dispatchListenerID);
     this.dsm.pillboxMenus?.removePillboxButton("dsm-pi-menu");
   }
 
@@ -32,7 +32,7 @@ export default class PerformanceInfo extends PluginController {
     if (e.type !== "on-evaluator-changes") return;
     this.timingDataHistory?.push(e.timingData);
     if (this.timingDataHistory.length > 10) this.timingDataHistory.shift();
-    // Don't Calc.controller.updateViews here. This is inside a dispatched event,
+    // Don't this.cc.updateViews here. This is inside a dispatched event,
     // so it will update views anyways.
   }
 
@@ -44,8 +44,8 @@ export default class PerformanceInfo extends PluginController {
   }
 
   refreshState() {
-    Calc.controller._showToast({ message: "Refreshing graph..." });
-    Calc.setState(Calc.getState());
+    this.cc._showToast({ message: "Refreshing graph..." });
+    this.calc.setState(this.calc.getState());
   }
 }
 

--- a/src/plugins/pillbox-menus/components/PillboxContainer.tsx
+++ b/src/plugins/pillbox-menus/components/PillboxContainer.tsx
@@ -2,7 +2,6 @@ import PillboxMenus from "..";
 import "./PillboxContainer.less";
 import { Component, jsx } from "#DCGView";
 import { If, Tooltip, For } from "#components";
-import { Calc } from "#globals";
 import { format } from "#i18n";
 
 export default class PillboxContainer extends Component<{
@@ -57,8 +56,7 @@ export default class PillboxContainer extends Component<{
                     this.horizontal
                       ? {}
                       : {
-                          background:
-                            Calc.controller.getPillboxBackgroundColor(),
+                          background: this.pm.cc.getPillboxBackgroundColor(),
                         }
                   }
                 >

--- a/src/plugins/pillbox-menus/components/PillboxMenu.tsx
+++ b/src/plugins/pillbox-menus/components/PillboxMenu.tsx
@@ -2,7 +2,6 @@ import PillboxMenus from "..";
 import "./PillboxMenu.less";
 import { Component, jsx } from "#DCGView";
 import { If, Switch } from "#components";
-import { Calc } from "#globals";
 import { keys } from "#utils/depUtils.ts";
 
 export default class PillboxMenu extends Component<{
@@ -88,8 +87,8 @@ export default class PillboxMenu extends Component<{
   ];
 
   didMountContainer() {
-    if (Calc.controller.isGraphSettingsOpen()) {
-      Calc.controller.dispatch({
+    if (this.pm.cc.isGraphSettingsOpen()) {
+      this.pm.cc.dispatch({
         type: "close-graph-settings",
       });
     }
@@ -111,9 +110,9 @@ export default class PillboxMenu extends Component<{
       this.pm.pillboxMenuOpen as string
     );
     if (
-      Calc.settings.settingsMenu &&
-      (!Calc.controller.isGeometry() ||
-        this.horizontal !== Calc.controller.isNarrowGeometryHeader())
+      this.pm.calc.settings.settingsMenu &&
+      (!this.pm.cc.isGeometry() ||
+        this.horizontal !== this.pm.cc.isNarrowGeometryHeader())
     )
       index += 1;
     return index;

--- a/src/plugins/pillbox-menus/index.ts
+++ b/src/plugins/pillbox-menus/index.ts
@@ -3,7 +3,6 @@ import { MenuFunc } from "./components/Menu";
 import PillboxContainer from "./components/PillboxContainer";
 import PillboxMenu from "./components/PillboxMenu";
 import { DCGView } from "#DCGView";
-import { Calc } from "#globals";
 import { plugins, PluginID, ConfigItem } from "#plugins/index.ts";
 
 export default class PillboxMenus extends PluginController<undefined> {
@@ -13,7 +12,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   private expandedCategory: string | null = null;
 
   afterEnable() {
-    Calc.controller.dispatcher.register((e) => {
+    this.cc.dispatcher.register((e) => {
       if (e.type === "toggle-graph-settings") {
         this.pillboxMenuPinned = false;
         this.closeMenu();
@@ -61,7 +60,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   }
 
   updateMenuView() {
-    Calc.controller.updateViews();
+    this.cc.updateViews();
   }
 
   addPillboxButton(info: PillboxButton) {
@@ -107,9 +106,9 @@ export default class PillboxMenus extends PluginController<undefined> {
     // added, or figure out a better layout at that point because it's starting
     // to be a lot of pillbox threshold.
     return (
-      !Calc.settings.graphpaper ||
-      (Calc.controller.isGeoUIActive() &&
-        Calc.controller.computeMajorLayout().grapher.width > 500)
+      !this.calc.settings.graphpaper ||
+      (this.cc.isGeoUIActive() &&
+        this.cc.computeMajorLayout().grapher.width > 500)
     );
   }
 

--- a/src/plugins/pin-expressions/components/PinnedPanel.tsx
+++ b/src/plugins/pin-expressions/components/PinnedPanel.tsx
@@ -1,31 +1,26 @@
 import PinExpressions from "..";
 import { jsx } from "#DCGView";
 import { For, If } from "#components";
-import { Calc, ItemModel } from "#globals";
+import { ItemModel } from "#globals";
 
 export interface ListView {
   makeDragCopyViewForModel: (model: ItemModel) => void;
 }
 
-export function PinnedPanel(
-  pinExpressions: PinExpressions,
-  listView: ListView
-) {
+export function PinnedPanel(pe: PinExpressions, listView: ListView) {
   return (
     <For
       each={() =>
-        pinExpressions.dsm.textMode?.inTextMode
-          ? []
-          : Calc.controller?.getAllItemModels?.() ?? []
+        pe.dsm.textMode?.inTextMode ? [] : pe.cc?.getAllItemModels?.() ?? []
       }
       key={(model) => (model as any).guid}
     >
       <div
         class="dsm-pinned-expressions dcg-exppanel"
-        style={() => ({ background: Calc.controller.getBackgroundColor() })}
+        style={() => ({ background: pe.cc.getBackgroundColor() })}
       >
         {(model: any) => (
-          <If predicate={() => pinExpressions?.isExpressionPinned(model.id)}>
+          <If predicate={() => pe?.isExpressionPinned(model.id)}>
             {/** marking as a drag copy causes it not to affect the render shells
              * calculations (all the logic is present already because if the top
              * expression is dragged to the bottom, it shouldn't cause all

--- a/src/plugins/pin-expressions/index.ts
+++ b/src/plugins/pin-expressions/index.ts
@@ -2,7 +2,6 @@ import { Inserter, PluginController } from "../PluginController";
 import { ActionButton } from "../expr-action-buttons";
 import { ListView, PinnedPanel } from "./components/PinnedPanel";
 import "./pinExpressions.less";
-import { Calc } from "#globals";
 
 export default class PinExpressions extends PluginController {
   static id = "pin-expressions" as const;
@@ -28,7 +27,7 @@ export default class PinExpressions extends PluginController {
   ];
 
   pinExpression(id: string) {
-    if (Calc.controller.getItemModel(id)?.type !== "folder")
+    if (this.cc.getItemModel(id)?.type !== "folder")
       this.dsm.metadata?.updateExprMetadata(id, {
         pinned: true,
       });
@@ -36,8 +35,8 @@ export default class PinExpressions extends PluginController {
 
   isExpressionPinned(id: string) {
     return (
-      !Calc.controller.getExpressionSearchOpen() &&
-      Calc.controller.getItemModel(id)?.type !== "folder" &&
+      !this.cc.getExpressionSearchOpen() &&
+      this.cc.getItemModel(id)?.type !== "folder" &&
       (this.dsm.metadata?.getDsmItemModel(id)?.pinned ?? false)
     );
   }

--- a/src/plugins/set-primary-color/index.ts
+++ b/src/plugins/set-primary-color/index.ts
@@ -1,4 +1,3 @@
-import { Calc } from "../../globals/window";
 import { PluginController } from "../PluginController";
 import "./_overrides.less";
 import "./custom-overrides.less";
@@ -105,7 +104,7 @@ export default class SetPrimaryColor extends PluginController<Config> {
     canvas.height = this.originalImage.naturalHeight;
     const ctx = canvas.getContext("2d");
     if (ctx === null) return;
-    const [bsat, bli, bhue] = Calc.controller.isGeometry()
+    const [bsat, bli, bhue] = this.cc.isGeometry()
       ? [0.67, 0.8, 285]
       : [1, 0.73, 130];
     ctx.filter = `saturate(${sat / bsat})

--- a/src/plugins/show-tips/Tip.tsx
+++ b/src/plugins/show-tips/Tip.tsx
@@ -2,10 +2,10 @@ import "./Tip.less";
 import { getTipData } from "./tips";
 import { Component, jsx } from "#DCGView";
 import { If } from "#components";
-import { Calc } from "#globals";
 import { format } from "#i18n";
+import ShowTips from ".";
 
-export default class Tip extends Component {
+export default class Tip extends Component<{ st: ShowTips }> {
   currentTipIndex!: number;
   tips!: ReturnType<typeof getTipData>;
 
@@ -40,6 +40,6 @@ export default class Tip extends Component {
   nextTip() {
     this.currentTipIndex += 1;
     this.currentTipIndex %= this.tips.length;
-    Calc.controller.updateViews();
+    this.props.st().cc.updateViews();
   }
 }

--- a/src/plugins/show-tips/index.ts
+++ b/src/plugins/show-tips/index.ts
@@ -19,6 +19,6 @@ export default class ShowTips extends PluginController {
   }
 
   tipView(): Inserter {
-    return () => DCGView.createElement(Tip, {});
+    return () => DCGView.createElement(Tip, { st: () => this });
   }
 }

--- a/src/plugins/text-mode/components/TextModeToggle.tsx
+++ b/src/plugins/text-mode/components/TextModeToggle.tsx
@@ -2,20 +2,19 @@ import TextMode from "..";
 import { format } from "#i18n";
 import { jsx } from "#DCGView";
 import { Tooltip } from "#components";
-import { Calc } from "#globals";
 
-export function TextModeToggle(textMode: TextMode) {
+export function TextModeToggle(tm: TextMode) {
   return (
     <Tooltip
       tooltip={() => format("text-mode-toggle")}
-      gravity={() => (Calc.controller.isNarrow() ? "n" : "s")}
+      gravity={() => (tm.cc.isNarrow() ? "n" : "s")}
     >
       <span
         class="dcg-icon-btn dsm-text-mode-toggle"
         handleEvent="true"
         role="button"
         tabindex="0"
-        onTap={() => textMode.toggleTextMode()}
+        onTap={() => tm.toggleTextMode()}
       >
         <i class="dcg-icon-title" />
       </span>

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -38,8 +38,8 @@ export default class TextMode extends PluginController {
     // expression UI doesn't render in text mode, we replace markTickRequiredNextFrame
     // with a version that calls markTickRequiredNextFrame only when sliders are playing
     if (this.inTextMode) {
-      Calc.controller.expressionSearchOpen = false;
-      Calc.controller.markTickRequiredNextFrame = function () {
+      this.cc.expressionSearchOpen = false;
+      this.cc.markTickRequiredNextFrame = function () {
         if (this.getPlayingSliders().length > 0) {
           // eslint-disable-next-line no-proto
           (this as any).__proto__.markTickRequiredNextFrame.apply(this);
@@ -47,9 +47,9 @@ export default class TextMode extends PluginController {
       };
     } else {
       // Revert back to the old markTickRequiredNextFrame given by prototype
-      delete (Calc.controller as any).markTickRequiredNextFrame;
+      delete (this.cc as any).markTickRequiredNextFrame;
     }
-    Calc.controller.updateViews();
+    this.cc.updateViews();
   }
 
   /**
@@ -61,7 +61,7 @@ export default class TextMode extends PluginController {
     if (hasError) this.conversionError(() => this.toggleTextMode());
     container.appendChild(this.view.dom);
     this.preventPropagation(container);
-    this.dispatchListenerID = Calc.controller.dispatcher.register((event) => {
+    this.dispatchListenerID = this.cc.dispatcher.register((event) => {
       // setTimeout to avoid dispatch-in-dispatch from handlers responding to
       // calc state changing by dispatching an event
       setTimeout(() => {
@@ -83,7 +83,7 @@ export default class TextMode extends PluginController {
   }
 
   textModeToggle(): Inserter {
-    if (Calc.controller.isInEditListMode()) return undefined;
+    if (this.cc.isInEditListMode()) return undefined;
     return () => TextModeToggle(this);
   }
 
@@ -101,11 +101,11 @@ export default class TextMode extends PluginController {
   }
 
   toastErrorGraphUndo(msg: string) {
-    this.toastError(msg, () => Calc.controller.dispatch({ type: "undo" }));
+    this.toastError(msg, () => this.cc.dispatch({ type: "undo" }));
   }
 
   toastError(msg: string, undoCallback?: () => void) {
-    Calc.controller._showToast({
+    this.cc._showToast({
       message: msg,
       // `undoCallback: undefined` still adds the "Press Ctrl+Z" message
       ...(undoCallback ? { undoCallback } : {}),
@@ -117,7 +117,7 @@ export default class TextMode extends PluginController {
    */
   unmountEditor() {
     if (this.dispatchListenerID !== null) {
-      Calc.controller.dispatcher.unregister(this.dispatchListenerID);
+      this.cc.dispatcher.unregister(this.dispatchListenerID);
     }
     if (this.view) {
       this.view.destroy();

--- a/src/plugins/text-mode/view/editor.ts
+++ b/src/plugins/text-mode/view/editor.ts
@@ -1,5 +1,5 @@
 import TextMode from "..";
-import { analysisStateField, doLint } from "../LanguageServer";
+import { analysisStateField, doLint, tmPlugin } from "../LanguageServer";
 // Language extension
 import { textMode } from "../lezer/index";
 import "./editor.less";
@@ -123,6 +123,8 @@ export function startState(tm: TextMode, text: string) {
       styleMappingPlugin,
       footerPlugin(),
       formatPanelPlugin(),
+      // Expose the tm plugin to functions that only have a state.
+      tmPlugin.of(tm),
     ],
   });
   state = state.update(collapseStylesAtStart(state)).state;

--- a/src/plugins/text-mode/view/plugins/StyleCircle.tsx
+++ b/src/plugins/text-mode/view/plugins/StyleCircle.tsx
@@ -1,7 +1,7 @@
 import "./StyleCircle.less";
 import { Component, DCGView, jsx } from "#DCGView";
 import { ExpressionIconView, ImageIconView } from "#components";
-import { Calc, ItemModel } from "#globals";
+import { ItemModel } from "#globals";
 
 export default class StyleCircle extends Component<{
   id: string;
@@ -15,14 +15,14 @@ export default class StyleCircle extends Component<{
         return (
           <ExpressionIconView
             model={DCGView.const(model)}
-            controller={DCGView.const(Calc.controller)}
+            controller={DCGView.const(model.controller)}
           />
         );
       case "image":
         return (
           <ImageIconView
             model={DCGView.const(model)}
-            controller={DCGView.const(Calc.controller)}
+            controller={DCGView.const(model.controller)}
           />
         );
       default:

--- a/src/plugins/text-mode/view/plugins/styleCircles.ts
+++ b/src/plugins/text-mode/view/plugins/styleCircles.ts
@@ -1,10 +1,10 @@
-import { analysisStateField } from "../../LanguageServer";
+import { analysisStateField, tmPlugin } from "../../LanguageServer";
 import { statementsIntersecting } from "../statementIntersection";
 import StyleCircle from "./StyleCircle";
 import { RangeSet, Extension } from "@codemirror/state";
 import { GutterMarker, gutter, gutters } from "@codemirror/view";
 import { DCGView } from "#DCGView";
-import { Calc, ItemModel } from "#globals";
+import type { ItemModel } from "#globals";
 
 export function styleCircles(): Extension {
   return [gutters(), styleCircleGutter];
@@ -17,8 +17,9 @@ const styleCircleGutter = gutter({
     const { from, to } = view.viewport;
     const ranges = [];
     let last = -1;
+    const tm = view.state.facet(tmPlugin);
     for (const stmt of statementsIntersecting(program, from, to)) {
-      const model = Calc.controller.getItemModel(stmt.id);
+      const model = tm.cc.getItemModel(stmt.id);
       if (model?.type === "expression" || model?.type === "image") {
         const pos = view.lineBlockAt(stmt.pos.from).from;
         if (pos > last) {
@@ -55,7 +56,7 @@ class StyleCircleMarker extends GutterMarker {
       id: DCGView.const(this.id),
       model: DCGView.const(this.model),
     });
-    this.unsub = Calc.controller.subscribeToChanges(() => view.update());
+    this.unsub = this.model.controller.subscribeToChanges(() => view.update());
     return this.div;
   }
 

--- a/src/plugins/video-creator/View.ts
+++ b/src/plugins/video-creator/View.ts
@@ -1,5 +1,4 @@
 import VideoCreator from ".";
-import { Calc } from "#globals";
 
 const captureFrameID = "dsm-vc-capture-frame";
 
@@ -20,7 +19,7 @@ function applyCaptureFrame(vc: VideoCreator) {
       canvas?.parentNode?.appendChild(frame);
     }
 
-    const pixelBounds = Calc.graphpaperBounds.pixelCoordinates;
+    const pixelBounds = vc.calc.graphpaperBounds.pixelCoordinates;
     const ratio =
       vc.getCaptureHeightNumber() /
       vc.getCaptureWidthNumber() /
@@ -45,5 +44,5 @@ function applyCaptureFrame(vc: VideoCreator) {
 
 export function updateView(vc: VideoCreator) {
   applyCaptureFrame(vc);
-  Calc.controller.updateViews();
+  vc.calc.controller.updateViews();
 }

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -1,8 +1,6 @@
 import VideoCreator from "..";
 import { scaleBoundsAboutCenter } from "./utils";
 import DSM from "#DSM";
-import { Calc } from "#globals";
-import { EvaluateSingleExpression } from "#utils/depUtils.ts";
 
 let dispatchListenerID: string | null = null;
 let callbackIfCancel: (() => void) | null = null;
@@ -34,15 +32,15 @@ export async function captureFrame(vc: VideoCreator) {
     tryCancel();
     // poll for mid-screenshot cancellation (only affects UI)
     const interval = window.setInterval(tryCancel, 50);
-    const pixelBounds = Calc.graphpaperBounds.pixelCoordinates;
+    const pixelBounds = vc.calc.graphpaperBounds.pixelCoordinates;
     const ratio = height / width / (pixelBounds.height / pixelBounds.width);
-    const mathBounds = Calc.graphpaperBounds.mathCoordinates;
+    const mathBounds = vc.calc.graphpaperBounds.mathCoordinates;
     // make the captured region entirely visible
     const clampedMathBounds = scaleBoundsAboutCenter(
       mathBounds,
       Math.min(ratio, 1 / ratio)
     );
-    Calc.asyncScreenshot(
+    vc.calc.asyncScreenshot(
       {
         width: width / targetPixelRatio,
         targetPixelRatio,
@@ -69,9 +67,9 @@ export interface SliderSettings {
 export async function captureSlider(vc: VideoCreator) {
   const sliderSettings = vc.sliderSettings;
   const variable = sliderSettings.variable;
-  const min = EvaluateSingleExpression(sliderSettings.minLatex);
-  const max = EvaluateSingleExpression(sliderSettings.maxLatex);
-  const step = EvaluateSingleExpression(sliderSettings.stepLatex);
+  const min = vc.eval(sliderSettings.minLatex);
+  const max = vc.eval(sliderSettings.maxLatex);
+  const step = vc.eval(sliderSettings.stepLatex);
   const slider = vc.getMatchingSlider();
   if (slider === undefined) {
     return;
@@ -84,7 +82,7 @@ export async function captureSlider(vc: VideoCreator) {
   // rarely hurts to have an extra frame
   for (let i = 0; i <= numSteps; i++) {
     const value = min + correctDirectionStep * i;
-    Calc.setExpression({
+    vc.calc.setExpression({
       id: slider.id,
       latex: `${variable}=${value}`,
     });
@@ -97,8 +95,8 @@ export async function captureSlider(vc: VideoCreator) {
   }
 }
 
-function slidersLatexJoined() {
-  return Calc.controller
+function slidersLatexJoined(vc: VideoCreator) {
+  return vc.cc
     .getPlayingSliders()
     .map((x) => x.latex)
     .join(";");
@@ -114,12 +112,12 @@ async function captureActionFrame(vc: VideoCreator, step: () => void) {
       vc.setTickCountLatex(String(tickCountRemaining - 1));
       vc.actionCaptureState = "waiting-for-update";
       if (tickCountRemaining - 1 > 0) {
-        const slidersBefore = slidersLatexJoined();
+        const slidersBefore = slidersLatexJoined(vc);
         step();
         stepped = true;
         if (
           vc.captureMethod === "ticks" &&
-          slidersLatexJoined() === slidersBefore
+          slidersLatexJoined(vc) === slidersBefore
         ) {
           // Due to rounding, this slider tick does not actually change the state,
           // so don't expect an event update. Just move to the next frame now.
@@ -142,9 +140,9 @@ async function captureActionFrame(vc: VideoCreator, step: () => void) {
 async function captureActionOrSliderTicks(vc: VideoCreator, step: () => void) {
   await new Promise<void>((resolve) => {
     callbackIfCancel = resolve;
-    dispatchListenerID = Calc.controller.dispatcher.register((e) => {
+    dispatchListenerID = vc.cc.dispatcher.register((e) => {
       if (
-        // near-equivalent to Calc.observeEvent("change", ...)
+        // near-equivalent to vc.calc.observeEvent("change", ...)
         // but event "change" is not triggered for slider playing movement
         e.type === "on-evaluator-changes" &&
         // check waiting-for-update in case there is more than one update before the screenshot finishes
@@ -169,25 +167,25 @@ function forceReloadMenu(dsm: DSM) {
   if (!pm) return;
   if (pm.pillboxMenuOpen === "dsm-vc-menu") {
     pm.pillboxMenuOpen = null;
-    Calc.controller.updateViews();
+    pm.cc.updateViews();
     pm.pillboxMenuOpen = "dsm-vc-menu";
-    Calc.controller.updateViews();
+    pm.cc.updateViews();
   }
 }
 
 export async function capture(vc: VideoCreator) {
   vc.isCapturing = true;
   vc.updateView();
-  const tickSliders = Calc.controller._tickSliders.bind(Calc.controller);
+  const tickSliders = vc.cc._tickSliders.bind(vc.cc);
   if (vc.captureMethod !== "once") {
-    if (Calc.controller.getTickerPlaying?.()) {
-      Calc.controller.dispatch({ type: "toggle-ticker" });
+    if (vc.cc.getTickerPlaying?.()) {
+      vc.cc.dispatch({ type: "toggle-ticker" });
     }
     if (vc.captureMethod === "ticks") {
       // prevent the current slider ticking since we will manually tick the sliders.
-      Calc.controller._tickSliders = () => {};
-    } else if (Calc.controller.getPlayingSliders().length > 0) {
-      Calc.controller.stopAllSliders();
+      vc.cc._tickSliders = () => {};
+    } else if (vc.cc.getPlayingSliders().length > 0) {
+      vc.cc.stopAllSliders();
       forceReloadMenu(vc.dsm);
     }
   }
@@ -195,7 +193,7 @@ export async function capture(vc: VideoCreator) {
     case "action": {
       const step = () => {
         if (vc.currentActionID !== null)
-          Calc.controller.dispatch({
+          vc.cc.dispatch({
             type: "action-single-step",
             id: vc.currentActionID,
           });
@@ -211,7 +209,7 @@ export async function capture(vc: VideoCreator) {
       };
       await captureActionOrSliderTicks(vc, step);
       // restore the typical handling of slider ticking
-      Calc.controller._tickSliders = tickSliders;
+      vc.cc._tickSliders = tickSliders;
       break;
     }
     case "once":
@@ -233,7 +231,7 @@ export async function capture(vc: VideoCreator) {
   vc.actionCaptureState = "none";
   vc.updateView();
   if (dispatchListenerID !== null) {
-    Calc.controller.dispatcher.unregister(dispatchListenerID);
+    vc.cc.dispatcher.unregister(dispatchListenerID);
     dispatchListenerID = null;
   }
   // no need to retain a pending cancellation, if any; capture is already finished

--- a/src/plugins/video-creator/backend/utils.ts
+++ b/src/plugins/video-creator/backend/utils.ts
@@ -1,5 +1,3 @@
-import { EvaluateSingleExpression } from "#utils/depUtils.ts";
-
 interface Bounds {
   left: number;
   right: number;
@@ -10,15 +8,6 @@ interface Bounds {
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
 export function escapeRegex(s: string) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-export function isValidNumber(s: string) {
-  return !isNaN(EvaluateSingleExpression(s));
-}
-
-export function isValidLength(s: string) {
-  const evaluated = EvaluateSingleExpression(s);
-  return !isNaN(evaluated) && evaluated >= 2;
 }
 
 export function scaleBoundsAboutCenter(b: Bounds, r: number) {

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -57,6 +57,7 @@ export default class SelectCapture extends Component<{
                     handleFocusChanged={(b) =>
                       this.vc.updateFocus("capture-slider-var", b)
                     }
+                    controller={this.vc.cc}
                   />
                 </span>
                 <StaticMathQuillView latex="=" />
@@ -71,6 +72,7 @@ export default class SelectCapture extends Component<{
                   handleFocusChanged={(b) =>
                     this.vc.updateFocus("capture-slider-min", b)
                   }
+                  controller={this.vc.cc}
                 />
                 {format("video-creator-to")}
                 <InlineMathInputView
@@ -84,6 +86,7 @@ export default class SelectCapture extends Component<{
                   handleFocusChanged={(b) =>
                     this.vc.updateFocus("capture-slider-max", b)
                   }
+                  controller={this.vc.cc}
                 />
                 {format("video-creator-step")}
                 <InlineMathInputView
@@ -97,6 +100,7 @@ export default class SelectCapture extends Component<{
                   handleFocusChanged={(b) =>
                     this.vc.updateFocus("capture-slider-step", b)
                   }
+                  controller={this.vc.cc}
                 />
               </div>
             </div>
@@ -155,6 +159,7 @@ export default class SelectCapture extends Component<{
                 handleFocusChanged={(b) =>
                   this.vc.updateFocus("capture-tick-time-step", b)
                 }
+                controller={this.vc.cc}
               />
             </div>
           ),
@@ -169,6 +174,7 @@ export default class SelectCapture extends Component<{
             hasError={() => !this.vc.isCaptureWidthValid()}
             handleFocusChanged={(b) => this.vc.updateFocus("capture-width", b)}
             isFocused={() => this.vc.isFocused("capture-width")}
+            controller={this.vc.cc}
           />
           ×
           <InlineMathInputView
@@ -178,6 +184,7 @@ export default class SelectCapture extends Component<{
             hasError={() => !this.vc.isCaptureHeightValid()}
             handleFocusChanged={(b) => this.vc.updateFocus("capture-height", b)}
             isFocused={() => this.vc.isFocused("capture-height")}
+            controller={this.vc.cc}
           />
           <If predicate={() => this.vc.isDefaultCaptureSizeDifferent()}>
             {() => (
@@ -263,6 +270,7 @@ export default class SelectCapture extends Component<{
                   handleFocusChanged={(b) =>
                     this.vc.updateFocus("capture-tick-count", b)
                   }
+                  controller={this.vc.cc}
                 />
               </div>
             )}

--- a/src/plugins/video-creator/components/MainPopup.tsx
+++ b/src/plugins/video-creator/components/MainPopup.tsx
@@ -178,6 +178,7 @@ export default class MainPopup extends Component<{
                         handleFocusChanged={(b) =>
                           this.vc.updateFocus("export-fps", b)
                         }
+                        controller={this.vc.cc}
                       />
                     </div>
                   )}

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -1,4 +1,4 @@
-import { Calc, Console } from "../../globals/window";
+import { Console } from "../../globals/window";
 import { getCurrentGraphTitle } from "../../utils/depUtils";
 import { PluginController } from "../PluginController";
 import { Config, configList } from "./config";
@@ -15,7 +15,7 @@ export default class Wakatime extends PluginController<Config> {
   handler!: string;
 
   afterEnable() {
-    this.handler = Calc.controller.dispatcher.register((e) => {
+    this.handler = this.cc.dispatcher.register((e) => {
       if (
         e.type === "on-evaluator-changes" ||
         e.type === "clear-unsaved-changes"
@@ -28,7 +28,7 @@ export default class Wakatime extends PluginController<Config> {
       if (msg.type === "heartbeat-error") {
         if (msg.isAuthError) {
           this.dsm.disablePlugin("wakatime");
-          Calc.controller._showToast({
+          this.cc._showToast({
             message:
               "WakaTime heartbeat error: check your secret key. Plugin has been deactivated.",
             toastStyle: "error",
@@ -42,15 +42,15 @@ export default class Wakatime extends PluginController<Config> {
   }
 
   afterDisable() {
-    Calc.controller.dispatcher.unregister(this.handler);
+    this.cc.dispatcher.unregister(this.handler);
   }
 
   maybeSendHeartbeat(isWrite: boolean) {
     if (!(performance.now() - this.lastUpdate > heartbeatInterval || isWrite))
       return;
-    const graphName = getCurrentGraphTitle() ?? "Untitled Graph";
+    const graphName = getCurrentGraphTitle(this.calc) ?? "Untitled Graph";
     const graphURL = window.location.href;
-    const lineCount = Calc.getExpressions().length;
+    const lineCount = this.calc.getExpressions().length;
 
     Console.debug("[WakaTime] Sending heartbeat at:", new Date());
     postMessageUp({

--- a/src/plugins/wolfram2desmos/index.ts
+++ b/src/plugins/wolfram2desmos/index.ts
@@ -1,7 +1,6 @@
 import { PluginController } from "../PluginController";
 import { Config, configList } from "./config";
 import { wolfram2desmos, isIllegalASCIIMath } from "./wolfram2desmos";
-import { Calc } from "#globals";
 
 // https://stackoverflow.com/a/34278578
 function typeInTextArea(
@@ -71,7 +70,7 @@ export default class WolframToDesmos extends PluginController<Config> {
       !(elem?.classList.contains("dcg-label-input") ?? true) &&
       pasteData !== undefined &&
       pasteData !== "" &&
-      Calc.controller.getItemModel(Calc.selectedExpressionId)?.type ===
+      this.cc.getItemModel(this.calc.selectedExpressionId)?.type ===
         "expression" &&
       isIllegalASCIIMath(pasteData)
     ) {

--- a/src/preload/script.ts
+++ b/src/preload/script.ts
@@ -18,7 +18,7 @@ import { fullReplacementCached } from "./replacementHelpers/cacheReplacement";
  * returns before actually initializing the calculator. This leads to a race
  * condition, so poll for Calc being ready. */
 function tryRunDesModder() {
-  if (window.Calc !== undefined) runDesModder();
+  if ((window as any).Calc !== undefined) runDesModder();
   else setTimeout(tryRunDesModder, 10);
 }
 

--- a/src/script.ts
+++ b/src/script.ts
@@ -2,9 +2,9 @@ import { format } from "#i18n";
 import { drawGLesmosSketchToCtx } from "./plugins/GLesmos/drawGLesmosSketchToCtx";
 import DSM from "#DSM";
 import "./fonts/style.css";
-import window from "#globals";
+import window, { Calc } from "#globals";
 
-const dsm = new DSM(window.Calc);
+const dsm = new DSM((window as any).Calc as Calc);
 
 window.DesModder = {
   controller: dsm,

--- a/src/script.ts
+++ b/src/script.ts
@@ -4,7 +4,7 @@ import DSM from "#DSM";
 import "./fonts/style.css";
 import window from "#globals";
 
-const dsm = new DSM();
+const dsm = new DSM(window.Calc);
 
 window.DesModder = {
   controller: dsm,

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,5 +1,5 @@
 import Node from "#parsing/parsenode.ts";
-import { CalcType, Fragile, Private } from "#globals";
+import { type Calc, Fragile, Private } from "#globals";
 
 const evaluateLatex = Fragile.evaluateLatex;
 
@@ -21,7 +21,7 @@ export function parseDesmosLatex(s: string) {
   return parseDesmosLatexRaw(s, { allowDt: true, allowIndex: true });
 }
 
-export function EvaluateSingleExpression(calc: CalcType, s: string): number {
+export function EvaluateSingleExpression(calc: Calc, s: string): number {
   // may also return NaN (which is a number)
   return evaluateLatex(s, calc.controller.isDegreeMode());
 }
@@ -37,7 +37,7 @@ export function truncatedLatexLabel(label: any, labelOptions: any) {
   return Private.Mathtools.Label.truncatedLatexLabel(label, labelOptions);
 }
 
-export function getCurrentGraphTitle(calc: CalcType): string | undefined {
+export function getCurrentGraphTitle(calc: Calc): string | undefined {
   return calc._calc.globalHotkeys?.headerController?.graphsController?.getCurrentGraphTitle?.();
 }
 

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,5 +1,5 @@
 import Node from "#parsing/parsenode.ts";
-import { Calc, Fragile, Private } from "#globals";
+import { CalcType, Fragile, Private } from "#globals";
 
 const evaluateLatex = Fragile.evaluateLatex;
 
@@ -21,9 +21,9 @@ export function parseDesmosLatex(s: string) {
   return parseDesmosLatexRaw(s, { allowDt: true, allowIndex: true });
 }
 
-export function EvaluateSingleExpression(s: string): number {
+export function EvaluateSingleExpression(calc: CalcType, s: string): number {
   // may also return NaN (which is a number)
-  return evaluateLatex(s, Calc.controller.isDegreeMode());
+  return evaluateLatex(s, calc.controller.isDegreeMode());
 }
 
 export const getQueryParams = Fragile.getQueryParams;
@@ -37,8 +37,8 @@ export function truncatedLatexLabel(label: any, labelOptions: any) {
   return Private.Mathtools.Label.truncatedLatexLabel(label, labelOptions);
 }
 
-export function getCurrentGraphTitle(): string | undefined {
-  return Calc._calc.globalHotkeys?.headerController?.graphsController?.getCurrentGraphTitle?.();
+export function getCurrentGraphTitle(calc: CalcType): string | undefined {
+  return calc._calc.globalHotkeys?.headerController?.graphsController?.getCurrentGraphTitle?.();
 }
 
 export const List = Fragile.List;

--- a/src/utils/listenerHelpers.ts
+++ b/src/utils/listenerHelpers.ts
@@ -1,5 +1,5 @@
 import { MathQuillField } from "#components";
-import { CalcType, DispatchedEvent } from "#globals";
+import type { Calc, DispatchedEvent } from "#globals";
 
 interface DispatchOverridingHandler {
   handler: (evt: DispatchedEvent) => boolean | undefined;
@@ -8,7 +8,7 @@ interface DispatchOverridingHandler {
 }
 
 const calcDispatchOverrideHandlers = new WeakMap<
-  CalcType,
+  Calc,
   DispatchOverridingHandler[]
 >();
 
@@ -19,7 +19,7 @@ let dispatchOverridingHandlerId = 0;
 // the handler can return false to force the dispatcher to stop early
 // (e.g. to stop desmos from doing a default action upon pressing a key)
 export function registerCustomDispatchOverridingHandler(
-  calc: CalcType,
+  calc: Calc,
   handler: (evt: DispatchedEvent) => boolean | undefined,
   priority: number
 ): number {
@@ -38,7 +38,7 @@ export function registerCustomDispatchOverridingHandler(
 // deregisters a function created with registerCustomDispatchOverridingHandler
 // uses the id that the former function returns
 export function deregisterCustomDispatchOverridingHandler(
-  calc: CalcType,
+  calc: Calc,
   id: number
 ): void {
   const handlers = getDispatchOverrideHandlers(calc);
@@ -51,7 +51,7 @@ export function deregisterCustomDispatchOverridingHandler(
   }
 }
 
-function getDispatchOverrideHandlers(calc: CalcType) {
+function getDispatchOverrideHandlers(calc: Calc) {
   const curr = calcDispatchOverrideHandlers.get(calc);
   if (curr) return curr;
   const newHandlers = setupDispatchOverride(calc);
@@ -60,7 +60,7 @@ function getDispatchOverrideHandlers(calc: CalcType) {
 }
 
 // Change calc.handleDispatchedAction to first run a set of custom handlers
-export function setupDispatchOverride(calc: CalcType) {
+export function setupDispatchOverride(calc: Calc) {
   const old = calc.controller.handleDispatchedAction;
   const handlers: DispatchOverridingHandler[] = [];
   calc.controller.handleDispatchedAction = function (evt) {

--- a/src/utils/listenerHelpers.ts
+++ b/src/utils/listenerHelpers.ts
@@ -1,12 +1,16 @@
-import { pollForValue } from "./utils";
 import { MathQuillField } from "#components";
-import { Calc, DispatchedEvent } from "#globals";
+import { CalcType, DispatchedEvent } from "#globals";
 
-let dispatchOverridingHandlers: {
+interface DispatchOverridingHandler {
   handler: (evt: DispatchedEvent) => boolean | undefined;
   priority: number;
   id: number;
-}[] = [];
+}
+
+const calcDispatchOverrideHandlers = new WeakMap<
+  CalcType,
+  DispatchOverridingHandler[]
+>();
 
 let dispatchOverridingHandlerId = 0;
 
@@ -15,47 +19,60 @@ let dispatchOverridingHandlerId = 0;
 // the handler can return false to force the dispatcher to stop early
 // (e.g. to stop desmos from doing a default action upon pressing a key)
 export function registerCustomDispatchOverridingHandler(
+  calc: CalcType,
   handler: (evt: DispatchedEvent) => boolean | undefined,
   priority: number
 ): number {
+  const handlers = getDispatchOverrideHandlers(calc);
   const id = dispatchOverridingHandlerId++;
   // add the handler
-  dispatchOverridingHandlers.push({ handler, priority, id });
+  handlers.push({ handler, priority, id });
 
   // sort the handlers so that higher priorities are first
   // could easily be optimized but prob not a bottleneck
-  dispatchOverridingHandlers.sort((a, b) => b.priority - a.priority);
+  handlers.sort((a, b) => b.priority - a.priority);
 
   return id;
 }
 
 // deregisters a function created with registerCustomDispatchOverridingHandler
 // uses the id that the former function returns
-export function deregisterCustomDispatchOverridingHandler(id: number): void {
+export function deregisterCustomDispatchOverridingHandler(
+  calc: CalcType,
+  id: number
+): void {
+  const handlers = getDispatchOverrideHandlers(calc);
   // remove all handlers with matching IDs
-  dispatchOverridingHandlers = dispatchOverridingHandlers.filter(
-    (entry) => entry.id !== id
-  );
+  // This is in general O(ND), but only one handler should be deleted typically.
+  for (let i = handlers.length - 1; i >= 0; i--) {
+    if (handlers[i].id === id) {
+      handlers.splice(i, 1);
+    }
+  }
 }
 
-// once Calc is defined, change handleDispatchedAction to first
-// run a set of custom handlers
-export function setupDispatchOverride() {
-  const old = Calc.controller.handleDispatchedAction;
-  Calc.controller.handleDispatchedAction = function (evt) {
-    for (const { handler } of dispatchOverridingHandlers) {
+function getDispatchOverrideHandlers(calc: CalcType) {
+  const curr = calcDispatchOverrideHandlers.get(calc);
+  if (curr) return curr;
+  const newHandlers = setupDispatchOverride(calc);
+  calcDispatchOverrideHandlers.set(calc, newHandlers);
+  return newHandlers;
+}
+
+// Change calc.handleDispatchedAction to first run a set of custom handlers
+export function setupDispatchOverride(calc: CalcType) {
+  const old = calc.controller.handleDispatchedAction;
+  const handlers: DispatchOverridingHandler[] = [];
+  calc.controller.handleDispatchedAction = function (evt) {
+    for (const { handler } of handlers) {
       const keepGoing = handler(evt);
       if (keepGoing === false) return;
     }
 
     old.call(this, evt);
   };
+  return handlers;
 }
-
-void (async () => {
-  await pollForValue(() => Calc);
-  setupDispatchOverride();
-})();
 
 // "attach" a function onto an existing function, performing some functionality
 // and then optionally triggering the existing function.

--- a/text-mode-core/TextModeConfig.ts
+++ b/text-mode-core/TextModeConfig.ts
@@ -9,12 +9,12 @@ export interface PublicConfig {
   parseDesmosLatex?: Parse;
 }
 
-export function buildConfigFromGlobals(Desmos: any, Calc: any) {
-  const config = Calc.controller.getMathquillConfig({});
+export function buildConfigFromGlobals(Desmos: any, calc: any) {
+  const config = calc.controller.getMathquillConfig({});
   return buildConfig({
     operatorNames: config.autoOperatorNames,
     commandNames: config.autoCommands,
-    colors: Calc?.colors,
+    colors: calc?.colors,
     parseDesmosLatex: Desmos.Private.Parser.parse,
   });
 }


### PR DESCRIPTION
Pass a specific `calc` around everywhere. Now, `Calc` is only used in three places (grep for `window.Calc` for them, since `Calc` is used as the type of calc now). In theory, this allows DesModder to run on any page with one more calculator instances, but replacements and content script are the blocking points for now.
  1. In `src/script.ts`, the main initialization, `const dsm = new DSM(window.Calc);`
  2. In GLesmos replacements, `.drawGLesmosSketchToCtx?.(window.Calc.controller, ...` (I didn't bother to figure out how to extract a Desmos controller from that point in code)
  3. In `src/preload/script.ts`, where it waits to inject the main script until `window.Calc` is loaded.

Note `cc` is used as a shortcut for `calc.controller`.

One component of https://github.com/DesModder/DesModder/pull/714