### PR TITLE
Add "fast screenshots" option for 2d video creator

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -193,6 +193,7 @@ video-creator-angle-speed = Speed:
 video-creator-step-count = Step count:
 video-creator-frame-count = Frame count:
 video-creator-target-same-pixel-ratio = Target same pixel ratio
+video-creator-fast-screenshot = Fast screenshots
 video-creator-target-tooltip = Adjusts scaling of line width, point size, label size, etc.
 video-creator-ffmpeg-loading = FFmpeg loading...
 video-creator-ffmpeg-fail = If this doesn't work in the next few seconds, try reloading the page or reporting this bug to DesModder devs.

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -44,6 +44,11 @@ async function screenshot3d(vc: VideoCreator, size: ScreenshotOpts) {
 }
 
 async function screenshot2d(vc: VideoCreator, size: ScreenshotOpts) {
+  if (vc.fastScreenshots) {
+    return await new Promise<string>((resolve) => {
+      vc.cc.evaluator.notifyWhenSynced(() => resolve(vc.calc.screenshot(size)));
+    });
+  }
   // make the captured region entirely visible
   const { width, height } = size;
   const pixelBounds = vc.calc.graphpaperBounds.pixelCoordinates;

--- a/src/plugins/video-creator/components/CaptureMethod.css
+++ b/src/plugins/video-creator/components/CaptureMethod.css
@@ -38,11 +38,15 @@
   margin-left: 8px;
 }
 
+.dsm-vc-fast-screenshots {
+  margin-bottom: 8px;
+}
+
 .dsm-vc-pixel-ratio {
   margin-bottom: 8px;
 }
 
-.dsm-vc-pixel-ratio-inner {
+.dsm-vc-checkbox-inner {
   cursor: pointer;
 }
 

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -167,6 +167,21 @@ export default class SelectCapture extends Component<{
           ntimes: () => null,
           once: () => null,
         })}
+        <If predicate={() => !this.vc.cc.is3dProduct()}>
+          {() => (
+            <div class="dsm-vc-fast-screenshots">
+              <Checkbox
+                checked={() => this.vc.fastScreenshots}
+                onChange={(checked) => this.vc.setFastScreenshots(checked)}
+                ariaLabel="Fast screenshots"
+              >
+                <span class="dsm-vc-checkbox-inner">
+                  {format("video-creator-fast-screenshot")}
+                </span>
+              </Checkbox>
+            </div>
+          )}
+        </If>
         <div class="dsm-vc-capture-size">
           {format("video-creator-size")}
           <ManagedNumberInput
@@ -213,9 +228,9 @@ export default class SelectCapture extends Component<{
                   tooltip={() => format("video-creator-target-tooltip")}
                   gravity="n"
                 >
-                  <div class="dsm-vc-pixel-ratio-inner">
+                  <span class="dsm-vc-checkbox-inner">
                     {format("video-creator-target-same-pixel-ratio")}
-                  </div>
+                  </span>
                 </Tooltip>
               </Checkbox>
             </div>

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -76,6 +76,7 @@ export default class VideoCreator extends PluginController {
   readonly captureHeight = this.managedNumberInputModel("");
   readonly captureWidth = this.managedNumberInputModel("");
   samePixelRatio = false;
+  fastScreenshots = true;
 
   readonly or = new Orientation(this);
 
@@ -260,6 +261,11 @@ export default class VideoCreator extends PluginController {
 
   getCaptureHeightNumber() {
     return this.captureHeight.getValue();
+  }
+
+  setFastScreenshots(fastScreenshot: boolean) {
+    this.fastScreenshots = fastScreenshot;
+    this.updateView();
   }
 
   setSamePixelRatio(samePixelRatio: boolean) {


### PR DESCRIPTION
It just calls `.screenshot()` instead of `.asyncScreenshot`. Made possible by the `notifyWhenSynced` function.

I don't know why I yapped so much at #184. Fixes #184.