### PR TITLE
Fix cancelling slow captures (slider and ticks)

### DIFF
--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -1,5 +1,5 @@
 import VideoCreator from "..";
-import { cancelCapture, CaptureMethod } from "../backend/capture";
+import { CaptureMethod } from "../backend/capture";
 import "./CaptureMethod.css";
 import { Component, jsx } from "#DCGView";
 import {
@@ -245,7 +245,7 @@ export default class SelectCapture extends Component<{
                 <Button
                   color="light-gray"
                   class="dsm-vc-cancel-capture-button"
-                  onTap={() => cancelCapture(this.vc)}
+                  onTap={() => this.vc.cancelCapture()}
                 >
                   {format("video-creator-cancel-capture")}
                 </Button>


### PR DESCRIPTION
The problem was we were stopping the capture by throwing an error. But it was inside a callback (sometimes), so that didn't work in some situations. Now, no error throwing. Use promises without rejecting.

Fixes https://github.com/DesModder/DesModder/issues/776