### PR TITLE
Support Restriction in Text Mode

### DIFF
--- a/parsing/parsenode.ts
+++ b/parsing/parsenode.ts
@@ -272,6 +272,12 @@ export interface Piecewise extends Expression {
   // empty(): unknown
 }
 
+export interface Restriction extends Expression {
+  // "\\{x<1\\}" or "\\{x<1,y>2\\}" (this is a restriction with an Or child)
+  type: "Restriction";
+  args: [ChildExprNode];
+}
+
 interface RGBColor extends Expression {
   // No idea how to get RGBColor
   type: "RGBColor";
@@ -364,6 +370,11 @@ export interface And extends Expression {
   // "1<2<3"
   args: [Comparator, Comparator];
   type: "And";
+}
+export interface Or extends Expression {
+  // "\\{x<1,y>2\\}"
+  args: [ChildExprNode, ChildExprNode];
+  type: "Or";
 }
 interface RawExponent extends Exponent {
   // Not sure how to get RawExponent
@@ -645,6 +656,7 @@ export type ChildExprNode =
   | Norm
   | NamedCoordinateAccess
   | Piecewise
+  | Restriction
   | Product
   | Sum
   | SeededFunctionCall
@@ -657,6 +669,7 @@ export type ChildExprNode =
   | Exponent
   | Negative
   | And
+  | Or
   | Comparator
   // Seed + ExtendSeed only used in SeededFunctionCalls?
   | Seed

--- a/text-mode-core/TextAST/index.ts
+++ b/text-mode-core/TextAST/index.ts
@@ -121,6 +121,8 @@ export type Expression<C extends S = Concrete> =
   | Substitution<C>
   | AssignmentExpression<C>
   | PiecewiseExpression<C>
+  | Restriction<C>
+  | Or<C>
   | PrefixExpression<C>
   | Norm<C>
   | SequenceExpression<C>
@@ -210,6 +212,18 @@ export type PiecewiseBranch<C extends S = Concrete> = Positioned<C> & {
         consequent: null;
       }
   );
+
+export type Restriction<C extends S = Concrete> = Positioned<C> & {
+  type: "Restriction";
+  /** True corresponds to {} */
+  condition: Expression<C> | true;
+};
+
+export type Or<C extends S = Concrete> = Positioned<C> & {
+  type: "Or";
+  left: Expression<C>;
+  right: Expression<C>;
+};
 
 export type PrefixExpression<C extends S = Concrete> = Positioned<C> & {
   type: "PrefixExpression";

--- a/text-mode-core/aug/AugLatex.ts
+++ b/text-mode-core/aug/AugLatex.ts
@@ -37,12 +37,14 @@ export type AnyChild =
   | ListComprehension
   | Substitution
   | Piecewise
+  | Restriction
   | RepeatedOperator
   | BinaryOperator
   | Negative
   | Norm
   | Factorial
   | Comparator
+  | Or
   | DoubleInequality
   | AssignmentExpression;
 
@@ -212,12 +214,28 @@ export interface Substitution {
   assignments: AssignmentExpression[];
 }
 
+type PiecewiseBoolean = Comparator | DoubleInequality;
+type RestrictionBoolean = PiecewiseBoolean | Or;
+
+export function isPiecewiseBoolean(arg: AnyChild): arg is PiecewiseBoolean {
+  return arg.type === "Comparator" || arg.type === "DoubleInequality";
+}
+
+export function isRestrictionBoolean(arg: AnyChild): arg is RestrictionBoolean {
+  return isPiecewiseBoolean(arg) || arg.type === "Or";
+}
+
 export interface Piecewise {
   // A large piecewise is represented by another piecewise in the alternate
   type: "Piecewise";
-  condition: Comparator | DoubleInequality | true;
+  condition: PiecewiseBoolean | true;
   consequent: AnyChild;
   alternate: AnyChild;
+}
+
+export interface Restriction {
+  type: "Restriction";
+  condition: RestrictionBoolean | true;
 }
 
 export interface RepeatedOperator {
@@ -240,6 +258,12 @@ export interface BinaryOperator {
     | "Exponent";
   left: AnyChild;
   right: AnyChild;
+}
+
+export interface Or {
+  type: "Or";
+  left: RestrictionBoolean;
+  right: RestrictionBoolean;
 }
 
 export interface Negative {

--- a/text-mode-core/aug/augLatexToRaw.ts
+++ b/text-mode-core/aug/augLatexToRaw.ts
@@ -155,6 +155,19 @@ function childNodeToStringNoParen(
       }
       return "\\left\\{" + piecewiseParts.join(",") + "\\right\\}";
     }
+    case "Restriction": {
+      if (e.condition === true) return "\\left\\{\\right\\}";
+      return (
+        "\\left\\{" + childNodeToString(cfg, e.condition, e) + "\\right\\}"
+      );
+    }
+    case "Or":
+      // This can only show up inside a restriction.
+      return (
+        childNodeToString(cfg, e.left, e) +
+        "," +
+        childNodeToString(cfg, e.right, e)
+      );
     case "RepeatedOperator": {
       const prefix = e.name === "Product" ? "\\prod" : "\\sum";
       return (

--- a/text-mode-core/aug/augNeedsParens.ts
+++ b/text-mode-core/aug/augNeedsParens.ts
@@ -48,6 +48,8 @@ export default function augNeedsParens(
     case "Visualization":
     case "List":
     case "Piecewise":
+    case "Restriction":
+    case "Or": // Note "Or" can only show up as a direct child of restriction or Or.
     case "Range":
     case "Norm":
       return false;
@@ -150,6 +152,7 @@ function power(node: Aug.Latex.AnyChild): number {
     case "Range":
     case "ListComprehension":
     case "Piecewise":
+    case "Restriction":
       return POWERS.atom;
     case "Factorial":
       return POWERS.factorial;
@@ -175,6 +178,7 @@ function power(node: Aug.Latex.AnyChild): number {
     case "DoubleInequality":
     case "AssignmentExpression":
       return POWERS.compare;
+    case "Or":
     case "Seq":
       return POWERS.seq;
     case "Substitution":

--- a/text-mode-core/down/textToAug.unit.test.ts
+++ b/text-mode-core/down/textToAug.unit.test.ts
@@ -311,22 +311,16 @@ describe("Basic exprs", () => {
   });
   describe("Piecewise", () => {
     testExpr("trivial piecewise", "{}", {
-      type: "Piecewise",
+      type: "Restriction",
       condition: true,
-      consequent: number(1),
-      alternate: number(NaN),
     });
     testExpr("implicit consequent", "{x>1}", {
-      type: "Piecewise",
+      type: "Restriction",
       condition: comparator(">", id("x"), number(1)),
-      consequent: number(1),
-      alternate: number(NaN),
     });
     testExpr("implicit consequent double inequality", "{1<x<5}", {
-      type: "Piecewise",
+      type: "Restriction",
       condition: doubleInequality(number(1), "<", id("x"), "<", number(5)),
-      consequent: number(1),
-      alternate: number(NaN),
     });
     testExpr("single condition", "{x>1:2}", {
       type: "Piecewise",
@@ -347,14 +341,11 @@ describe("Basic exprs", () => {
       alternate: number(5),
     });
     testExpr("implicit consequent twice", "{x<1,x>1}", {
-      type: "Piecewise",
-      condition: comparator("<", id("x"), number(1)),
-      consequent: number(1),
-      alternate: {
-        type: "Piecewise",
-        condition: comparator(">", id("x"), number(1)),
-        consequent: number(1),
-        alternate: number(NaN),
+      type: "Restriction",
+      condition: {
+        type: "Or",
+        left: comparator("<", id("x"), number(1)),
+        right: comparator(">", id("x"), number(1)),
       },
     });
     testExpr("two conditions and else", "{x>1:2,y>3:4,5}", {

--- a/text-mode-core/tests/roundTripEmit.unit.test.ts
+++ b/text-mode-core/tests/roundTripEmit.unit.test.ts
@@ -66,7 +66,8 @@ describe("Text Emit round-trips (keeping optional spaces)", () => {
     `sin(x) with x = 5`,
     `x + y with x = 5, y = -5`,
     `{}`,
-    // TODO: preserve (lack of) `:1` in round-trip
+    // Lack of `: 1` is only preserved here since it's counted as a restriction.
+    `{x > 5}`,
     `{x > 5: 1}`,
     `{x > 5: 2}`,
     `{x > 5: 2, 3}`,

--- a/text-mode-core/tests/roundTripParse.unit.test.ts
+++ b/text-mode-core/tests/roundTripParse.unit.test.ts
@@ -257,10 +257,13 @@ describe("Operator Precedence round-trip", () => {
     "[1,2,3]",
     "[(b\\o{with}b=3),2,b\\o{with}b=3]",
     "[b\\o{with}b=3]",
-    /// parent = Piecewise
-    "\\{\\}",
-    "\\{x=5\\}",
-    "\\{x=5,y=4\\}",
+    /// parent = Restriction
+    "y=x\\cdot \\{\\}",
+    "y=x\\cdot \\{x=5\\}",
+    "y=x\\cdot \\{x=5,y=4\\}",
+    "y=x\\cdot \\{x=5,y=4,z>7\\}",
+    /// parent = Piecewise or Restriction
+    "\\{x=5:2,y=4\\}",
     "\\{x>1:3+x,5*y\\}",
     "\\{x>1:5\\}",
     "\\{x>1\\}",

--- a/text-mode-core/up/astToText.ts
+++ b/text-mode-core/up/astToText.ts
@@ -104,6 +104,8 @@ function astToTextDoc(ctx: EmitContext, path: TextAST.NodePath) {
     case "ListComprehension":
     case "Substitution":
     case "PiecewiseExpression":
+    case "Restriction":
+    case "Or":
     case "PrefixExpression":
     case "Norm":
     case "SequenceExpression":
@@ -516,6 +518,26 @@ function exprToTextNoParen(
         ctx.softline,
         "}",
       ]);
+    case "Restriction":
+      if (e.condition === true) return "{}";
+      return group([
+        "{",
+        indent([
+          ctx.softline,
+          exprToText(ctx, path.withChild(e.condition, "condition")),
+        ]),
+        ctx.softline,
+        "}",
+      ]);
+    case "Or":
+      // "Or" can only appear inside a restriction, which provides the group().
+      // Hence we don't put a group here even though it's binary.
+      return [
+        exprToText(ctx, path.withChild(e.left, "left")),
+        ",",
+        ctx.line,
+        exprToText(ctx, path.withChild(e.right, "right")),
+      ];
     case "BinaryExpression": {
       const left = exprToText(ctx, path.withChild(e.left, "left"));
       const right = exprToText(ctx, path.withChild(e.right, "right"));

--- a/text-mode-core/up/augToAST.ts
+++ b/text-mode-core/up/augToAST.ts
@@ -552,6 +552,17 @@ export function childLatexToAST(e: Aug.Latex.AnyChild): TextAST.Expression {
         branches: piecewiseBranches,
       };
     }
+    case "Restriction":
+      return {
+        type: "Restriction",
+        condition: e.condition === true ? true : childLatexToAST(e.condition),
+      };
+    case "Or":
+      return {
+        type: "Or",
+        left: childLatexToAST(e.left),
+        right: childLatexToAST(e.right),
+      };
     case "RepeatedOperator":
       return {
         type: "RepeatedExpression",

--- a/text-mode-core/up/needsParens.ts
+++ b/text-mode-core/up/needsParens.ts
@@ -71,10 +71,12 @@ export default function needsParens(path: NodePath): boolean {
         default:
           return true;
       }
+    case "Or": // "Or" is always a direct child of Or or Piecewise
     case "RangeExpression":
     case "ListExpression":
     case "ListComprehension":
     case "PiecewiseExpression":
+    case "Restriction":
       // They come with their own grouping ([] or {}), no need to add parens
       return false;
     case "Number":


### PR DESCRIPTION
Now `{x>2}` is parsed as a restriction instead of a piecewise; this allows stuff like `polygon(...)*{a>3}` to work.

This really makes me want to support implicit multiplication (omitting `*`). #756.
