### PR TITLE
Fix draw order lookup in Intellisense

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -269,7 +269,7 @@ interface CalcPrivate {
       }[];
       __itemIdToModel: Record<string, ItemModel>;
 
-      drawOrder: string[];
+      drawLayers: { drawOrder: string[] }[];
     };
     _addItemToEndFromAPI: (item: ItemModel) => void;
     _showToast: (toast: Toast) => void;

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -269,7 +269,7 @@ interface CalcPrivate {
       }[];
       __itemIdToModel: Record<string, ItemModel>;
 
-      drawLayers: { drawOrder: string[] }[];
+      drawLayers: { layer: number; drawOrder: string[]; drawSet: string[] }[];
     };
     _addItemToEndFromAPI: (item: ItemModel) => void;
     _showToast: (toast: Toast) => void;

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -222,23 +222,17 @@ export default class Intellisense extends PluginController<{
         );
 
         // sort the intellisense options so that closer ones appear first
-        const listModel = this.cc.listModel;
-        const orderMap = new Map<string, number>();
-        const flatOrder = listModel.drawLayers.flatMap((e) => e.drawOrder);
-        for (let i = 0; i < flatOrder.length; i++) {
-          orderMap.set(flatOrder[i], i);
-        }
         const myindex = this.cc.getSelectedItem()?.index;
         if (myindex !== undefined) {
           this.intellisenseOpts.sort((a, b) => {
             const aMin = Math.min(
               ...a.idents.map((e) =>
-                Math.abs((orderMap.get(e.exprId) ?? 0) - myindex)
+                Math.abs((this.getExpressionIndex(e.exprId) ?? 0) - myindex)
               )
             );
             const bMin = Math.min(
               ...b.idents.map((e) =>
-                Math.abs((orderMap.get(e.exprId) ?? 0) - myindex)
+                Math.abs((this.getExpressionIndex(e.exprId) ?? 0) - myindex)
               )
             );
             return aMin - bMin;

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -224,8 +224,8 @@ export default class Intellisense extends PluginController<{
         // sort the intellisense options so that closer ones appear first
         const listModel = this.cc.listModel;
         const orderMap = new Map<string, number>();
-        for (let i = 0; i < listModel.drawOrder.length; i++) {
-          orderMap.set(listModel.drawOrder[i], i);
+        for (let i = 0; i < listModel.drawLayers[0].drawOrder.length; i++) {
+          orderMap.set(listModel.drawLayers[0].drawOrder[i], i);
         }
         const myindex = this.cc.getSelectedItem()?.index;
         if (myindex !== undefined) {

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -224,8 +224,9 @@ export default class Intellisense extends PluginController<{
         // sort the intellisense options so that closer ones appear first
         const listModel = this.cc.listModel;
         const orderMap = new Map<string, number>();
-        for (let i = 0; i < listModel.drawLayers[0].drawOrder.length; i++) {
-          orderMap.set(listModel.drawLayers[0].drawOrder[i], i);
+        const flatOrder = listModel.drawLayers.flatMap((e) => e.drawOrder);
+        for (let i = 0; i < flatOrder.length; i++) {
+          orderMap.set(flatOrder[i], i);
         }
         const myindex = this.cc.getSelectedItem()?.index;
         if (myindex !== undefined) {


### PR DESCRIPTION
This patch fixes the Intellisense lookup which currently fails to sort the items by drawing order because Desmos removed a property from Calc.

The property removed was the `Calc.controller.listModel.drawOrder`. It's changed to `Calc.controller.listModel.drawLayers[...].drawOrder`. I am not sure why `drawLayers` is an array instead of an object, but I opened several graphs and they all had only one element. Maybe it's future proofing for later, but whatever the case I hardcoded the zero in the intellisense plugin.