### PR TITLE
Handle operatornames in Intellisense

### DIFF
--- a/src/plugins/intellisense/view.tsx
+++ b/src/plugins/intellisense/view.tsx
@@ -121,6 +121,11 @@ export function latexStringToIdentifierString(str: string) {
   if (str.slice(1, 5) === "_{ }") return str[0];
   const ltx = parseDesmosLatex(str);
   if (ltx.type === "Identifier") return ltx._symbol;
+  else {
+    // E.g. "\\sin" doesn't parse but "\\sin()" does
+    const ltx = parseDesmosLatex(str + "()");
+    if (ltx.type === "FunctionCall") return ltx._symbol;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
Fixes #705. Doesn't show useful documentation, but at least it's not saying `n` for `sin()`.

![image](https://github.com/DesModder/DesModder/assets/20214911/0950c57a-eb82-4b90-b4e0-afd761c0b8b3)
![image](https://github.com/DesModder/DesModder/assets/20214911/29e8df46-9e6b-4a50-a316-7c8297e35986)
