### PR TITLE
Fix rho

### DIFF
--- a/src/plugins/custom-mathquill-config/index.ts
+++ b/src/plugins/custom-mathquill-config/index.ts
@@ -24,7 +24,7 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
   oldConfig = this.cc.getMathquillConfig;
   doAutoCommandInjections = false;
   autoCommandInjections =
-    " gamma Gamma delta Delta epsilon zeta eta Theta iota kappa lambda Lambda mu Xi xi Pi rho sigma Sigma upsilon Upsilon Phi chi psi Psi omega Omega";
+    " gamma Gamma delta Delta epsilon zeta eta Theta iota kappa lambda Lambda mu Xi xi Pi sigma Sigma upsilon Upsilon Phi chi psi Psi omega Omega";
 
   updateConfig(config: Config) {
     this.cc.rootElt.classList.toggle("commaizer", config.commaDelimiter);


### PR DESCRIPTION
Rho can be now typed by default, caused an issue with rho being removed when the plugin is disabled.