### PR TITLE
add strong-mismatched-brackets option to plugin custom-mq-config

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -325,6 +325,8 @@ custom-mathquill-config-opt-extendedGreek-name = More Greek Letters
 custom-mathquill-config-opt-extendedGreek-desc = Enables replacements for all supported greek letters
 custom-mathquill-config-opt-lessFSpacing-name = Less Spacing Around "f"
 custom-mathquill-config-opt-lessFSpacing-desc = Reduces extra spacing around the letter "f"
+custom-mathquill-config-opt-strongMismatchedBrackets-name = strong mismatch brackets
+custom-mathquill-config-opt-strongMismatchedBrackets-desc = prevent '(' from matching with ']' and vice versa
 
 ## Code Golf
 code-golf-name = Code Golf

--- a/src/plugins/custom-mathquill-config/config.ts
+++ b/src/plugins/custom-mathquill-config/config.ts
@@ -65,6 +65,11 @@ export const configList = [
     type: "boolean",
     default: false,
   },
+  {
+    key: "strongMismatchedBrackets",
+    type: "boolean",
+    default: false,
+  },
 ] satisfies ConfigItem[];
 
 export interface Config {

--- a/src/plugins/custom-mathquill-config/custom-mathquill-config.replacements
+++ b/src/plugins/custom-mathquill-config/custom-mathquill-config.replacements
@@ -1,0 +1,20 @@
+# custom mathquill config Replacements
+
+*plugin* `better-evaluation-view`
+
+## Override mismatching brackets object
+
+*Description* `Override the damned object responsible for matching '[' with ')' and '(' with ']'`
+
+*Find* => `mismatchedBrackets`
+```js
+{"(":"]","[":")"}
+```
+
+*Replace* `mismatchedBrackets` with
+```js
+{
+    "(": DesModder.exposedPlugins['custom-mathquill-config']?.settings?.strongMismatchedBrackets ? ")" : "]",
+    "[": DesModder.exposedPlugins['custom-mathquill-config']?.settings?.strongMismatchedBrackets ? "]" : ")"
+}
+```

--- a/src/plugins/index-replacements.ts
+++ b/src/plugins/index-replacements.ts
@@ -15,6 +15,7 @@ import showTips from "#plugins/show-tips/show-tips.replacements";
 import syntaxHighlighting from "#plugins/syntax-highlighting/syntax-highlighting.replacements";
 import textMode from "#plugins/text-mode/text-mode.replacements";
 import insertPanels from "../preload/moduleOverrides/insert-panels.replacements";
+import customMathQuillConfig from "#plugins/custom-mathquill-config/custom-mathquill-config.replacements";
 
 export default [
   insertPanels,
@@ -34,4 +35,5 @@ export default [
   rightClickTray,
   codeGolf,
   syntaxHighlighting,
+  customMathQuillConfig,
 ];


### PR DESCRIPTION
making this pr to fix something that bothered me for the longest time; 
brackets and parentheses matching with each other
![image](https://github.com/DesModder/DesModder/assets/109063662/ff607cd9-e5bc-4268-a208-d43fe5587786)

I put it in the custom-mathquill-config plugin because I think it fits there, even though it's not part of the mathquill config object and uses replacements. I also didn't want to create another new plugin just for this small change.
