### PR TITLE
Remove dead code: `getQueryParams`

### DIFF
--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -94,7 +94,6 @@ export const Fragile = new Proxy(
     isRedo: (e: KeyboardEvent) => boolean;
     isHelp: (e: KeyboardEvent) => boolean;
   };
-  getQueryParams: () => Record<string, string | true>;
   List: {
     removeItemById: (listModel: any, id: string) => void;
     moveItemsTo: (listModel: any, from: number, to: number, n: number) => void;

--- a/src/plugins/builtin-settings/index.ts
+++ b/src/plugins/builtin-settings/index.ts
@@ -1,6 +1,5 @@
 import { PluginController } from "../PluginController";
 import { Config, configList } from "./config";
-import { getQueryParams } from "#utils/depUtils.ts";
 
 const managedKeys = configList.map((e) => e.key);
 
@@ -12,7 +11,6 @@ export default class BuiltinSettings extends PluginController<Config> {
 
   afterEnable() {
     this.initialSettings = { ...this.settings };
-    const queryParams = getQueryParams();
     for (const key of managedKeys) {
       this.initialSettings[key] =
         (
@@ -21,15 +19,6 @@ export default class BuiltinSettings extends PluginController<Config> {
             authorFeatures: boolean;
           }
         )[key] ?? false;
-    }
-    const queryConfig: Partial<Config> = {};
-    for (const key of managedKeys) {
-      if (queryParams[key]) {
-        queryConfig[key] = true;
-      }
-      if (queryParams["no" + key]) {
-        queryConfig[key] = false;
-      }
     }
     this.updateSettings(this.settings);
   }

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -31,8 +31,6 @@ export function EvaluateSingleExpression(calc: Calc, s: string): number {
   return evaluateLatex(s, calc.controller.isDegreeMode());
 }
 
-export const getQueryParams = Fragile.getQueryParams;
-
 export const autoCommandNames: string =
   Private.MathquillConfig?.getAutoCommands?.();
 export const autoOperatorNames: string =


### PR DESCRIPTION
First introduced in #144 (809397df0f731a76ed0282b0792220a96bce4655), but it has since been removed in favor of referencing `Calc.settings` directly.