### PR TITLE
Fix pillbox menus in /geometry

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -203,6 +203,7 @@ interface CalcPrivate {
       config: {
         // only includes products desmodder is enabled for
         product: Product;
+        settingsMenu: boolean;
       };
     };
     dispatch: (e: DispatchedEvent) => void;

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -264,6 +264,7 @@ interface CalcPrivate {
     _tickSliders: (nowTimestamp: number) => void;
     computeMajorLayout: () => { grapher: { width: number } };
     isGeometry: () => boolean;
+    geometryGettingStartedMessageState: string;
     isGeoUIActive: () => boolean;
     isNarrowGeometryHeader: () => boolean;
     expressionSearchOpen: boolean;

--- a/src/plugins/pillbox-menus/components/PillboxMenu.tsx
+++ b/src/plugins/pillbox-menus/components/PillboxMenu.tsx
@@ -109,12 +109,7 @@ export default class PillboxMenu extends Component<{
     let index = this.pm.pillboxButtonsOrder.indexOf(
       this.pm.pillboxMenuOpen as string
     );
-    if (
-      this.pm.calc.settings.settingsMenu &&
-      (!this.pm.cc.isGeometry() ||
-        this.horizontal !== this.pm.cc.isNarrowGeometryHeader())
-    )
-      index += 1;
+    if (this.pm.cc.graphSettings.config.settingsMenu) index += 1;
     return index;
   }
 

--- a/src/plugins/pillbox-menus/index.ts
+++ b/src/plugins/pillbox-menus/index.ts
@@ -101,15 +101,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   }
 
   showHorizontalPillboxMenu() {
-    // Constant threshold, independent of this.pillboxButtonsOrder.length
-    // Maybe want to tweak the threshold if a fourth possible pillbox button is
-    // added, or figure out a better layout at that point because it's starting
-    // to be a lot of pillbox threshold.
-    return (
-      !this.calc.settings.graphpaper ||
-      (this.cc.isGeoUIActive() &&
-        this.cc.computeMajorLayout().grapher.width > 500)
-    );
+    return !this.calc.settings.graphpaper;
   }
 
   getDefaultSetting(key: string) {

--- a/src/plugins/pillbox-menus/index.ts
+++ b/src/plugins/pillbox-menus/index.ts
@@ -85,6 +85,13 @@ export default class PillboxMenus extends PluginController<undefined> {
 
   toggleMenu(id: string) {
     this.pillboxMenuOpen = this.pillboxMenuOpen === id ? null : id;
+    if (
+      this.pillboxMenuOpen &&
+      this.cc.geometryGettingStartedMessageState !== "hidden"
+    ) {
+      this.cc.geometryGettingStartedMessageState = "hidden";
+      this.cc.dispatch({ type: "tick" });
+    }
     this.pillboxMenuPinned = false;
     this.updateMenuView();
   }

--- a/src/plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/plugins/pillbox-menus/pillbox-menus.replacements
@@ -2,23 +2,6 @@
 
 *plugin* `pillbox-menus`
 
-## Insert spot for extra pillbox buttons in geometry toolbar
-
-*Description* `Add pillbox buttons (like the DesModder button) in the geometry calculator`
-
-*Find* => `from`
-```js
-$DCGView.createElement("div", {
-  class: $DCGView.const("dcg-header-right dcg-do-blur")
-},
-```
-
-*Replace* `from` with
-```js
-__from__
-DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonsView(true)),
-```
-
 ## Insert spot for extra pillbox buttons in regular pillbox view
 
 *Description* `Add pillbox buttons (like the DesModder button) in the graphing calculator`


### PR DESCRIPTION
- Always use vertical pillbox in geometry (this removes a broken replacement)
- Hide "pick a tool to get started" when opening pillbox menu
