### PR TITLE
Fix/style glitch

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -7,6 +7,7 @@ export default class Button extends Component<{
   class?: MaybeClassDict;
   onTap: (e: Event) => void;
   disabled?: boolean;
+  children?: any;
 }> {
   template() {
     return (
@@ -24,7 +25,7 @@ export default class Button extends Component<{
         }
         onTap={(e: Event) => !this.props.disabled?.() && this.props.onTap(e)}
       >
-        {this.children}
+        {this.props.children}
       </span>
     );
   }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,7 +3,7 @@ import { Component, jsx } from "#DCGView";
 import { mergeClass, MaybeClassDict } from "#utils/utils.ts";
 
 export default class Button extends Component<{
-  color: "primary" | "red" | "light-gray";
+  color: "blue" | "red" | "light-gray";
   class?: MaybeClassDict;
   onTap: (e: Event) => void;
   disabled?: boolean;

--- a/src/plugins/performance-info/PerformanceView.tsx
+++ b/src/plugins/performance-info/PerformanceView.tsx
@@ -64,7 +64,7 @@ export class PerformanceView extends Component<{
         <div class="dsm-pi-refresh-state-button-container">
           <Tooltip tooltip={format("performance-info-refresh-graph-tooltip")}>
             <Button
-              color="primary"
+              color="blue"
               class="dsm-pi-refresh-state-button"
               onTap={() => {
                 this.props.pi().refreshState();

--- a/src/plugins/set-primary-color/_overrides.less
+++ b/src/plugins/set-primary-color/_overrides.less
@@ -18,15 +18,12 @@
   .dcg-graphpaper-branding .dcg-edit-branding.dcg-hovered i {
     color: rgb(var(--dsm-primary-color-rgb));
   }
-  .dcg-btn-blue,
-  .dcg-btn-primary {
+  .dcg-btn-blue {
     background: rgb(var(--dsm-primary-color-rgb));
     border: 1px solid rgb(var(--dsm-primary-light-1-rgb));
   }
   .dcg-btn-blue.dcg-hovered,
-  .dcg-btn-blue.dcg-focus-visible,
-  .dcg-btn-primary.dcg-hovered,
-  .dcg-btn-primary.dcg-focus-visible {
+  .dcg-btn-blue.dcg-focus-visible {
     background: rgb(var(--dsm-primary-dark-3-rgb));
   }
   .dcg-btn-secondary {

--- a/src/plugins/set-primary-color/custom-overrides.less
+++ b/src/plugins/set-primary-color/custom-overrides.less
@@ -1,5 +1,5 @@
 // "Fix" the save button by making the save-ok state colorful again
-// Styles are copied from .dcg-btn-primary
+// Styles are copied from .dcg-btn-blue
 .dsm-set-primary-color.dcg-sliding-interior {
   .dcg-action-save.dcg-btn-white-outline {
     background: rgb(var(--dsm-primary-color-rgb));

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -96,14 +96,14 @@ export default class SelectCapture extends Component<{
                 {() => (
                   <div class="dsm-vc-action-navigate-container">
                     <Button
-                      color="primary"
+                      color="blue"
                       onTap={() => this.vc.addToActionIndex(-1)}
                       disabled={() => this.vc.isCapturing}
                     >
                       {format("video-creator-prev-action")}
                     </Button>
                     <Button
-                      color="primary"
+                      color="blue"
                       onTap={() => this.vc.addToActionIndex(+1)}
                       disabled={() => this.vc.isCapturing}
                     >
@@ -242,7 +242,7 @@ export default class SelectCapture extends Component<{
             {
               true: () => (
                 <Button
-                  color="primary"
+                  color="blue"
                   class="dsm-vc-capture-frame-button"
                   disabled={() =>
                     this.vc.isCapturing ||

--- a/src/plugins/video-creator/components/MainPopup.tsx
+++ b/src/plugins/video-creator/components/MainPopup.tsx
@@ -152,7 +152,7 @@ export default class MainPopup extends Component<{
               />
               <div class="dsm-vc-export">
                 <Button
-                  color="primary"
+                  color="blue"
                   class="dsm-vc-export-frames-button"
                   onTap={() => {
                     void this.vc.exportFrames();

--- a/src/tests/puppeteer-utils.ts
+++ b/src/tests/puppeteer-utils.ts
@@ -70,7 +70,7 @@ async function makeNewPage() {
 }
 
 const ENTER_ELM = ".dcg-action-toggle-edit.dcg-icon-btn";
-const EXIT_ELM = ".dcg-action-toggle-edit.dcg-btn-primary";
+const EXIT_ELM = ".dcg-action-toggle-edit.dcg-btn-blue";
 
 export class Driver {
   enabledPluginsStart!: string[];

--- a/src/utils/utilComponents.tsx
+++ b/src/utils/utilComponents.tsx
@@ -4,6 +4,7 @@ import { For } from "#components";
 export class IndexFor<T> extends Component<{
   each: () => T[];
   key: (t: T) => string | number;
+  children?: any;
 }> {
   template() {
     const indexCache = new Map<string | number, number>();
@@ -25,7 +26,7 @@ export class IndexFor<T> extends Component<{
         key={([e]) => this.props.key(e)}
       >
         {([e, index]: [T, () => number]) => {
-          return (this.children as any)[0](e, index);
+          return this.props?.children(e, index);
         }}
       </For>
     );


### PR DESCRIPTION
This patch fixes
- missing style from blue buttons
- missing text from all buttons
- intellisense showing an empty list

Notes:
Let me know if the way I fixed the change from `this.children` to `this.prop.children` is OK. I could not figure out how the children property was assigned formerly (I assumed through Desmos code from stepping through the code), so I just took the shotcut and added children as a component property of the appropriate components as type `any`.

I have tested only on Chrome. I will test later on Firefox.