### PR TITLE
Remove home link disable on panic popover

### DIFF
--- a/src/panic/panic.html
+++ b/src/panic/panic.html
@@ -92,10 +92,6 @@
   body.dsm-panic-open #dsm-panic-reopen-button {
     display: none;
   }
-  body:not(.dsm-panic-open) .dcg-header .dcg-home-link {
-    pointer-events: none;
-    cursor: default;
-  }
 </style>
 <div id="dsm-panic-popover">
   <button class="dsm-panic-close-button" id="dsm-panic-x-button">✖</button>


### PR DESCRIPTION
I presume this change was made a while ago when the panic button was on top of Desmos' home link. I was checking the git history of this line, and it seems the last change was about a year ago in May, so I think it lines up. Either way the purpose of this change is because currently the link is unclickable until the popover is open, but then it is blocked, so it renders the home link unusable.