### PR TITLE
Fix Video Creator Loading Pie for Export

### DIFF
--- a/src/plugins/video-creator/backend/export.ts
+++ b/src/plugins/video-creator/backend/export.ts
@@ -60,6 +60,7 @@ export async function cancelExport(vc: VideoCreator) {
 export async function initFFmpeg(vc: VideoCreator) {
   if (ffmpeg === null) {
     ffmpeg = createFFmpeg({ log: false });
+    // Idk why this doesn't just use ffmpeg.setProgress, but it works for now.
     ffmpeg.setLogger(({ type, message }) => {
       if (type === "fferr") {
         const match = message.match(/frame=\s*(?<frame>\d+)/);

--- a/src/plugins/video-creator/components/LoadingPie.tsx
+++ b/src/plugins/video-creator/components/LoadingPie.tsx
@@ -37,12 +37,15 @@ export default class LoadingPie extends Component<{
       e.removeChild(e.firstChild);
     }
     if (progress >= 0 && progress <= 1) {
-      const svg = document.createElement("svg");
-      svg.className = "dsm-vc-pie-overlay";
+      const NS = "http://www.w3.org/2000/svg";
+      const svg = document.createElementNS(NS, "svg");
+      svg.setAttribute("xmlns", NS);
+      svg.setAttribute("class", "dsm-vc-pie-overlay");
       svg.setAttribute("viewBox", "-1 -1 2 2");
-      const path = document.createElement("path");
+      const path = document.createElementNS(NS, "path");
       svg.appendChild(path);
       path.setAttribute("d", this.getPiePath());
+      e.appendChild(svg);
     }
   }
 


### PR DESCRIPTION
![image](https://github.com/DesModder/DesModder/assets/20214911/d7e25bf6-d228-46ce-a729-dbe16cddd39c)

Fixes #779. Problem was not (as guessed) parsing log messages. It was namespace stuff, and I didn't even push the SVG to the page.

Problem was introduced in https://github.com/DesModder/DesModder/pull/319/commits/8c1d3c969653f5a238f9e6cfabce8eea2eebf1dc. Firefox's linter complained about the innerHTML, so I replaced it (incorrectly) with createElement stuff.