### PR TITLE
Don't wrap text inside segmented control for video creator

### DIFF
--- a/src/plugins/video-creator/components/MainPopup.less
+++ b/src/plugins/video-creator/components/MainPopup.less
@@ -94,3 +94,8 @@ input.dsm-vc-outfile-name {
   animation-duration: 10s;
   animation-name: delayed-reveal;
 }
+
+.dsm-vc-popover .dcg-segmented-control-interior {
+  // lang=ja text can be longer when all capture methods are available.
+  text-wrap: nowrap;
+}


### PR DESCRIPTION
The Japanese titles were wrapping for some reason.