### PR TITLE
Don't update video creator latex when menu closed

### DIFF
--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -106,6 +106,10 @@ export default class VideoCreator extends PluginController {
     }
   }
 
+  isMenuOpen() {
+    return this.dsm.pillboxMenus?.pillboxMenuOpen === "dsm-vc-menu";
+  }
+
   afterEnable() {
     this.calc.observe("graphpaperBounds", () => this.graphpaperBoundsChanged());
     this._applyDefaultCaptureSize();

--- a/src/plugins/video-creator/orientation.ts
+++ b/src/plugins/video-creator/orientation.ts
@@ -214,6 +214,7 @@ export class Orientation {
   }
 
   applySpinningSpeedFromGraph() {
+    if (!this.vc.isMenuOpen()) return;
     if (this._applyingSpinningOrientation) return;
     const sd = this.getSpinningSpeedAndDirection();
     if (!sd) return;
@@ -279,6 +280,7 @@ export class Orientation {
 
   _applyingSpinningOrientation = false;
   updateLatexOrientationFromGraph() {
+    if (!this.vc.isMenuOpen()) return;
     const grapher3d = this.cc.grapher3d;
     if (!grapher3d) return;
     if (this._applyingSpinningOrientation) return;


### PR DESCRIPTION
This fixes bug where you can't scroll while a graph is spinning.

Really, the listeners should only be attached when the view is mounted, but I struggled getting that to work.