### PR TITLE
Fix intellisense key handling in the presence of other plugins

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -67,7 +67,13 @@ export default class DSM extends TransparentPlugins {
     this.applyStoredEnabled(recordToMap(dsmPreload.pluginsEnabled));
     delete window.DesModderPreload;
 
+    // Enable core plugins
     for (const { id } of pluginList) {
+      if (plugins.get(id)?.isCore) this._enablePlugin(id);
+    }
+    // Then all the other plugins
+    for (const { id } of pluginList) {
+      if (plugins.get(id)?.isCore) continue;
       if (this.isPluginEnabled(id)) this._enablePlugin(id);
     }
     this.pillboxMenus?.updateMenuView();

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -95,6 +95,7 @@ export default class DSM extends TransparentPlugins {
 
   disablePlugin(id: PluginID) {
     const plugin = plugins.get(id);
+    if (plugin?.isCore) throw new Error(`Core plugin ${id} cannot be disabled`);
     if (plugin && this.isPluginToggleable(id)) {
       if (this.isPluginEnabled(id)) {
         const plugin = this.enabledPlugins[id];

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -7,7 +7,7 @@ export class PluginController<
   static descriptionLearnMore?: string = undefined;
   static forceEnabled?: boolean = undefined;
   static config: readonly ConfigItem[] | undefined = undefined;
-  /** Core plugins get enabled before all others. TODO: and can't be disabled. */
+  /** Core plugins get enabled before all others and can't be disabled. */
   static isCore = false;
   calc = this.dsm.calc;
   cc = this.calc.controller;

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -7,6 +7,8 @@ export class PluginController<
   static descriptionLearnMore?: string = undefined;
   static forceEnabled?: boolean = undefined;
   static config: readonly ConfigItem[] | undefined = undefined;
+  /** Core plugins get enabled before all others. TODO: and can't be disabled. */
+  static isCore = false;
   calc = this.dsm.calc;
   cc = this.calc.controller;
 

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -96,76 +96,7 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
     if (this.calc.focusedMathQuill && this.settings.ctrlArrow) {
       const remove = hookIntoOverrideKeystroke(
         this.calc.focusedMathQuill.mq,
-        (key, _) => {
-          const mq = MathQuillView.getFocusedMathquill();
-
-          if (!mq) return true;
-          const navOption = NavigationTable[key];
-          if (!navOption) return true;
-
-          // type an empty string to force desmos to update
-          setTimeout(() => {
-            this.calc.focusedMathQuill?.typedText("");
-          }, 0);
-
-          // backspace is implicitly "left"
-          const dir = navOption.dir;
-          const mode = navOption.mode;
-
-          // remove the "Ctrl-" to get the normal arrow op to emulate
-          const arrowOp = key.slice(5);
-
-          const ctrlr = getController(mq);
-
-          const next = ctrlr.cursor?.[navOption.dir];
-
-          // if the next element is one of the following:
-          // bracket, fraction, sum, product, integral, sqrt, nthroot
-          // then skip over the entire thing when ctrl+arrowing (don't edit internals)
-          // Shift-arrow already does this behavior perfectly so we first do that.
-          // Then we do a normal arrow press to delete the selection.
-          if (isCtrlArrowSkippableSymbolMQElem(next?._el)) {
-            mq.keystroke(dir === R ? "Shift-Right" : "Shift-Left");
-
-            // remove selection if not extending a selection
-            if (mode !== "extend-sel") mq.keystroke(arrowOp);
-
-            // skip over entire variable names, numbers, and operatornames
-          } else if (
-            isAtStartOrEndOfASubscriptOrSuperscript(mq, dir) ||
-            (next && isWordMQElem(next._el))
-          ) {
-            // leave start/end of sub/sup
-            if (isAtStartOrEndOfASubscriptOrSuperscript(mq, dir))
-              mq.keystroke(arrowOp);
-
-            let i = 0;
-            while (isWordMQElem(ctrlr.cursor?.[dir]?._el) && i < 1000) {
-              // skip over super/subscript
-              if (isSupSubscriptMQElem(ctrlr.cursor?.[dir]?._el)) {
-                mq.keystroke(dir === R ? "Shift-Right" : "Shift-Left");
-
-                // remove selection if not extending selection
-                if (mode !== "extend-sel") mq.keystroke(arrowOp);
-              } else {
-                mq.keystroke(arrowOp);
-              }
-
-              // if at the start/end of a subscript/superscript block,
-              // then escape it
-              if (isAtStartOrEndOfASubscriptOrSuperscript(mq, dir)) {
-                mq.keystroke(arrowOp);
-              }
-              i++;
-            }
-
-            // treat it as a normal arrow key press in all other respects
-          } else {
-            mq.keystroke(arrowOp);
-          }
-
-          return false;
-        },
+        this.onMQKeystroke.bind(this),
         0,
         "better-nav-ctrl"
       );
@@ -173,6 +104,77 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
       if (remove) this.customRemoveHandlers.push(remove);
     }
   };
+
+  onMQKeystroke(key: string, _: KeyboardEvent) {
+    const mq = MathQuillView.getFocusedMathquill();
+
+    if (!mq) return true;
+    const navOption = NavigationTable[key];
+    if (!navOption) return true;
+
+    // type an empty string to force desmos to update
+    setTimeout(() => {
+      this.calc.focusedMathQuill?.typedText("");
+    }, 0);
+
+    // backspace is implicitly "left"
+    const dir = navOption.dir;
+    const mode = navOption.mode;
+
+    // remove the "Ctrl-" to get the normal arrow op to emulate
+    const arrowOp = key.slice(5);
+
+    const ctrlr = getController(mq);
+
+    const next = ctrlr.cursor?.[navOption.dir];
+
+    // if the next element is one of the following:
+    // bracket, fraction, sum, product, integral, sqrt, nthroot
+    // then skip over the entire thing when ctrl+arrowing (don't edit internals)
+    // Shift-arrow already does this behavior perfectly so we first do that.
+    // Then we do a normal arrow press to delete the selection.
+    if (isCtrlArrowSkippableSymbolMQElem(next?._el)) {
+      mq.keystroke(dir === R ? "Shift-Right" : "Shift-Left");
+
+      // remove selection if not extending a selection
+      if (mode !== "extend-sel") mq.keystroke(arrowOp);
+
+      // skip over entire variable names, numbers, and operatornames
+    } else if (
+      isAtStartOrEndOfASubscriptOrSuperscript(mq, dir) ||
+      (next && isWordMQElem(next._el))
+    ) {
+      // leave start/end of sub/sup
+      if (isAtStartOrEndOfASubscriptOrSuperscript(mq, dir))
+        mq.keystroke(arrowOp);
+
+      let i = 0;
+      while (isWordMQElem(ctrlr.cursor?.[dir]?._el) && i < 1000) {
+        // skip over super/subscript
+        if (isSupSubscriptMQElem(ctrlr.cursor?.[dir]?._el)) {
+          mq.keystroke(dir === R ? "Shift-Right" : "Shift-Left");
+
+          // remove selection if not extending selection
+          if (mode !== "extend-sel") mq.keystroke(arrowOp);
+        } else {
+          mq.keystroke(arrowOp);
+        }
+
+        // if at the start/end of a subscript/superscript block,
+        // then escape it
+        if (isAtStartOrEndOfASubscriptOrSuperscript(mq, dir)) {
+          mq.keystroke(arrowOp);
+        }
+        i++;
+      }
+
+      // treat it as a normal arrow key press in all other respects
+    } else {
+      mq.keystroke(arrowOp);
+    }
+
+    return false;
+  }
 
   afterEnable() {
     this.afterConfigChange();

--- a/src/plugins/expr-action-buttons/index.ts
+++ b/src/plugins/expr-action-buttons/index.ts
@@ -6,6 +6,7 @@ import { ItemModel } from "#globals";
 export default class ExprActionButtons extends PluginController<undefined> {
   static id = "expr-action-buttons" as const;
   static enabledByDefault = true;
+  static isCore = true;
 
   beforeDisable() {
     throw new Error(

--- a/src/plugins/index-replacements.ts
+++ b/src/plugins/index-replacements.ts
@@ -6,6 +6,7 @@ import extraExpressionButtons from "#plugins/expr-action-buttons/expr-action-but
 import findReplace from "#plugins/find-replace/find-replace.replacements";
 import hideErrors from "#plugins/hide-errors/hide-errors.replacements";
 import metadata from "#plugins/manage-metadata/manage-metadata.replacements";
+import overrideKeystroke from "#plugins/override-keystroke/override-keystroke.replacements";
 import pillbox from "#plugins/pillbox-menus/pillbox-menus.replacements";
 import pinExpressions from "#plugins/pin-expressions/pin-expressions.replacements";
 import rightClickTray from "#plugins/right-click-tray/right-click-tray.replacements";
@@ -18,6 +19,7 @@ import insertPanels from "../preload/moduleOverrides/insert-panels.replacements"
 export default [
   insertPanels,
   metadata,
+  overrideKeystroke,
   pillbox,
   betterEvaluationView,
   findReplace,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -28,6 +28,7 @@ import VideoCreator from "./video-creator";
 import Wakatime from "./wakatime";
 import WolframToDesmos from "./wolfram2desmos";
 import BetterNavigation from "./better-navigation";
+import OverrideKeystroke from "./override-keystroke";
 
 interface ConfigItemGeneric {
   // indentation level for hierarchical relationships in settings
@@ -131,6 +132,7 @@ export const keyToPlugin = {
   textMode: TextMode,
   performanceInfo: PerformanceInfo,
   metadata: ManageMetadata,
+  overrideKeystroke: OverrideKeystroke,
   multiline: Multiline,
   intellisense: Intellisense,
   compactView: CompactView,
@@ -186,6 +188,7 @@ export class TransparentPlugins implements KeyToPluginInstance {
   get textMode () { return this.ep["text-mode"]; }
   get performanceInfo () { return this.ep["performance-info"]; }
   get metadata () { return this.ep["manage-metadata"]; }
+  get overrideKeystroke () { return this.ep["override-keystroke"]; }
   get intellisense () { return this.ep["intellisense"]; }
   get compactView () { return this.ep["compact-view"]; }
   get multiline () { return this.ep["multiline"]; }

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -485,6 +485,7 @@ export default class Intellisense extends PluginController<{
       this.isActiveElementValidForIntellisense()
     ) {
       this.canHaveIntellisense = true;
+      this.view?.update();
     }
 
     // Jump to definition
@@ -535,6 +536,7 @@ export default class Intellisense extends PluginController<{
       return;
 
     this.canHaveIntellisense = false;
+    this.view?.update();
   };
 
   jumpToDefinitionById(id: string) {

--- a/src/plugins/manage-metadata/index.ts
+++ b/src/plugins/manage-metadata/index.ts
@@ -8,6 +8,7 @@ import { getMetadata, setMetadata } from "./sync";
 export default class ManageMetadata extends PluginController {
   static id = "manage-metadata" as const;
   static enabledByDefault = true;
+  static isCore = true;
 
   graphMetadata: GraphMetadata = getBlankMetadata();
 

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -191,78 +191,75 @@ export default class Multiline extends PluginController<Config> {
     if (this.calc.focusedMathQuill) {
       const remove = hookIntoOverrideKeystroke(
         this.calc.focusedMathQuill.mq,
-        (key, _) => {
-          const mq = this.calc.focusedMathQuill?.mq;
-
-          if (key === "Shift-Enter" && this.settings.spacesToNewlines) {
-            if (mq) {
-              mq.typedText("   ");
-              this.enqueueVerticalifyOperation(
-                mq.__controller.container.querySelector(".dcg-mq-root-block")!
-              );
-              setTimeout(() => {
-                this.dequeueAllMultilinifications();
-              });
-            }
-
-            return false;
-          }
-
-          if (
-            mq &&
-            key.endsWith("Backspace") &&
-            this.settings.spacesToNewlines
-          ) {
-            if (isNextToTripleSpaceLineBreak(mq, L)) {
-              mq.keystroke("Backspace");
-              mq.keystroke("Backspace");
-              mq.keystroke("Backspace");
-              return false;
-            }
-          }
-
-          if (mq && key.endsWith("Del") && this.settings.spacesToNewlines) {
-            if (isNextToTripleSpaceLineBreak(mq, R)) {
-              mq.keystroke("Del");
-              mq.keystroke("Del");
-              mq.keystroke("Del");
-              return false;
-            }
-          }
-
-          // handle arrow nav with spaces2newlines
-          if (
-            mq &&
-            (key.endsWith("Left") || key.endsWith("Right")) &&
-            this.settings.spacesToNewlines
-          ) {
-            const right = key.endsWith("Right");
-            const shift = key.includes("Shift");
-
-            const arrowDir =
-              (shift ? "Shift-" : "") + (right ? "Right" : "Left");
-            const dir = right ? R : L;
-
-            // check for three consecutive spaces
-            if (isNextToTripleSpaceLineBreak(mq, dir)) {
-              mq.keystroke(arrowDir);
-              mq.keystroke(arrowDir);
-              mq.keystroke(arrowDir);
-              return false;
-            }
-          }
-
-          if (key === "Shift-Up" || key === "Shift-Down") {
-            this.doMultilineVerticalNav(key);
-            return false;
-          }
-        },
+        this.onMQKeystroke.bind(this),
         1,
         "multiline"
       );
       if (remove) this.customHandlerRemovers.push(remove);
     }
   };
+
+  onMQKeystroke(key: string, _: KeyboardEvent) {
+    const mq = this.calc.focusedMathQuill?.mq;
+
+    if (key === "Shift-Enter" && this.settings.spacesToNewlines) {
+      if (mq) {
+        mq.typedText("   ");
+        this.enqueueVerticalifyOperation(
+          mq.__controller.container.querySelector(".dcg-mq-root-block")!
+        );
+        setTimeout(() => {
+          this.dequeueAllMultilinifications();
+        });
+      }
+
+      return false;
+    }
+
+    if (mq && key.endsWith("Backspace") && this.settings.spacesToNewlines) {
+      if (isNextToTripleSpaceLineBreak(mq, L)) {
+        mq.keystroke("Backspace");
+        mq.keystroke("Backspace");
+        mq.keystroke("Backspace");
+        return false;
+      }
+    }
+
+    if (mq && key.endsWith("Del") && this.settings.spacesToNewlines) {
+      if (isNextToTripleSpaceLineBreak(mq, R)) {
+        mq.keystroke("Del");
+        mq.keystroke("Del");
+        mq.keystroke("Del");
+        return false;
+      }
+    }
+
+    // handle arrow nav with spaces2newlines
+    if (
+      mq &&
+      (key.endsWith("Left") || key.endsWith("Right")) &&
+      this.settings.spacesToNewlines
+    ) {
+      const right = key.endsWith("Right");
+      const shift = key.includes("Shift");
+
+      const arrowDir = (shift ? "Shift-" : "") + (right ? "Right" : "Left");
+      const dir = right ? R : L;
+
+      // check for three consecutive spaces
+      if (isNextToTripleSpaceLineBreak(mq, dir)) {
+        mq.keystroke(arrowDir);
+        mq.keystroke(arrowDir);
+        mq.keystroke(arrowDir);
+        return false;
+      }
+    }
+
+    if (key === "Shift-Up" || key === "Shift-Down") {
+      this.doMultilineVerticalNav(key);
+      return false;
+    }
+  }
 
   findCursorX() {
     const cursor = document.querySelector(".dcg-mq-cursor");

--- a/src/plugins/override-keystroke/index.ts
+++ b/src/plugins/override-keystroke/index.ts
@@ -1,0 +1,43 @@
+import { PluginID } from "..";
+import { PluginController } from "../PluginController";
+
+type MQKeystrokeCallback = (
+  key: string,
+  event: KeyboardEvent
+) => undefined | "cancel";
+
+export default class OverrideKeystroke extends PluginController {
+  static id = "override-keystroke" as const;
+  static enabledByDefault = true;
+  static isCore = true;
+
+  private readonly mqKeystrokeListeners = new Map<
+    PluginID,
+    MQKeystrokeCallback
+  >();
+
+  onMQKeystroke(key: string, event: KeyboardEvent): undefined | "cancel" {
+    const plugins = [...this.mqKeystrokeListeners.keys()].sort();
+    for (const pluginID of plugins) {
+      if (!this.dsm.isPluginEnabled(pluginID)) continue;
+      const cb = this.mqKeystrokeListeners.get(pluginID);
+      if (!cb) continue;
+      const ret = cb(key, event);
+      if (ret === "cancel") return "cancel";
+    }
+  }
+
+  /**
+   * Add a listener. They will be resolved in sorted order by ID.
+   * If one listener returns "cancel", then later listeners will not run.
+   */
+  setMQKeystrokeListener(pluginID: PluginID, cb: MQKeystrokeCallback) {
+    this.mqKeystrokeListeners.set(pluginID, cb);
+  }
+
+  beforeDisable() {
+    throw new Error(
+      "Programming Error: core plugin Override Keystroke should not be disableable"
+    );
+  }
+}

--- a/src/plugins/override-keystroke/override-keystroke.replacements
+++ b/src/plugins/override-keystroke/override-keystroke.replacements
@@ -1,0 +1,18 @@
+# Override Keystroke
+
+*plugin* `override-keystroke` `intellisense` `multiline` `better-navigation`
+
+## Duplicate metadata when an expression is duplicated
+
+*Description* `Duplicate metadata (e.g. GLesmos enabled, or pinned/unpinned) when an expression is duplicated`
+
+*Find* => `from`
+```js
+overrideKeystroke: ($key, $e) => {
+```
+
+*Replace* `from` with
+```js
+overrideKeystroke: ($key, $e) => {
+  if (DSM.overrideKeystroke?.onMQKeystroke($key, $e) === "cancel") return;
+```

--- a/src/plugins/pillbox-menus/index.ts
+++ b/src/plugins/pillbox-menus/index.ts
@@ -8,6 +8,7 @@ import { plugins, PluginID, ConfigItem } from "#plugins/index.ts";
 export default class PillboxMenus extends PluginController<undefined> {
   static id = "pillbox-menus" as const;
   static enabledByDefault = true;
+  static isCore = true;
   expandedPlugin: PluginID | null = null;
   private expandedCategory: string | null = null;
 

--- a/src/preload/moduleReplacements.ts
+++ b/src/preload/moduleReplacements.ts
@@ -35,6 +35,9 @@ const pluginNames = [
   "code-golf",
   "syntax-highlighting",
   "better-navigation",
+  "multiline",
+  "intellisense",
+  "override-keystroke",
 ];
 
 replacements.forEach((r) => {

--- a/src/utils/listenerHelpers.ts
+++ b/src/utils/listenerHelpers.ts
@@ -1,4 +1,3 @@
-import { MathQuillField } from "#components";
 import type { Calc, DispatchedEvent } from "#globals";
 
 interface DispatchOverridingHandler {
@@ -103,33 +102,6 @@ export function propGetSet<Obj extends object, Key extends keyof Obj>(
   key: Key
 ) {
   return [() => obj[key], (v: Obj[Key]) => (obj[key] = v)] as const;
-}
-
-// override all keyboard inputs entering a MathQuill field
-// and optionally prevent them from doing their default behavior
-export function hookIntoOverrideKeystroke(
-  // field for which to override kb inputs
-  mq: MathQuillField,
-  // callback function
-  // return false to override all other events
-  fn: (key: string, evt: KeyboardEvent) => boolean | undefined,
-  // higher priority --> runs first
-  priority: number,
-  // unique key to prevent adding duplicate hooks
-  key: string
-) {
-  return hookIntoFunction(
-    mq.__options,
-    "overrideKeystroke",
-    key,
-    priority,
-    (stop, k, e) => {
-      const cont = fn(k, e);
-      if (cont === false) {
-        stop();
-      }
-    }
-  );
 }
 
 type HookedFunctionCallback<Fn extends (...args: any[]) => any> = (


### PR DESCRIPTION
Multiline, Better Navigation, and Intellisense each hook into the key handler using monkey-patching. Now they've started conflicting each other.

Instead of monkey-patching, use a replacement (regular-patching) and call a method on a new override-keystrokes plugin.

The ?w=1 flag https://github.com/DesModder/DesModder/pull/824/files?w=1 removes whitespace-only changes.