### PR TITLE
Fix dot after subscriptify

### DIFF
--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -730,11 +730,10 @@ export default class Intellisense extends PluginController<{
           // no change but breaks cursor position
           if (ident.ident.length === 1) return;
 
+          const identWithoutSubscripts = ident.ident.replace(/_/g, "");
           if (
-            this.latestMQ.__options.autoOperatorNames[
-              ident.ident.replace(/_/g, "")
-            ] ||
-            this.latestMQ.__options.autoCommands[ident.ident.replace(/_/g, "")]
+            this.latestMQ.__options.autoOperatorNames[identWithoutSubscripts] ||
+            this.latestMQ.__options.autoCommands[identWithoutSubscripts]
           ) {
             return;
           }

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -260,7 +260,10 @@ export function getCorrectableIdentifier(mq: MathQuillField): {
 
     const ltx = cursor?.latex?.();
     if (ltx === undefined) break;
-    identifierSegments.push(ltx.replace(/[^a-zA-Z0-9]/g, ""));
+    const filteredLatex = ltx.replace(/[^a-zA-Z0-9]/g, "");
+    // MathQuill considers "." to be a digit, so filter out that case.
+    if (filteredLatex.length === 0) break;
+    identifierSegments.push(filteredLatex);
 
     if (subscript) {
       goBack += ltx === "_{ }" ? 1 : ltx.length - 3;


### PR DESCRIPTION
This fixes bug where `.` doesn't get typed after a subscript when the 'auto-subscriptify' option is enabled in Intellisense.