### PR TITLE
Fix PillboxMenu nested dispatch (closes #780)

### DIFF
--- a/src/plugins/pillbox-menus/components/PillboxMenu.tsx
+++ b/src/plugins/pillbox-menus/components/PillboxMenu.tsx
@@ -88,8 +88,11 @@ export default class PillboxMenu extends Component<{
 
   didMountContainer() {
     if (this.pm.cc.isGraphSettingsOpen()) {
-      this.pm.cc.dispatch({
-        type: "close-graph-settings",
+      // don't dispatch during tick
+      setTimeout(() => {
+        this.pm.cc.dispatch({
+          type: "close-graph-settings",
+        });
       });
     }
     this.generalEventNames.forEach((name) =>


### PR DESCRIPTION
very basic pr, sure hope i didn't mess anything up
the delay between the menus opening and closing is minimal, <10ms
arises from didMountContainer getting called within a tick dispatched from toggleMenu