### PR TITLE
Fix container selector

### DIFF
--- a/src/components/Button.less
+++ b/src/components/Button.less
@@ -1,4 +1,4 @@
-.dcg-calculator-api-container {
+.dcg-container {
   .dsm-btn {
     display: inline-block;
     line-height: 28px;

--- a/src/components/SegmentedControl.less
+++ b/src/components/SegmentedControl.less
@@ -1,6 +1,4 @@
-.dcg-calculator-api-container
-  .dsm-menu-container
-  .dcg-segmented-control-container {
+.dcg-container .dsm-menu-container .dcg-segmented-control-container {
   .dcg-segmented-control-btn.dcg-disabled {
     pointer-events: none;
     cursor: default;

--- a/src/plugins/custom-mathquill-config/custom-mathquill-config.less
+++ b/src/plugins/custom-mathquill-config/custom-mathquill-config.less
@@ -1,24 +1,21 @@
 .commaizer {
-  .dcg-calculator-api-container .dcg-mq-root-block .dcg-mq-group-start,
-  .dcg-calculator-api-container
+  .dcg-container .dcg-mq-root-block .dcg-mq-group-start,
+  .dcg-container
     .dcg-mq-math-mode
     .dcg-mq-root-block
     .dcg-mq-group-start::before {
     content: var(--delimiter-override);
   }
 
-  .dcg-calculator-api-container .dcg-mq-root-block .dcg-mq-group-start,
-  .dcg-calculator-api-container
-    .dcg-mq-math-mode
-    .dcg-mq-root-block
-    .dcg-mq-group-start {
+  .dcg-container .dcg-mq-root-block .dcg-mq-group-start,
+  .dcg-container .dcg-mq-math-mode .dcg-mq-root-block .dcg-mq-group-start {
     margin-left: 0;
     margin-right: 0;
   }
 }
 
 .less-f-spacing {
-  .dcg-calculator-api-container .dcg-mq-math-mode var.dcg-mq-f {
+  .dcg-container .dcg-mq-math-mode var.dcg-mq-f {
     margin-left: unset;
     margin-right: 0.05em;
   }

--- a/src/plugins/find-replace/ReplaceBar.less
+++ b/src/plugins/find-replace/ReplaceBar.less
@@ -22,7 +22,7 @@
     color: darken(@color, 20%);
   }
 
-  .dcg-calculator-api-container &.dsm-disabled {
+  .dcg-container &.dsm-disabled {
     color: @color;
     opacity: 0.3;
     cursor: default;

--- a/src/plugins/hide-errors/hide-errors.less
+++ b/src/plugins/hide-errors/hide-errors.less
@@ -1,7 +1,4 @@
-.dcg-calculator-api-container
-  .dcg-create-sliders
-  .dsm-hide-errors
-  .dcg-btn-slider {
+.dcg-container .dcg-create-sliders .dsm-hide-errors .dcg-btn-slider {
   // ensure [hide] button is upright text, not italics
   font-style: normal;
 }

--- a/src/plugins/pillbox-menus/components/PillboxMenu.less
+++ b/src/plugins/pillbox-menus/components/PillboxMenu.less
@@ -1,4 +1,4 @@
-.dcg-calculator-api-container
+.dcg-container
   .dsm-menu-container.dcg-constrained-height-popover
   .dcg-popover-interior {
   padding: 10px;
@@ -16,7 +16,7 @@
   }
 }
 
-.dcg-calculator-api-container
+.dcg-container
   .dcg-settings-container.dcg-left.dcg-geometry-settings-container.dcg-constrained-height-popover {
   top: 53px;
   right: 43px;
@@ -28,7 +28,7 @@
   }
 }
 
-.dcg-calculator-api-container
+.dcg-container
   .dcg-tooltip-positioning-container
   .dcg-tooltip-message-container
   .dcg-tooltip-message {

--- a/src/plugins/pin-expressions/pinExpressions.less
+++ b/src/plugins/pin-expressions/pinExpressions.less
@@ -10,7 +10,7 @@
   }
 }
 
-body .dcg-calculator-api-container {
+body .dcg-container {
   .dsm-has-pinned-expressions .dcg-expression-top-bar.dcg-expressions-scrolled {
     box-shadow: none;
   }

--- a/src/plugins/set-primary-color/_overrides.less
+++ b/src/plugins/set-primary-color/_overrides.less
@@ -1,21 +1,13 @@
-.dsm-set-primary-color.dcg-calculator-api-container {
-  .trip-block .trip-interior {
-    border: 3px solid rgb(var(--dsm-primary-color-rgb));
+// MACHINE-GENERATED FILE: Do not edit, except by clean-css.mjs.
+.dsm-set-primary-color.dcg-sliding-interior {
+  .dcg-geo-token-view {
+    border: 2px solid rgb(var(--dsm-primary-color-rgb));
   }
-  .trip-block .trip-interior .trip-link {
-    color: rgb(var(--dsm-primary-color-rgb));
+  .dcg-geo-token-view:not(.dcg-static-token).dcg-focus-visible {
+    box-shadow: 0 0 0 3px rgba(var(--dsm-primary-color-rgb), 128) !important;
   }
-  .trip-block.trip-n .trip-arrow {
-    border-top-color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .trip-block.trip-s .trip-arrow {
-    border-bottom-color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .trip-block.trip-e .trip-arrow {
-    border-right-color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .trip-block.trip-w .trip-arrow {
-    border-left-color: rgb(var(--dsm-primary-color-rgb));
+  .dcg-text--dark-blue {
+    color: rgb(var(--dsm-primary-dark-5-rgb));
   }
   .dcg-grapher-focused {
     box-shadow: inset 0 0 0 3px rgba(var(--dsm-primary-color-rgb), 153);
@@ -29,35 +21,33 @@
   .dcg-btn-blue,
   .dcg-btn-primary {
     background: rgb(var(--dsm-primary-color-rgb));
-    border: 1px solid rgb(var(--dsm-primary-dark-1-rgb));
+    border: 1px solid rgb(var(--dsm-primary-light-1-rgb));
   }
   .dcg-btn-blue.dcg-hovered,
-  .dcg-btn-primary.dcg-hovered {
-    background: rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  .dcg-btn-blue.dcg-depressed,
-  .dcg-btn-primary.dcg-depressed {
+  .dcg-btn-blue.dcg-focus-visible,
+  .dcg-btn-primary.dcg-hovered,
+  .dcg-btn-primary.dcg-focus-visible {
     background: rgb(var(--dsm-primary-dark-3-rgb));
   }
   .dcg-btn-secondary {
     border: 1px solid rgb(var(--dsm-primary-color-rgb));
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-btn-secondary.dcg-hovered {
-    border-color: rgb(var(--dsm-primary-dark-1-rgb));
-    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-dark-1-rgb));
+  .dcg-btn-secondary.dcg-hovered,
+  .dcg-btn-secondary.dcg-focus-visible {
+    border-color: rgb(var(--dsm-primary-dark-3-rgb));
+    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-dark-3-rgb));
     color: rgb(var(--dsm-primary-dark-4-rgb));
   }
   .dcg-btn-secondary.dcg-depressed {
-    border-color: rgb(var(--dsm-primary-dark-3-rgb));
-    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-dark-3-rgb));
     color: rgb(var(--dsm-primary-dark-5-rgb));
-    background: rgba(var(--dsm-primary-color-rgb), 0.1);
+    background: rgba(var(--dsm-primary-color-rgb), 26);
   }
   .dcg-primary-link {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-primary-link.dcg-hovered {
+  .dcg-primary-link.dcg-hovered,
+  .dcg-primary-link.dcg-focus-visible {
     color: rgb(var(--dsm-primary-dark-4-rgb));
   }
   .dcg-primary-link.dcg-depressed {
@@ -68,8 +58,24 @@
     border: 1px solid rgb(var(--dsm-primary-color-rgb));
     box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-text--dark-blue {
+  .dcg-blue-link {
+    color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-blue-link.dcg-hovered,
+  .dcg-blue-link.dcg-focus-visible {
+    color: rgb(var(--dsm-primary-dark-4-rgb));
+  }
+  .dcg-blue-link.dcg-depressed {
     color: rgb(var(--dsm-primary-dark-5-rgb));
+  }
+  .dcg-shared-tab-gray-underline.dcg-selected {
+    color: rgb(var(--dsm-primary-color-rgb));
+    border-bottom: 3px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  input.dcg-shared-input-blue-outline:focus,
+  textarea.dcg-shared-input-blue-outline:focus {
+    border: 1px solid rgb(var(--dsm-primary-color-rgb));
+    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-popover .dcg-language-picker .dcg-language-header {
     color: rgb(var(--dsm-primary-color-rgb));
@@ -79,20 +85,37 @@
     border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-geo-token-view {
-    border: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-geo-token-view:not(.dcg-static-token).dcg-focus-visible {
-    box-shadow: 0 0 0 3px rgba(var(--dsm-primary-color-rgb), 128) !important;
-  }
   .dcg-multi-select-header .dcg-btn-outline[role="button"].dcg-focus-visible,
   .dcg-multi-select-header .dcg-navigate-back[role="button"].dcg-focus-visible,
   .dcg-multi-select-header .dcg-delete-btn[role="button"].dcg-focus-visible,
   .dcg-multi-select-header .dcg-more-options[role="button"].dcg-focus-visible {
     box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128) !important;
   }
+  .dcg-options-menu button.dcg-focus-visible,
+  .dcg-options-menu button.dcg-hovered:not(.dcg-disabled) {
+    box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128);
+  }
+  .dcg-options-menu textarea:focus {
+    border: 1px solid rgb(var(--dsm-primary-color-rgb));
+    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  }
   .dcg-component-checkbox.dcg-checked .dcg-checkbox i {
     color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-container .dcg-label-container input:focus:not([disabled]) {
+    border-color: rgb(var(--dsm-primary-color-rgb));
+    box-shadow: 0 1px rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-segmented-control-container
+    .dcg-segmented-control-btn.dcg-theme-mini.dcg-selected {
+    background: rgba(var(--dsm-primary-color-rgb), 38);
+    border-color: rgb(var(--dsm-primary-color-rgb));
+    color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-segmented-control-container
+    .dcg-segmented-control-btn.dcg-theme-mini.dcg-selected
+    + .dcg-segmented-control-btn {
+    border-left: 1px solid rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-move-to-folder input:focus {
     border: 1px solid rgb(var(--dsm-primary-color-rgb));
@@ -106,6 +129,8 @@
     .dcg-math-field.dcg-invalid,
   .dcg-table-column-menu .dcg-iconed-mathquill-row .dcg-math-field.dcg-focus,
   .dcg-table-column-menu .dcg-iconed-mathquill-row .dcg-math-field.dcg-invalid,
+  .dcg-image-options-menu .dcg-iconed-mathquill-row .dcg-math-field.dcg-focus,
+  .dcg-image-options-menu .dcg-iconed-mathquill-row .dcg-math-field.dcg-invalid,
   .dcg-generic-options-menu .dcg-iconed-mathquill-row .dcg-math-field.dcg-focus,
   .dcg-generic-options-menu
     .dcg-iconed-mathquill-row
@@ -117,34 +142,38 @@
     .dcg-color-tile.dcg-focus-visible {
     box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128) !important;
   }
-  .dcg-container .dcg-label-container input:focus:not([disabled]) {
-    border-color: rgb(var(--dsm-primary-color-rgb));
-    box-shadow: 0 1px rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-segmented-control-container
-    .dcg-segmented-control-btn.dcg-theme-mini.dcg-selected {
-    background: rgba(var(--dsm-primary-color-rgb), 0.15);
-    border-color: rgb(var(--dsm-primary-color-rgb));
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-segmented-control-container
-    .dcg-segmented-control-btn.dcg-theme-mini.dcg-selected
-    + .dcg-segmented-control-btn {
-    border-left: 1px solid rgb(var(--dsm-primary-color-rgb));
-  }
   .dcg-multi-select-transformations-menu
     .dcg-new-transformations-container
     .dcg-new-transformation
     i.dcg-icon-reflection:after {
     border-right: 2px dashed rgba(var(--dsm-primary-color-rgb), 0.5);
   }
-  .dcg-options-menu button.dcg-focus-visible,
-  .dcg-options-menu button.dcg-hovered:not(.dcg-disabled) {
-    box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128);
+  .dcg-basic-keypad .dcg-keypad-btn-container .dcg-keypad-btn.dcg-btn-tall-blue,
+  .dcg-basic-keypad
+    .dcg-keypad-btn-container
+    .dcg-keypad-btn.dcg-btn-short-blue {
+    background: rgb(var(--dsm-primary-color-rgb));
+    border: 1px solid rgb(var(--dsm-primary-light-1-rgb));
   }
-  .dcg-options-menu textarea:focus {
-    border: 1px solid rgb(var(--dsm-primary-color-rgb));
-    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  .dcg-basic-keypad
+    .dcg-keypad-btn-container
+    .dcg-keypad-btn.dcg-btn-tall-blue.dcg-hovered:not(.dcg-disabled),
+  .dcg-basic-keypad
+    .dcg-keypad-btn-container
+    .dcg-keypad-btn.dcg-btn-short-blue.dcg-hovered:not(.dcg-disabled) {
+    background: rgb(var(--dsm-primary-dark-3-rgb));
+  }
+  .dcg-complex-tool-instruction-view .dcg-step-completed i {
+    color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-complex-tool-instruction-view .dcg-step-active-icon span {
+    background: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-complex-tool-instruction-view
+    .dcg-mathquill-wrapper
+    .dcg-mq-container
+    .dcg-math-field.dcg-focus {
+    border: 2px solid rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-inline-math-input-view .dcg-math-field.dcg-focus,
   .dcg-inline-math-input-view .dcg-math-field.dcg-invalid {
@@ -158,118 +187,23 @@
     border: 2px solid rgba(var(--dsm-primary-color-rgb), 0.35);
   }
   .dcg-slider-interior .dcg-thumb .dcg-graphic {
-    background: rgba(var(--dsm-primary-color-rgb), 0.35);
+    background: rgba(var(--dsm-primary-color-rgb), 89);
   }
   .dcg-slider-interior .dcg-thumb .dcg-center {
     background: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-smart-textarea-container .dcg-displayTextarea a {
-    color: rgb(var(--dsm-primary-color-rgb));
+  .dcg-geo-basic-tools
+    .dcg-geo-basic-tools-row
+    .dcg-tool-button-container
+    > button.dcg-focus-visible {
+    box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128) !important;
   }
-  .dcg-smart-textarea-container .dcg-displayTextarea a.dcg-hovered,
-  .dcg-smart-textarea-container .dcg-displayTextarea a .dcg-depressed {
-    color: rgb(var(--dsm-primary-dark-4-rgb));
-  }
-  .dcg-expressionitem.dcg-expressiontable .dcg-show-more-row td .dcg-show-more {
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-expressionitem.dcg-expressiontable
-    .dcg-show-more-row
-    td
-    .dcg-show-more.dcg-hovered {
-    color: rgb(var(--dsm-primary-dark-4-rgb));
-  }
-  .dcg-expressionitem.dcg-expressiontable
-    .dcg-show-more-row
-    td
-    .dcg-show-more.dcg-depressed {
-    color: rgb(var(--dsm-primary-dark-5-rgb));
-  }
-  .dcg-expressionitem.dcg-expressiontable
-    .dcg-tabledata
-    .dcg-row
-    .dcg-cell.dcg-selected:not(.dcg-non-editable)
-    .dcg-inner-border {
-    border: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-expression-search-bar .dcg-math-field.dcg-mq-focused {
-    border: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-expression-search-bar
-    .dcg-search-replace-icon-container
-    .dcg-icon-check {
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-ticker
-    .dcg-ticker-settings-internal
-    .dcg-action-definition
-    .dcg-math-field.dcg-focus,
-  .dcg-ticker
-    .dcg-ticker-settings-internal
-    .dcg-action-definition
-    .dcg-math-field.dcg-invalid {
-    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-ticker
-    .dcg-ticker-settings-internal
-    .dcg-action-frequency
-    .dcg-math-field.dcg-focus,
-  .dcg-ticker
-    .dcg-ticker-settings-internal
-    .dcg-action-frequency
-    .dcg-math-field.dcg-invalid {
-    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-clickable-section .dcg-clickable-menu-row .dcg-math-field.dcg-focus,
-  .dcg-clickable-section .dcg-clickable-menu-row .dcg-math-field.dcg-invalid {
-    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-label-orientation-view .dcg-orientation-option.dcg-selected {
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-label-orientation-view .dcg-orientation-option.dcg-selected.dcg-hovered {
-    color: rgb(var(--dsm-primary-dark-4-rgb));
-  }
-  .dcg-image-options-menu
-    .dcg-clickable-image-controls
-    .dcg-clickable-menu-row
-    .dcg-math-field.dcg-focus,
-  .dcg-image-options-menu
-    .dcg-clickable-image-controls
-    .dcg-clickable-menu-row
-    .dcg-math-field.dcg-invalid {
-    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-image-options-menu
-    .dcg-clickable-image-controls
-    .dcg-clickable-menu-row
-    input:focus:not([disabled]) {
-    border-color: rgb(var(--dsm-primary-color-rgb));
-    box-shadow: 0 1px rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-basic-keypad .dcg-keypad-btn-container .dcg-keypad-btn.dcg-btn-tall-blue,
-  .dcg-basic-keypad
-    .dcg-keypad-btn-container
-    .dcg-keypad-btn.dcg-btn-short-blue {
-    background: rgb(var(--dsm-primary-color-rgb));
-    border: 1px solid rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  .dcg-basic-keypad
-    .dcg-keypad-btn-container
-    .dcg-keypad-btn.dcg-btn-tall-blue.dcg-hovered:not(.dcg-disabled),
-  .dcg-basic-keypad
-    .dcg-keypad-btn-container
-    .dcg-keypad-btn.dcg-btn-short-blue.dcg-hovered:not(.dcg-disabled) {
-    background: rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  .dcg-basic-keypad
-    .dcg-keypad-btn-container
-    .dcg-keypad-btn.dcg-btn-tall-blue.dcg-depressed:not(.dcg-disabled),
-  .dcg-basic-keypad
-    .dcg-keypad-btn-container
-    .dcg-keypad-btn.dcg-btn-short-blue.dcg-depressed:not(.dcg-disabled) {
-    background: rgb(var(--dsm-primary-dark-3-rgb));
-    border: 1px solid rgb(var(--dsm-primary-dark-3-rgb));
+  .dcg-geo-basic-tools
+    .dcg-geo-basic-tools-row
+    .dcg-tool-button-container
+    > button.dcg-selected {
+    border: 1px solid rgb(var(--dsm-primary-color-rgb));
+    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-settings-container
     .dcg-axes-settings-container
@@ -296,49 +230,97 @@
     border: 1px solid rgb(var(--dsm-primary-color-rgb));
     box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-settings-container
-    .dcg-braille-container
-    .dcg-refreshable-braille-note
-    a {
+  .dcg-settings-view-3d-container
+    .dcg-inline-math-input-view
+    .dcg-math-field.dcg-focus,
+  .dcg-settings-view-3d-container
+    .dcg-inline-math-input-view
+    .dcg-math-field.dcg-invalid {
+    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-clickable-section .dcg-clickable-menu-row .dcg-math-field.dcg-focus,
+  .dcg-clickable-section .dcg-clickable-menu-row .dcg-math-field.dcg-invalid {
+    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-label-orientation-view .dcg-orientation-option.dcg-selected {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-geometry-toolbar-view .dcg-complex-tool-success i.dcg-icon-check {
-    color: rgb(var(--dsm-primary-color-rgb));
+  .dcg-label-orientation-view .dcg-orientation-option.dcg-selected.dcg-hovered {
+    color: rgb(var(--dsm-primary-dark-4-rgb));
   }
-  .dcg-geo-basic-tools
-    .dcg-geo-basic-tools-row
-    .dcg-tool-button-container:focus-within
-    > button:not(.dcg-depressed) {
-    box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128) !important;
-  }
-  .dcg-geo-basic-tools
-    .dcg-geo-basic-tools-row
-    .dcg-tool-button-container
-    > button.dcg-focus-visible,
-  .dcg-geo-basic-tools
-    .dcg-geo-basic-tools-row
-    .dcg-tool-button-container
-    > button.dcg-hovered:not(.dcg-disabled) {
-    box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128) !important;
-  }
-  .dcg-geo-basic-tools
-    .dcg-geo-basic-tools-row
-    .dcg-tool-button-container
-    > button.dcg-selected {
-    border: 1px solid rgb(var(--dsm-primary-color-rgb));
-    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-complex-tool-instruction-view .dcg-step-completed i {
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-complex-tool-instruction-view .dcg-step-active-icon span {
-    background: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-complex-tool-instruction-view
-    .dcg-mathquill-wrapper
-    .dcg-mq-container
-    .dcg-math-field.dcg-focus {
+  .dcg-expression-search-bar .dcg-math-field.dcg-mq-focused {
     border: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-expression-search-bar
+    .dcg-search-replace-icon-container
+    .dcg-icon-check {
+    color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-smart-textarea-container .dcg-displayTextarea a {
+    color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-smart-textarea-container .dcg-displayTextarea a.dcg-hovered,
+  .dcg-smart-textarea-container .dcg-displayTextarea a .dcg-depressed {
+    color: rgb(var(--dsm-primary-dark-4-rgb));
+  }
+  .dcg-image-options-menu
+    .dcg-clickable-image-controls
+    .dcg-clickable-menu-row
+    .dcg-math-field.dcg-focus,
+  .dcg-image-options-menu
+    .dcg-clickable-image-controls
+    .dcg-clickable-menu-row
+    .dcg-math-field.dcg-invalid {
+    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-image-options-menu
+    .dcg-clickable-image-controls
+    .dcg-clickable-menu-row
+    input:focus:not([disabled]) {
+    border-color: rgb(var(--dsm-primary-color-rgb));
+    box-shadow: 0 1px rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-expressionitem.dcg-expressiontable .dcg-show-more-row td .dcg-show-more {
+    color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-expressionitem.dcg-expressiontable
+    .dcg-show-more-row
+    td
+    .dcg-show-more.dcg-hovered {
+    color: rgb(var(--dsm-primary-dark-4-rgb));
+  }
+  .dcg-expressionitem.dcg-expressiontable
+    .dcg-show-more-row
+    td
+    .dcg-show-more.dcg-depressed {
+    color: rgb(var(--dsm-primary-dark-5-rgb));
+  }
+  .dcg-expressionitem.dcg-expressiontable
+    .dcg-tabledata
+    .dcg-row
+    .dcg-cell.dcg-selected:not(.dcg-non-editable)
+    .dcg-inner-border {
+    border: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-ticker
+    .dcg-ticker-settings-internal
+    .dcg-action-definition
+    .dcg-math-field.dcg-focus,
+  .dcg-ticker
+    .dcg-ticker-settings-internal
+    .dcg-action-definition
+    .dcg-math-field.dcg-invalid {
+    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-ticker
+    .dcg-ticker-settings-internal
+    .dcg-action-frequency
+    .dcg-math-field.dcg-focus,
+  .dcg-ticker
+    .dcg-ticker-settings-internal
+    .dcg-action-frequency
+    .dcg-math-field.dcg-invalid {
+    border-bottom: 2px solid rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-custom-toolbar-settings-modal
     .dcg-configuration-grid-row
@@ -354,34 +336,28 @@
     .dcg-braille-input:focus {
     box-shadow: inset 0 0 0 2px rgb(var(--dsm-primary-color-rgb)) !important;
   }
-  .dcg-shared-btn-blue {
-    background: rgb(var(--dsm-primary-color-rgb));
-    border: 1px solid rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  .dcg-shared-btn-blue.dcg-hovered:not(.dcg-disabled) {
-    background: rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  .dcg-shared-btn-blue.dcg-depressed:not(.dcg-disabled) {
-    background: rgb(var(--dsm-primary-dark-3-rgb));
-    border: 1px solid rgb(var(--dsm-primary-dark-3-rgb));
-  }
-  .dcg-shared-blue-link {
+  .dcg-quest__header .dcg-header-link {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-shared-blue-link.dcg-hovered {
+  .dcg-quest__header .dcg-header-link.dcg-hovered,
+  .dcg-quest__header .dcg-header-link.dcg-focus-visible {
     color: rgb(var(--dsm-primary-dark-4-rgb));
+    border-bottom: 2px solid rgb(var(--dsm-primary-dark-4-rgb));
   }
-  .dcg-shared-blue-link.dcg-depressed {
+  .dcg-quest__header .dcg-header-link.dcg-depressed {
     color: rgb(var(--dsm-primary-dark-5-rgb));
+    border-bottom: 2px solid rgb(var(--dsm-primary-dark-4-rgb));
   }
-  .dcg-shared-tab-gray-underline.dcg-selected {
-    color: rgb(var(--dsm-primary-color-rgb));
-    border-bottom: 3px solid rgb(var(--dsm-primary-color-rgb));
+  .dcg-quest__header .dcg-header-link.dcg-active {
+    color: rgb(var(--dsm-primary-dark-5-rgb));
+    border-bottom: 2px solid rgb(var(--dsm-primary-dark-5-rgb));
   }
-  input.dcg-shared-input-blue-outline:focus,
-  textarea.dcg-shared-input-blue-outline:focus {
-    border: 1px solid rgb(var(--dsm-primary-color-rgb));
-    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  .dcg-quest__step-status-container .dcg-validation-checkmark:after {
+    border-right: 2px solid rgb(var(--dsm-primary-color-rgb));
+    border-top: 2px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-quest__step-status-container .dcg-satisfied {
+    border-color: rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-suggestions
     .dcg-feedback-action-container
@@ -393,18 +369,11 @@
     .dcg-icon-check {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-selectable-input-container .dcg-copy-button {
-    background: rgb(var(--dsm-primary-color-rgb));
+  .dcg-resources-content .dcg-resource-link.dcg-resources-view-all-quests span {
+    color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-selectable-input-container .dcg-copy-button.dcg-hovered {
-    background: rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  .dcg-selectable-input-container .dcg-copy-button.dcg-depressed {
-    background: rgb(var(--dsm-primary-dark-3-rgb));
-  }
-  .dcg-selectable-input-container .dcg-permalink:focus {
-    border-color: rgb(var(--dsm-primary-color-rgb));
-    box-shadow: inset 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  .dcg-shared-options-dropdown .dropdown-explanations .explanation a {
+    color: rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-share-container .dcg-share-actions .dcg-print-link i,
   .dcg-share-container .dcg-share-actions .dcg-export-image-link i,
@@ -415,7 +384,7 @@
   .dcg-share-container .dcg-share-actions .dcg-print-link.dcg-hovered i,
   .dcg-share-container .dcg-share-actions .dcg-export-image-link.dcg-hovered i,
   .dcg-share-container .dcg-share-actions .dcg-embed-link.dcg-hovered i {
-    background: rgba(var(--dsm-primary-color-rgb), 0.15);
+    background: rgba(var(--dsm-primary-color-rgb), 38);
   }
   .dcg-share-container .dcg-share-actions .dcg-print-link.dcg-depressed i,
   .dcg-share-container .dcg-share-actions .dcg-print-link.dcg-selected i,
@@ -426,7 +395,7 @@
   .dcg-share-container .dcg-share-actions .dcg-export-image-link.dcg-selected i,
   .dcg-share-container .dcg-share-actions .dcg-embed-link.dcg-depressed i,
   .dcg-share-container .dcg-share-actions .dcg-embed-link.dcg-selected i {
-    background: rgba(var(--dsm-primary-color-rgb), 0.3);
+    background: rgba(var(--dsm-primary-color-rgb), 77);
   }
   .dcg-share-container .dcg-embed-div textarea:focus {
     border: 1px solid rgb(var(--dsm-primary-color-rgb));
@@ -453,55 +422,62 @@
   .dcg-share-container .dcg-failed .dcg-action-close.dcg-depressed {
     color: rgb(var(--dsm-primary-dark-5-rgb));
   }
-  .dcg-shared-options-dropdown .dropdown-explanations .explanation a {
+  .dcg-selectable-input-container .dcg-copy-button {
+    background: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-selectable-input-container .dcg-copy-button.dcg-hovered {
+    background: rgb(var(--dsm-primary-dark-3-rgb));
+  }
+  .dcg-selectable-input-container .dcg-permalink:focus {
+    border-color: rgb(var(--dsm-primary-color-rgb));
+    box-shadow: inset 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-tour-step .dcg-trip-interior {
+    border: 3px solid rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-tour-step .dcg-trip-interior .dcg-trip-link {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-shared-options-dropdown
-    .dropdown-choice:not(.dropdown-choice-disabled).blue-link {
+  .dcg-tour-step.dcg-tour-step-n .dcg-trip-arrow {
+    border-top-color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-tour-step.dcg-tour-step-s .dcg-trip-arrow {
+    border-bottom-color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-tour-step.dcg-tour-step-e .dcg-trip-arrow {
+    border-right-color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-tour-step.dcg-tour-step-w .dcg-trip-arrow {
+    border-left-color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .modal .input:focus {
+    border: 1px solid rgb(var(--dsm-primary-color-rgb));
+    box-shadow: inset 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  }
+  .modal a {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-shared-options-dropdown
-    .dropdown-choice:not(.dropdown-choice-disabled).blue-link.dcg-hovered {
+  .modal a.dcg-hovered {
     color: rgb(var(--dsm-primary-dark-4-rgb));
-  }
-  .dcg-shared-options-dropdown
-    .dropdown-choice:not(.dropdown-choice-disabled).blue-link.dcg-depressed {
-    color: rgb(var(--dsm-primary-dark-5-rgb));
   }
   .dcg-shared-account-settings-dialog .dcg-shared-confirmation-message {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-keypad-control-bar
-    .dcg-keypad-control-btn:not(.dcg-disabled).dcg-selectable-btn:after {
-    background: rgba(var(--dsm-primary-color-rgb), 0.5);
-  }
-  .dcg-keypad-control-bar
-    .dcg-keypad-control-btn:not(
-      .dcg-disabled
-    ).dcg-selectable-btn.dcg-selected:after {
-    background: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-settings-dropdown .dcg-download-button.dcg-braille-equations {
+  .dcg-contest-submission-dialog .dcg-delete-btn,
+  .dcg-contest-submission-dialog .dcg-resubmit-link {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-settings-dropdown
-    .dcg-download-button.dcg-braille-equations.dcg-hovered:not(.dcg-disabled) {
-    color: rgb(var(--dsm-primary-dark-4-rgb));
+  .dcg-contest-submission-dialog .dcg-delete-btn.dcg-hovered,
+  .dcg-contest-submission-dialog .dcg-resubmit-link.dcg-hovered {
+    -webkit-text-decoration: rgb(var(--dsm-primary-dark-4-rgb));
+    text-decoration: rgb(var(--dsm-primary-dark-4-rgb));
   }
-  .dcg-settings-dropdown
-    .dcg-download-button.dcg-braille-equations.dcg-depressed:not(
-      .dcg-disabled
-    ) {
+  .dcg-contest-submission-dialog .dcg-delete-btn.dcg-depressed,
+  .dcg-contest-submission-dialog .dcg-resubmit-link.dcg-depressed {
     color: rgb(var(--dsm-primary-dark-5-rgb));
   }
-  .dcg-braille-io-keypad-container .dcg-braille-io-keypad a {
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-braille-io-keypad-container .dcg-braille-io-keypad a.dcg-hovered {
-    color: rgb(var(--dsm-primary-dark-4-rgb));
-  }
-  .dcg-braille-io-keypad-container .dcg-braille-io-keypad a.dcg-depressed {
-    color: rgb(var(--dsm-primary-dark-5-rgb));
+  .dcg-search-container input:focus {
+    border-color: rgb(var(--dsm-primary-color-rgb));
   }
   .dcg-basic-expression.dcg-focused {
     border-color: rgb(var(--dsm-primary-color-rgb));
@@ -519,65 +495,34 @@
   .dcg-basic-expression .dcg-mq-selection .dcg-mq-ans {
     background: rgb(var(--dsm-primary-color-rgb));
   }
-  #export-image-dialog .dcg-download-not-enabled-notice {
-    border: 2px solid rgb(var(--dsm-primary-color-rgb));
-    background: rgba(var(--dsm-primary-color-rgb), 0.1);
-  }
-  #export-image-dialog .dcg-download-button-group .dcg-button {
-    background: rgb(var(--dsm-primary-color-rgb));
-  }
-  #export-image-dialog
-    .dcg-download-button-group
-    .dcg-button.dcg-hovered:not(.dcg-disabled) {
-    background: rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  #export-image-dialog
-    .dcg-download-button:not(.dcg-braille-equations):not(.dcg-svg-button) {
-    background: rgb(var(--dsm-primary-color-rgb));
-  }
-  #export-image-dialog
-    .dcg-download-button:not(.dcg-braille-equations):not(
-      .dcg-svg-button
-    ).dcg-hovered:not(.dcg-disabled) {
-    background: rgb(var(--dsm-primary-dark-1-rgb));
-  }
-  #export-image-dialog .dcg-download-button.dcg-braille-equations {
-    border: 1px solid rgb(var(--dsm-primary-color-rgb));
+  .dcg-braille-io-keypad-container .dcg-braille-io-keypad a {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  #export-image-dialog
-    .dcg-download-button.dcg-braille-equations.dcg-hovered:not(.dcg-disabled) {
-    box-shadow: 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  .dcg-braille-io-keypad-container .dcg-braille-io-keypad a.dcg-hovered {
     color: rgb(var(--dsm-primary-dark-4-rgb));
   }
-  #export-image-dialog
-    .dcg-download-button.dcg-braille-equations.dcg-depressed:not(
-      .dcg-disabled
-    ) {
-    background: rgba(var(--dsm-primary-color-rgb), 0.2);
-  }
-  #export-image-dialog .dcg-svg-popover .dcg-beta-tag {
-    background: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-contest-submission-dialog .dcg-resubmit-link {
-    color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .dcg-contest-submission-dialog .dcg-resubmit-link.dcg-hovered {
-    -webkit-text-decoration: rgb(var(--dsm-primary-dark-4-rgb));
-    text-decoration: rgb(var(--dsm-primary-dark-4-rgb));
-  }
-  .dcg-contest-submission-dialog .dcg-resubmit-link.dcg-depressed {
+  .dcg-braille-io-keypad-container .dcg-braille-io-keypad a.dcg-depressed {
     color: rgb(var(--dsm-primary-dark-5-rgb));
   }
-  .modal .input:focus {
-    border: 1px solid rgb(var(--dsm-primary-color-rgb));
-    box-shadow: inset 0 0 0 1px rgb(var(--dsm-primary-color-rgb));
+  .dcg-keypad-control-bar
+    .dcg-keypad-control-btn:not(.dcg-disabled).dcg-selectable-btn:after {
+    background: rgba(var(--dsm-primary-color-rgb), 128);
   }
-  .modal a {
-    color: rgb(var(--dsm-primary-color-rgb));
+  .dcg-keypad-control-bar
+    .dcg-keypad-control-btn:not(
+      .dcg-disabled
+    ).dcg-selectable-btn.dcg-selected:after {
+    background: rgb(var(--dsm-primary-color-rgb));
   }
-  .modal a.dcg-hovered {
-    color: rgb(var(--dsm-primary-dark-4-rgb));
+  #export-image-dialog .dcg-download-not-enabled-notice {
+    border: 2px solid rgb(var(--dsm-primary-color-rgb));
+    background: rgba(var(--dsm-primary-color-rgb), 26);
+  }
+  .dcg-dropdown-container .dcg-dropdown-input.dcg-focus-visible {
+    border-color: rgb(var(--dsm-primary-color-rgb));
+  }
+  .dcg-dropdown-container .dcg-dropdown-option.dcg-focus-visible {
+    box-shadow: 0 0 0 2px rgba(var(--dsm-primary-color-rgb), 128) inset;
   }
   .dcg-loading-container .dcg-cancel-while-loading {
     color: rgba(var(--dsm-primary-color-rgb), 128);
@@ -587,8 +532,5 @@
   }
   .dcg-loading-container .dcg-cancel-while-loading.dcg-depressed {
     color: rgb(var(--dsm-primary-color-rgb));
-  }
-  .syncing-status-bar .success-status-text {
-    background: rgb(var(--dsm-primary-color-rgb));
   }
 }

--- a/src/plugins/set-primary-color/clean-css.mjs
+++ b/src/plugins/set-primary-color/clean-css.mjs
@@ -37,6 +37,8 @@ const colorMapping = {
   "#347ff5": "--dsm-primary-light-1-rgb", // 1.11
   "52,127,245": "--dsm-primary-light-1-rgb",
   // primary btn border (on dark bg); for simplicity make same as light-1
+  "#4380e0": "--dsm-primary-light-1-rgb",
+  "67,128,224": "--dsm-primary-light-1-rgb",
   "#4480e0": "--dsm-primary-light-1-rgb", // nonlinear, avg 1.2
   "68,128,224": "--dsm-primary-light-1-rgb",
   // Green from Desmos. Will probably be patched
@@ -97,9 +99,8 @@ css = css
 css = css.replace(/(?:[^\n]*,\n)*[^\n]*{\s*}/g, "");
 // Remove duplicated newlines
 css = css.replace(/\n{2,}/g, "\n");
-// Remove leading ".dcg-calculator-api-container "
-css = css.replaceAll(".dcg-calculator-api-container ", "");
+// Remove leading ".dcg-calculator-api-container-vXX "
+css = css.replaceAll(/.dcg-calculator-api-container\S+ /g, "");
 
-console.log(
-  ".dsm-set-primary-color.dcg-calculator-api-container { " + css + "}"
-);
+console.log("// MACHINE-GENERATED FILE: Do not edit, except by clean-css.mjs.");
+console.log(".dsm-set-primary-color.dcg-sliding-interior { " + css + "}");

--- a/src/plugins/set-primary-color/custom-overrides.less
+++ b/src/plugins/set-primary-color/custom-overrides.less
@@ -1,6 +1,6 @@
 // "Fix" the save button by making the save-ok state colorful again
 // Styles are copied from .dcg-btn-primary
-.dsm-set-primary-color.dcg-calculator-api-container {
+.dsm-set-primary-color.dcg-sliding-interior {
   .dcg-action-save.dcg-btn-white-outline {
     background: rgb(var(--dsm-primary-color-rgb));
     border: 1px solid rgb(var(--dsm-primary-dark-2-rgb));
@@ -16,7 +16,7 @@
   }
 }
 // Fix borders around tokens
-.dsm-set-primary-color.dcg-calculator-api-container .dcg-geo-token-view {
+.dsm-set-primary-color.dcg-sliding-interior .dcg-geo-token-view {
   border-color: currentColor;
 }
 // Provide defaults for links and such used in DesModder but not Desmos

--- a/src/plugins/set-primary-color/index.ts
+++ b/src/plugins/set-primary-color/index.ts
@@ -49,9 +49,8 @@ export default class SetPrimaryColor extends PluginController<Config> {
   apiContainer!: HTMLElement;
 
   afterEnable() {
-    this.apiContainer = document.querySelector(
-      ".dcg-calculator-api-container"
-    )!;
+    // .dcg-sliding-interior contains everything (header and body)
+    this.apiContainer = document.querySelector(".dcg-sliding-interior")!;
     this.applyConfig();
     this.apiContainer.classList.add("dsm-set-primary-color");
     this.senseDarkReader();

--- a/src/plugins/show-tips/Tip.less
+++ b/src/plugins/show-tips/Tip.less
@@ -1,4 +1,4 @@
-.dcg-calculator-api-container.dsm-show-tips {
+.dcg-container.dsm-show-tips {
   .dcg-expressions-branding > :not(.dsm-usage-tip) {
     display: none;
   }

--- a/src/plugins/show-tips/index.ts
+++ b/src/plugins/show-tips/index.ts
@@ -3,7 +3,7 @@ import { Inserter, PluginController } from "../PluginController";
 import Tip from "./Tip";
 
 function apiContainer() {
-  return document.querySelector(".dcg-calculator-api-container");
+  return document.querySelector(".dcg-container");
 }
 
 export default class ShowTips extends PluginController {


### PR DESCRIPTION
Desmos changed `.dcg-calculator-api-container` to `dcg-calculator-api-container-v1_10`. PR changes to using either `.dcg-container` (for most stuff) or `.dcg-sliding-interior` (for set-primary-color, which also has to affect the header).