### PR TITLE
Handle exprId not passed in

### DIFF
--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -69,7 +69,7 @@ $DCGView.createElement($Tooltip,
 ```js
 DSM.replaceElement(
   () => __errorTriangle__,
-  () => DSM.hideErrors?.errorTriangle(this.props.exprId())
+  () => DSM.hideErrors?.errorTriangle(this.props.exprId?.() ?? "")
 )
 ```
 


### PR DESCRIPTION
This happens for error triangles other than the main statement, such as for clickable objects with undefined variables.