### PR TITLE
Fix broken replacements

### DIFF
--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -171,6 +171,7 @@ export abstract class ExpressionViewComponent extends ClassComponent<
   }
 > {}
 
+// `?` to avoid a crash if the replacement fails
 const ExpressionView = window.DesModderFragile?.ExpressionView;
 
 export abstract class IconViewComponent extends ClassComponent<{
@@ -178,6 +179,7 @@ export abstract class IconViewComponent extends ClassComponent<{
   controller: CalcController;
 }> {}
 
+// `?` to avoid a crash if the replacement fails
 export const ImageIconView = window.DesModderFragile?.ImageIconView;
 
 interface ModelAndController {

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -171,14 +171,14 @@ export abstract class ExpressionViewComponent extends ClassComponent<
   }
 > {}
 
-const ExpressionView = window.DesModderFragile.ExpressionView;
+const ExpressionView = window.DesModderFragile?.ExpressionView;
 
 export abstract class IconViewComponent extends ClassComponent<{
   model: ItemModel;
   controller: CalcController;
 }> {}
 
-export const ImageIconView = window.DesModderFragile.ImageIconView;
+export const ImageIconView = window.DesModderFragile?.ImageIconView;
 
 interface ModelAndController {
   model: ExpressionModel;

--- a/src/core-plugins/override-keystroke/override-keystroke.replacements
+++ b/src/core-plugins/override-keystroke/override-keystroke.replacements
@@ -6,7 +6,14 @@
 
 *Description* `Duplicate metadata (e.g. GLesmos enabled, or pinned/unpinned) when an expression is duplicated`
 
-*Find* => `from`
+*Find* => `parentMQ`
+```js
+didMountMathquill($) {
+  this.cachedConfig = this.getCacheableMQConfig();
+  __MQbody__
+```
+
+*Find* inside `MQbody` => `from`
 ```js
 overrideKeystroke: ($key, $e) => {
 ```

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -100,14 +100,14 @@ DSM.insertElement(() => DSM.hideErrors?.hideButton(() => this.model))
 
 *Find* => `from`
 ```js
-shouldShowSliderPrompt() {
+shouldShowSliderPrompt($expression) {
   let
 ```
 
 *Replace* `from` with
 ```js
-shouldShowSliderPrompt() {
-    if (DSM.hideErrors?.isErrorHidden(this.model?.id)) return false;
+shouldShowSliderPrompt($expression) {
+    if (DSM.hideErrors?.isErrorHidden($expression?.id)) return false;
     let
 ```
 

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -80,8 +80,9 @@ DSM.insertElement(
 
 ```js
 $ExpressionView = class extends $ {
-  didMount() {
-      this.onItemViewMounted(),
+  didMountRootNode($e) {
+      this.rootNode = $e,
+      this.onItemViewMounted($e),
       this.lastBrailleMode = this.controller.getBrailleMode()
   }
 ```


### PR DESCRIPTION
It seems like an oddly simple fix, but I am not 100% confident that was it (on the off change that I searched the wrong new replacement). The error was correctly identified by the panic system.
> "Show style circles and expression footers for Text Mode statements"

The page crashes if you try to open text mode when there is an expression with a style circle present.