### PR TITLE
Use idb instead of idb-keyval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/desmos": "^1.6.0",
         "client-zip": "^2.4.4",
         "eslint-plugin-rulesdir": "^0.2.2",
-        "idb-keyval": "^6.2.1",
+        "idb": "^8.0.0",
         "js-tokens": "^8.0.1",
         "moo": "^0.5.2",
         "prettier": "^2.8.8"
@@ -6047,10 +6047,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/idb-keyval": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+    "node_modules/idb": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
+      "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -15393,10 +15393,10 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
-    "idb-keyval": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+    "idb": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
+      "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@types/desmos": "^1.6.0",
     "client-zip": "^2.4.4",
     "eslint-plugin-rulesdir": "^0.2.2",
-    "idb-keyval": "^6.2.1",
+    "idb": "^8.0.0",
     "js-tokens": "^8.0.1",
     "moo": "^0.5.2",
     "prettier": "^2.8.8"


### PR DESCRIPTION
We'll use idb soon for Wakatime (#817), and no need to have two different IndexedDB wrappers
