### PR TITLE
Better Navigation: Fix Ctrl+Backspace and Ctrl+Delete

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -182,6 +182,7 @@ interface CalcPrivate {
   focusedMathQuill:
     | {
         mq: MathQuillField;
+        typedText: (text: string) => void;
       }
     | undefined;
   /// / undocumented, may break

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -103,6 +103,11 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
           const navOption = NavigationTable[key];
           if (!navOption) return true;
 
+          // type an empty string to force desmos to update
+          setTimeout(() => {
+            this.calc.focusedMathQuill?.typedText("");
+          }, 0);
+
           // backspace is implicitly "left"
           const dir = navOption.dir;
           const mode = navOption.mode;
@@ -158,6 +163,7 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
           } else {
             mq.keystroke(arrowOp);
           }
+
           return false;
         },
         0,


### PR DESCRIPTION
Before, Ctrl+Backspace and Ctrl+Delete wouldn't cause the graph to update (e.g. if you type out `x` and hit `Ctrl+Backspace`, a line will still be drawn). I've fixed this by simulating typing out an empty string with MathQuill's `typedText`. I've tested this with all the other key combos too--- it doesn't seem to break the selection-creating variants which is a good sign.