### PR TITLE
Improve Japanese localization

### DIFF
--- a/localization/ja.ftl
+++ b/localization/ja.ftl
@@ -28,7 +28,7 @@ GLesmos-no-support = 残念ながら、あなたのブラウザは WebGL2 をサ
 
 ## Tips
 show-tips-name = ヒントの表示
-show-tips-desc = 数式リストの一番下にヒントを表示する
+show-tips-desc = 数式リストの一番下にヒントを表示します。
 show-tips-tip-export-videos = 動画をエクスポートする場合は、GIF よりも MP4 または APNG のほうがよいでしょう。
 show-tips-tip-disable-graphpaper = 計算機の設定でグラフ用紙を無効にすると、一連の数式を書くのに便利です。
 show-tips-tip-paste-asciimath = Desmos には直接 ASCII Math を貼り付けることができます。
@@ -67,7 +67,7 @@ show-tips-tip-listcomps = リスト内包は、点のグリッドや多角形の
 show-tips-tip-list-filters = リストフィルターは、正の要素や偶数の要素などのフィルターに使用できます。
 show-tips-tip-bernard = Bernard
 show-tips-tip-new-desmos = Desmos の新着情報
-show-tips-tip-simultaneous-actions =アクションの割り当ては順次ではなく、同時に行われる。
+show-tips-tip-simultaneous-actions =アクションの割り当ては順次ではなく、同時に行われます。
 show-tips-tip-share-permalink = サインインしなくても、パーマリンク経由でグラフを共有できます。
 show-tips-tip-point-coordinate = 点の変数に .x または .y を追加して、ポイントの x 座標または y 座標を抽出できます。
 show-tips-tip-audiotrace = オーディオトレースを使ってグラフを聴くことができます。
@@ -152,7 +152,7 @@ set-primary-color-opt-doFavicon-desc = ファビコンにも基調色設定を�
 
 ## Hide Errors
 hide-errors-name = エラーの非表示
-hide-errors-desc = エラーの三角形をクリックすると非表示になります。
+hide-errors-desc = エラーの三角形をクリックすることで非表示にします。
 hide-errors-hide = 非表示
 
 ## Folder Tools
@@ -228,7 +228,7 @@ performance-info-other = その他
 
 ## Better Evaluation View
 better-evaluation-view-name = 高機能な評価ビュー
-better-evaluation-view-desc = リストの要素、色、未定義の値を表示する
+better-evaluation-view-desc = リストの要素、色、undefined の値を表示します。
 better-evaluation-view-opt-lists-name = リストの要素を表示
 better-evaluation-view-opt-lists-desc = リストの長さの代わりに要素を表示する
 better-evaluation-view-opt-colors-name = 色を表示
@@ -327,7 +327,7 @@ code-golf-note-latex-byte-count = LaTeX 表現のバイト数 { $chars }
 
 ## Syntax highlightAlternatingLines
 syntax-highlighting-name = シンタックスハイライト
-syntax-highlighting-desc = 数式のさまざまな部分に色をつけて判読性を向上する
+syntax-highlighting-desc = 数式のさまざまな部分に色をつけて判読性を高めます。
 syntax-highlighting-opt-bracketPairColorization-name = 括弧の色付け
 syntax-highlighting-opt-bracketPairColorization-desc = 括弧に交互に色を適用し (例: ()[]{"{"}{"}"}||)、 一致する括弧のペアを見つけやすくします。
 syntax-highlighting-opt-bracketPairColorizationColors-name = 括弧の色

--- a/localization/ja.ftl
+++ b/localization/ja.ftl
@@ -8,282 +8,345 @@
 
 ## General
 menu-learn-more = 詳細
-menu-desmodder-plugins = DesModderプラグイン
-menu-desmodder-tooltip = DesModderメニュー
+menu-desmodder-plugins = DesModder プラグイン
+menu-desmodder-tooltip = DesModder メニュー
 
 ## Category names
 category-core-name = コア
-category-utility-name = 用途
-category-visual-name = 表示
-category-integrations-name = 統合
+category-utility-name = 操作
+category-visual-name = 外観
+category-integrations-name = インテグレーション
 
 ## GLesmos
 GLesmos-name = GLesmos
-GLesmos-desc = GPUでレンダリングする。タブのリロードで無効になります。まれにUIが遅くなったり、フリーズすることがあります。問題がある場合はページをリロードしてください。
-GLesmos-label-toggle-glesmos = GLesmosを使ったレンダリング
-GLesmos-confirm-lines = ラインの確認
-GLesmos-confirm-lines-body = GLesmosのライン・レンダリングは遅いことがあります。特にレイヤーのリストには注意してください。
-GLesmos-no-support = 残念ながら、あなたのブラウザはWebGL2をサポートしていないため、GLesmosをサポートしていません。
+GLesmos-desc = GPU でのレンダリング。タブの再読み込みで無効になります。まれに UI が遅くなったり、フリーズしたりすることがあります。問題がある場合はページを再読み込みしてください。
+GLesmos-label-toggle-glesmos = GLesmos を使ったレンダリング
+GLesmos-confirm-lines = 線のレンダリングの確認
+GLesmos-confirm-lines-body = GLesmos の線のレンダリングは遅いことがあります。特にレイヤーのリストには注意してください。
+GLesmos-no-support = 残念ながら、あなたのブラウザは WebGL2 をサポートしていないため、GLesmos はサポートされません。
 # Missing: error messages
 
 ## Tips
 show-tips-name = ヒントの表示
-show-tips-desc = 表現リストの一番下にヒントを表示する
-show-tips-tip-export-videos = 動画をエクスポートする場合は、GIFよりもMP4またはAPNGを優先する。
-show-tips-tip-disable-graphpaper = 電卓の設定でグラフ用紙を無効にすると、一連の方程式を書くのに便利です。
-show-tips-tip-paste-asciimath = Desmosに直接ASCII Mathを貼り付ける
-show-tips-tip-pin = よく使う表現をブックマークしてアクセスを簡略化
-show-tips-tip-long-video-capture = 長いビデオキャプチャを開始する前に、テストする事を推奨します。
+show-tips-desc = 数式リストの一番下にヒントを表示する
+show-tips-tip-export-videos = 動画をエクスポートする場合は、GIF よりも MP4 または APNG のほうがよいでしょう。
+show-tips-tip-disable-graphpaper = 計算機の設定でグラフ用紙を無効にすると、一連の数式を書くのに便利です。
+show-tips-tip-paste-asciimath = Desmos には直接 ASCII Math を貼り付けることができます。
+show-tips-tip-pin = よく使う数式を固定（ブックマーク）してアクセスを簡略化できます。
+show-tips-tip-long-video-capture = 長い動画のキャプチャをはじめる前にテストすることを推奨します。
 show-tips-tip-find-replace = 検索と置換は変数名の変更に最適です。
-show-tips-tip-duplicate = Ctrl+Q または Ctrl+Shift+Q を押して、現在の式を複製する。
-show-tips-tip-note-newline = ノートやフォルダのタイトルで Shift+Enter を押下すると改行されます。
-show-tips-tip-hide-errors = 黄色の三角形をクリック（またはShift+Enter）すると、警告が非表示になります。
-show-tips-tip-note-folder =  " を押下すると、フォルダを素早く作成できる。
-show-tips-tip-arctan = 点の角度を求めるには、arctan(y / x)の代わりにarctan(y, x)を使ってください。
-show-tips-tip-indefinite-integral = 積分は無限境界を持つことができます。
-show-tips-tip-random = ランダム関数は、次のような分布からサンプリングすることができます。
-show-tips-tip-two-argument-round = Two-argument round は四捨五入ラベルに最適です。
-show-tips-tip-two-argument-sort = sort(A, B)を使って、あるリストを別のリストのキーでソート出来ます。
-show-tips-tip-custom-colors = rgb関数とhsv関数を使ってカスタムカラーを作成する事が出来ます。
-show-tips-tip-ctrl-f = Ctrl+F で式を検索出来ます。
-show-tips-tip-derivatives = 素数表記法またはライプニッツ表記法を用いて導関数をとる事が出来ます。
-show-tips-tip-unbounded-list-slices = List slices は境界を持つ必要はありません。
-show-tips-tip-dataviz-plots = データを視覚化するには、ヒストグラムやボックスプロットなどを使用できます。
+show-tips-tip-duplicate = Ctrl+Q または Ctrl+Shift+Q を押下して、現在の式を複製できます。
+show-tips-tip-note-newline = 説明文やフォルダーのタイトルで Shift+Enter を押下すると改行されます。
+show-tips-tip-hide-errors = 黄色の三角形をクリック（または Shift+Enter を押下）すると、エラーが非表示になります。
+show-tips-tip-note-folder =  " を押下すると、フォルダーを素早く作成できます。
+show-tips-tip-arctan = 点の角度を求めるには、arctan(y / x) の代わりに arctan(y, x) を使ってください。
+show-tips-tip-indefinite-integral = 積分範囲は無限区間にすることができます。
+show-tips-tip-random = ランダム関数は分布からサンプリングすることができます。
+show-tips-tip-two-argument-round = 2引数の round 関数は丸めたラベルに最適です。
+show-tips-tip-two-argument-sort = sort(A, B) を使って、あるリストを別のリストのキーでソートできます。
+show-tips-tip-custom-colors = rgb 関数と hsv 関数を使ってカスタムカラーを作成することができます。
+show-tips-tip-ctrl-f = Ctrl+F で数式を検索できます。
+show-tips-tip-derivatives = ラグランジュ記法またはライプニッツ記法を用いて導関数をとることができます。
+show-tips-tip-unbounded-list-slices = リストのスライスは終了位置を必要としません。
+show-tips-tip-dataviz-plots = データを視覚化するには、ヒストグラムや箱ひげ図などが使用できます。
 show-tips-tip-statistics = Desmosには多くの統計機能が組み込まれています。
-show-tips-tip-table-draggable-points = ドラッグ可能な点のリストにはテーブルを使用してください。
-show-tips-tip-polygon = 簡単な多角形には多角形関数を使用します。
-show-tips-tip-point-arithmetic = 点（ベクトル）演算は期待通りに機能します。例：（1, 2）＋（3, 4）は（4, 6）。
-show-tips-tip-shift-drag = Shiftキーを押しながら軸の上をドラッグすると、その軸だけを拡大縮小することができます。
-show-tips-tip-action-ticker = actions と tickers を使用してシミュレーションを実行します。
-show-tips-tip-latex-copy-paste = Desmosの数式は、LaTeXエディタに直接コピーペーストできます。
-show-tips-tip-time-in-worker = グラフの実行速度をテストするには、?timeInWorkerを使用するか、パフォーマンス表示プラグインを有効にしてください。
-show-tips-tip-format-labels = backticks を使ってポイントラベルを数学フォーマットする
-show-tips-tip-dynamic-labels = 変数に基づく動的なポイントラベルに ${"{"} {"}"} を使用する。
-show-tips-tip-disable-text-outline = テキストのアウトラインを無効にすると、ラベルが読みやすくなることがあります。
-show-tips-tip-regression-power = regression はあなたが想像している以上に強力です。
+show-tips-tip-table-draggable-points = ドラッグ可能な点のリストには表を使用してください。
+show-tips-tip-polygon = 簡単な多角形には polygon 関数を使用してください。
+show-tips-tip-point-arithmetic = 点（ベクトル）演算は期待通りに機能します。例: (1, 2) + (3, 4) = (4, 6)
+show-tips-tip-shift-drag = Shift キーを押しながら軸の上をドラッグすると、その軸だけを拡大縮小することができます。
+show-tips-tip-action-ticker = アクションとティッカーを使うとシミュレーションを実行できます。
+show-tips-tip-latex-copy-paste = Desmos の数式は、LaTeX エディタに直接コピー&ペーストできます。
+show-tips-tip-time-in-worker = グラフの実行速度をテストするには、?timeInWorker を使用するか、パフォーマンス表示のプラグインを有効にしてください。
+show-tips-tip-format-labels = 点のラベルを数式にするにはバッククォートを使ってください。
+show-tips-tip-dynamic-labels = 変数に基づく動的な点のラベルには ${"{"} {"}"} を使ってください。
+show-tips-tip-disable-text-outline = ラベルの輪郭を無効にすると読みやすくなることがあります。
+show-tips-tip-regression-power = 回帰分析は想像以上に強力です。
 show-tips-tip-spreadsheet-table = スプレッドシートのデータを貼り付けて表を作成できます。
 show-tips-tip-keyboard-shortcuts = Ctrl+/ か Cmd+/ でキーボードショートカットのリストを開けます。
 show-tips-tip-listcomps = リスト内包は、点のグリッドや多角形のリストに最適です。
-show-tips-tip-list-filters = リストフィルターは、正要素や偶数要素などのフィルターに使用できます。
+show-tips-tip-list-filters = リストフィルターは、正の要素や偶数の要素などのフィルターに使用できます。
 show-tips-tip-bernard = Bernard
 show-tips-tip-new-desmos = Desmos の新着情報
 show-tips-tip-simultaneous-actions =アクションの割り当ては順次ではなく、同時に行われる。
 show-tips-tip-share-permalink = サインインしなくても、パーマリンク経由でグラフを共有できます。
-show-tips-tip-point-coordinate = ポイント変数に .x または .y を追加して、ポイントの x 座標または y 座標を抽出します。
-show-tips-tip-audiotrace = Audio Traceを使ってグラフを聴きます。
-show-tips-tip-audiotrace-note-frequency = オーディオトレースの周波数は、ビューポート内の高さまたは低さに依存します。
-show-tips-tip-audiotrace-range = オーディオ・トレースの範囲はE4（329.63Hz）からE5（659.25Hz）までです。
-show-tips-tip-other-calculators = Desmosには他にも電卓があります。
-show-tips-tip-lock-viewport = ビューポートを移動させたくない場合はグラフ設定でロックしてください。
-show-tips-tip-glesmos = GLesmosプラグインを有効にして、いくつかの内含を高速化する。
-show-tips-tip-disable-show-tips = ヒントを非表示にするにはDesmodderの設定で「ヒントを表示」プラグインを無効にしてください。
-show-tips-tip-compact-view-multiline = コンパクト・ビューやマルチライン式を有効にして、一度に多くの式を見ることができます。
-show-tips-tip-intellisense = 長い変数名が多い場合、Intellisenseを有効にして、簡単に扱えるようにしましょう。
+show-tips-tip-point-coordinate = 点の変数に .x または .y を追加して、ポイントの x 座標または y 座標を抽出できます。
+show-tips-tip-audiotrace = オーディオトレースを使ってグラフを聴くことができます。
+show-tips-tip-audiotrace-note-frequency = オーディオトレースの周波数は表示域内の高さまたは低さに依存します。
+show-tips-tip-audiotrace-range = オーディオトレースの範囲は E4 (329.63 Hz) から E5 (659.25 Hz) までです。
+show-tips-tip-other-calculators = Desmosには他にも計算機があります。
+show-tips-tip-lock-viewport = 表示域を移動させたくない場合は、グラフの設定で固定してください。
+show-tips-tip-glesmos = GLesmos プラグインを有効にすると、陰関数を高速化できます。
+show-tips-tip-disable-show-tips = 私にはうんざり？ヒントを非表示にするには Desmodder の設定でヒント表示のプラグインを無効にしてください。
+show-tips-tip-compact-view-multiline = 数式のスクロールにうんざりしていませんか？小型ビューや改行つき数式を有効にすると、すぐに数式の全体を見ることができます。
+show-tips-tip-intellisense = 長い変数名が多すぎますか？インテリセンスを有効にして、簡単に扱えるようにしましょう。
 show-tips-tip-youre-doing-great = あなたはよく頑張っています :)
 show-tips-tip-youre-superb = あなたは素晴らしい <3
 show-tips-tip-huggy = Huggy!
 
 ## Text Mode
-text-mode-name = テキストモードBETA
-text-mode-desc = バグの可能性があります。一時的なドキュメント：
+text-mode-name = テキストモード (ベータ版)
+text-mode-desc = バグがある可能性があります。一時的なドキュメントはこちら: 
 text-mode-toggle = テキストモードの切り替え
-# Missing: error messages
+text-mode-toggle-spaces = スペース
+text-mode-toggle-spaces-tooltip = 整形時、デリミタの後にスペースを挿入します。
+text-mode-toggle-newlines = インデント
+text-mode-toggle-newlines-tooltip = 整形時、改行とインデントを挿入します。
+text-mode-format = 整形
 
 ## Find and Replace
 find-and-replace-name = 検索と置換
-find-and-replace-desc = Ctrl+Fメニューに "replace all" ボタンが追加され、変数名や関数名の一括置換ができるようになりました。
-find-and-replace-replace-all = replace all
+find-and-replace-desc = Ctrl+F メニューに追加された「すべて置換」ボタンから、変数名や関数名の一括置換ができます。
+find-and-replace-replace-all = すべて置換
 
 ## Wolfram To Desmos
 wolfram2desmos-name = Wolfram から Desmos
-wolfram2desmos-desc = ASCII数学（Wolfram Alphaクエリの結果等）をDesmosに貼り付けることができます。
-wolfram2desmos-opt-reciprocalExponents2Surds-name = ラジカル記法
-wolfram2desmos-opt-reciprocalExponents2Surds-desc = 1未満の小数の累乗をラジカル等価（surd）に変換する。
-wolfram2desmos-opt-derivativeLoopLimit-name = デリバティブの拡大
-wolfram2desmos-opt-derivativeLoopLimit-desc = ライプニッツ記法のn階微分を反復微分に展開する。（10回まで）
+wolfram2desmos-desc = ASCII Math（Wolfram Alpha クエリの結果など）を Desmos に貼り付けることができます。
+wolfram2desmos-opt-reciprocalExponents2Surds-name = 根号表記
+wolfram2desmos-opt-reciprocalExponents2Surds-desc = 自然数の逆数のべきを、それと等価な根号表記で書き換えます。
+wolfram2desmos-opt-derivativeLoopLimit-name = 微分の展開
+wolfram2desmos-opt-derivativeLoopLimit-desc = ライプニッツ記法の n 階微分を反復微分に展開します（10回まで）。
 
 ## Pin Expressions
-pin-expressions-name = ブックマーク表現
-pin-expressions-desc = リスト編集モードからのブックマーク表現
+pin-expressions-name = 数式の固定
+pin-expressions-desc = 「リストの編集」モードから数式を固定することができます。
 pin-expressions-pin = 固定
-pin-expressions-unpin = 外す
+pin-expressions-unpin = 固定を外す
 
 ## Builtin Settings
-builtin-settings-name = 電卓の設定
+builtin-settings-name = 計算機の設定
 builtin-settings-desc = Desmosに組み込まれている機能を切り替えます。ほとんどのオプションは自分のブラウザにのみ適用され、他の人とグラフを共有するときは無視されます。
 builtin-settings-opt-advancedStyling-name = 高度なスタイリング
-builtin-settings-opt-advancedStyling-desc = ラベル編集、show-on-hover、テキストアウトライン、1象限グリッドを有効にする。
-builtin-settings-opt-graphpaper-name = Graphpaper
+builtin-settings-opt-advancedStyling-desc = ラベルの編集、マウスホバー、ラベルの輪郭、第一象限の目盛を有効にします。
+builtin-settings-opt-graphpaper-name = グラフ用紙を有効にする
 builtin-settings-opt-graphpaper-desc = {""}
-builtin-settings-opt-authorFeatures-name = 管理者の特徴
-builtin-settings-opt-authorFeatures-desc = 隠しフォルダの切り替え、読み取り専用の切り替えなど
-builtin-settings-opt-pointsOfInterest-name = 注目ポイントを表示
-builtin-settings-opt-pointsOfInterest-desc = Intercepts, holes, intersectionsなど
+builtin-settings-opt-authorFeatures-name = 管理者機能
+builtin-settings-opt-authorFeatures-desc = 隠しフォルダーの切り替え、読み取り専用の切り替えなどが有効になります。
+builtin-settings-opt-pointsOfInterest-name = 注目すべき点を表示
+builtin-settings-opt-pointsOfInterest-desc = 切片、除去可能な不連続点、交点などを表示します。
 builtin-settings-opt-trace-name = 曲線に沿ってなぞる
 builtin-settings-opt-trace-desc = {""}
-builtin-settings-opt-expressions-name = 表現の表示
+builtin-settings-opt-expressions-name = 数式リストの表示
 builtin-settings-opt-expressions-desc = {""}
 builtin-settings-opt-zoomButtons-name = ズームボタンの表示
 builtin-settings-opt-zoomButtons-desc = {""}
-builtin-settings-opt-keypad-name = keypadの表示
+builtin-settings-opt-keypad-name = キーパッドの表示
 builtin-settings-opt-keypad-desc = {""}
+builtin-settings-opt-showIDs-name = ID を表示
+builtin-settings-opt-showIDs-desc = 行番号の代わりに数式 ID を表示します。
 
 ## Duplicate Expression Hotkey
-duplicate-expression-hotkey-name = 式の複製ホットキー
-duplicate-expression-hotkey-desc = 選択した式を複製するには、Ctrl+QまたはCtrl+Shift+Qを入力します。
+duplicate-expression-hotkey-name = 数式複製のホットキー
+duplicate-expression-hotkey-desc = Ctrl+Q または Ctrl+Shift+Q を押下することで式を複製できます。
 
 ## Right Click Tray
-right-click-tray-name = 右クリックトレイ
-right-click-tray-desc = 設定バブルを左クリックしたままではなく、右クリックで設定トレイを開けるようにする。
+right-click-tray-name = トレイの右クリック
+right-click-tray-desc = 左クリックの長押しではなく右クリックで各数式の設定トレイを開けるようにします。
 
 ## Set Primary Color
-set-primary-color-name = 原色設定
-set-primary-color-desc = ユーザーインターフェースの原色を選ぶ
-set-primary-color-opt-primaryColor-name = 原色
-set-primary-color-opt-primaryColor-desc = 電卓全体の原色
-set-primary-color-opt-doFavicon-name = サイトアイコンの更新
-set-primary-color-opt-doFavicon-desc = サイトアイコンの更新の切り替え
+set-primary-color-name = 基調色設定
+set-primary-color-desc = UI の基調色を変更します。
+set-primary-color-opt-primaryColor-name = 基調色
+set-primary-color-opt-primaryColor-desc = 計算機全体の基調色
+set-primary-color-opt-doFavicon-name = ファビコンに適用
+set-primary-color-opt-doFavicon-desc = ファビコンにも基調色設定を適用します。
 
 ## Hide Errors
 hide-errors-name = エラーの非表示
 hide-errors-desc = エラーの三角形をクリックすると非表示になります。
-hide-errors-hide = hide
+hide-errors-hide = 非表示
 
 ## Folder Tools
-folder-tools-name = Folder Tools
-folder-tools-desc = 編集-リスト-モード でフォルダを管理するのに役立つボタンを追加します。
-folder-tools-dump = Dump
-folder-tools-merge = Merge
-folder-tools-enclose = Enclose
+folder-tools-name = フォルダー管理ツール
+folder-tools-desc = 「リストの編集」モード でフォルダー管理に役立つボタンを追加します。
+folder-tools-dump = フォルダーを展開
+folder-tools-merge = 下の数式やフォルダーと統合
+folder-tools-enclose = フォルダーに包む
 
 ## Video Creator
-video-creator-name = ビデオクリエーター
-video-creator-desc = アクションやスライダーに基づいてグラフのビデオやGIFをエクスポートできます。
-video-creator-menu = ビデオクリエーターメニュー
+video-creator-name = 動画作成
+video-creator-desc = アクションやスライダーに基づいてグラフの動画やGIFをエクスポートできます。
+video-creator-menu = 動画作成メニュー
 video-creator-to = to
-video-creator-step = , ステップ
+video-creator-step = , 主目盛
+video-creator-ticks-playing-sliders = Playing sliders:
 video-creator-ticks-step = タイムステップ (ms):
 video-creator-prev-action = 前へ
 video-creator-next-action = 次へ
+video-creator-orientation = Orientation
+video-creator-orientation-mode-current-speed = current
+video-creator-orientation-mode-current-delta = step
+video-creator-orientation-mode-from-to = from/to
 video-creator-size = サイズ:
+video-creator-angle-current = Angle:
+video-creator-angle-from = From:
+video-creator-angle-to = To:
+video-creator-angle-step = Step:
+video-creator-angle-speed = Speed:
 video-creator-step-count = ステップ数:
-video-creator-target-same-pixel-ratio = 目標同一ピクセル比
-video-creator-target-tooltip = 線幅、ポイントサイズ、ラベルサイズなどのスケーリングを調整します。
-video-creator-ffmpeg-loading = FFmpeg loading...
-video-creator-ffmpeg-fail = 数秒以内にうまくいかない場合は、ページをリロードするか、このバグをDesModder開発者に報告してみてください。
-video-creator-exporting = Exporting...
+video-creator-frame-count = フレーム数:
+video-creator-target-same-pixel-ratio = ピクセル比を揃える
+video-creator-fast-screenshot = 高速キャプチャ
+video-creator-target-tooltip = 線の幅、点のサイズ、ラベルサイズなどの拡大縮小を調整してピクセル比を揃える
+video-creator-ffmpeg-loading = FFmpeg を読み込み中...
+video-creator-ffmpeg-fail = 数秒以内にうまくいかない場合は、ページを再読み込みするか、このバグを DesModder 開発者に報告してみてください。
+video-creator-exporting = エクスポート中...
 video-creator-cancel-capture = キャンセル
 video-creator-cancel-export = キャンセル
-video-creator-capture = キャプチャー
+video-creator-capture = キャプチャ
 video-creator-preview = プレビュー
-video-creator-delete-all = 全削除
+video-creator-delete-all = 全フレームを削除
 video-creator-filename-placeholder = ファイル名の設定
 video-creator-export = エクスポート
 video-creator-export-as = { $fileType } としてエクスポート
 video-creator-fps = FPS:
 video-creator-method-once = 1度だけ
+video-creator-method-ntimes = count
 video-creator-method-slider = スライダー
 video-creator-method-action = アクション
 video-creator-method-ticks = ticks
 
 ## Wakatime
 wakatime-name = WakaTime
-wakatime-desc = WakaTime.comでdesmosのアクティビティを追跡します。
-wakatime-opt-secretKey-name = Secret Key
-wakatime-opt-secretKey-desc = WakaTimeサーバーで使用するAPIキー
-wakatime-opt-splitProjects-name = グラフでプロジェクトを分割する。
-wakatime-opt-splitProjects-desc = 各グラフをDesmosプロジェクトのブランチとしてではなく、独自のプロジェクトとして保存する。
-wakatime-opt-projectName-name = Project name
-wakatime-opt-projectName-desc = WakaTimeから見ることができ、すべてのDesmosプロジェクトで共有されます。
+wakatime-desc = WakaTime.com で Desmos のアクティビティを追跡します。
+wakatime-opt-secretKey-name = API キー
+wakatime-opt-secretKey-desc = WakaTime サーバーで使用する API キー
+wakatime-opt-splitProjects-name = グラフでプロジェクトを分割する
+wakatime-opt-splitProjects-desc = 各グラフを Desmos プロジェクトのブランチとしてではなく、独自のプロジェクトとして保存する
+wakatime-opt-projectName-name = プロジェクト名
+wakatime-opt-projectName-desc = WakaTime から見ることができ、すべての Desmos プロジェクトで共有されます。
 
 ## Performance Display
-performance-info-name = Performance Display
-performance-info-desc = 現在のグラフのパフォーマンスに関する情報を表示する。
-performance-info-refresh-graph = Refresh Graph
-performance-info-refresh-graph-tooltip = 初期ロード時間をテストするためにグラフを更新する。
+performance-info-name = パフォーマンス表示
+performance-info-desc = 現在のグラフのパフォーマンスに関する情報を表示します。
+performance-info-refresh-graph = グラフを更新
+performance-info-refresh-graph-tooltip = 初期読み込み時間をテストするためにグラフを更新する
 performance-info-sticky-tooltip = メニューを開いたままにする
 performance-info-time-in-worker = 実行時間
-performance-info-compiling = Compiling
-performance-info-rendering = Rendering
-performance-info-other = Other
+performance-info-compiling = コンパイル
+performance-info-rendering = レンダリング
+performance-info-other = その他
 
 ## Better Evaluation View
-better-evaluation-view-name = Better Evaluation View
-better-evaluation-view-desc = リスト要素、色、未定義の値を表示する
-better-evaluation-view-opt-lists-name = Show list elements
-better-evaluation-view-opt-lists-desc = リストの長さの代わりにリストの要素を表示する
-better-evaluation-view-opt-colors-name = Show colors
-better-evaluation-view-opt-colors-desc = 色をrgb値で表示する
-better-evaluation-view-opt-colorLists-name = Show lists of colors
-better-evaluation-view-opt-colorLists-desc = 色のリストをrgb値のリストとして表示する。
+better-evaluation-view-name = 高機能な評価ビュー
+better-evaluation-view-desc = リストの要素、色、未定義の値を表示する
+better-evaluation-view-opt-lists-name = リストの要素を表示
+better-evaluation-view-opt-lists-desc = リストの長さの代わりに要素を表示する
+better-evaluation-view-opt-colors-name = 色を表示
+better-evaluation-view-opt-colors-desc = 色を RGB 値で表示する
+better-evaluation-view-opt-colorLists-name = 色のリストを表示
+better-evaluation-view-opt-colorLists-desc = 色のリストを RGB 値のリストとして表示する
 
 ## Pillbox Menus
 pillbox-menus-name = Pillbox Menus (Core)
-pillbox-menus-desc = Video CreatorやDesModderのメインメニューなど、右側のボタンを表示する。
+pillbox-menus-desc = 動画作成メニューや DesModder のメインメニューなどの右側のボタンを表示します。
 
 ## Manage Metadata
 manage-metadata-name = Manage Metadata (Core)
-manage-metadata-desc = GLesmosや固定/非固定のステータスなどのメタデータを管理する。
+manage-metadata-desc = GLesmos や数式固定の状態などのメタデータを管理します。
 
 ## Intellisense
-intellisense-name = Intellisense
-intellisense-desc = オートコンプリート候補、関数呼び出しヘルプ、定義へのジャンプなど、いくつかの一般的なIDE機能をDesmosにもたらします。ドキュメントはこちら:
+intellisense-name = インテリセンス
+intellisense-desc = 自動補完、関数呼び出しのヘルプ、定義へのジャンプなど、一般的な IDE 機能を Desmos に追加します。ドキュメントはこちら:
 intellisense-opt-subscriptify-name = 自動添え字
-intellisense-opt-subscriptify-desc = 変数名/関数名が添え字なしで入力されると、自動的に添え字が追加されます。
+intellisense-opt-subscriptify-desc = 変数名 / 関数名が添え字なしで入力されると、自動的に添え字が追加されます。
 intellisense-jump2def-menu-instructions = 複数の定義があります。以下から選んでジャンプしてください。
 
 ## Compact View
-compact-view-name = Compact View
-compact-view-desc = UIを凝縮し、一度に画面上の多くを見ることができるようにするためのさまざまなオプションを提供します。
-compact-view-opt-textFontSize-name = Text Font Size
-compact-view-opt-textFontSize-desc = フォントの大きさ
-compact-view-opt-mathFontSize-name = Math Font Size
-compact-view-opt-mathFontSize-desc = 数式中のフォントサイズ
-compact-view-opt-bracketFontSizeFactor-name = Bracket Multiplier
-compact-view-opt-bracketFontSizeFactor-desc = 括弧（括弧、中括弧など）内のテキストは、この倍数だけサイズが小さくなる。
-compact-view-opt-minimumFontSize-name = Min Font Size
-compact-view-opt-minimumFontSize-desc = 可能な最小の数学フォントサイズ（ブラケット・フォントサイズ係数より優先される）
-compact-view-opt-compactFactor-name = Remove Spacing
-compact-view-opt-compactFactor-desc = エクスプレッション・リストの空白スペースを削除します。
-compact-view-opt-noSeparatingLines-name = No Separating lines
-compact-view-opt-noSeparatingLines-desc = 式と式の間の区切り線を削除し、交互の色に置き換えます。
-compact-view-opt-highlightAlternatingLines-name = Highlight Alternating Lines
-compact-view-opt-highlightAlternatingLines-desc = 交互に表現される表現にハイライトを入れ、互いに区別しやすくする。
-compact-view-opt-hideEvaluations-name = Collapse Evaluations
-compact-view-opt-hideEvaluations-desc = 評価を横に表示します。フォーカスしたり、カーソルを合わせると表示されます。
+compact-view-name = 小型ビュー
+compact-view-desc = UI を凝縮し、すぐに画面上の多くを見られるようにするためのさまざまなオプションを提供します。
+compact-view-opt-textFontSize-name = 文字サイズ
+compact-view-opt-textFontSize-desc = {""}
+compact-view-opt-mathFontSize-name = 数式中文字サイズ
+compact-view-opt-mathFontSize-desc = {""}
+compact-view-opt-bracketFontSizeFactor-name = 括弧サイズの係数
+compact-view-opt-bracketFontSizeFactor-desc = 括弧（丸括弧、波括弧など）内のテキストは、この分だけ文字サイズが小さくなります。
+compact-view-opt-minimumFontSize-name = 最小文字サイズ
+compact-view-opt-minimumFontSize-desc = ふさわしい最小の文字サイズ（括弧サイズの係数より優先されます）
+compact-view-opt-compactFactor-name = スペースを削除
+compact-view-opt-compactFactor-desc = 数式リストのスペースを削除
+compact-view-opt-hideFolderToggles-name = フォルダーメニューを隠す
+compact-view-opt-hideFolderToggles-desc = フォルダーの表示 / 非表示を切り替えたり最前面に表示したりするために追加されたフォルダーメニューを隠します。
+compact-view-opt-noSeparatingLines-name = 区切り線を削除
+compact-view-opt-noSeparatingLines-desc = 式と式の間の区切り線を削除し、1行おきのハイライトで代替します。
+compact-view-opt-highlightAlternatingLines-name = 数式を交互にハイライト
+compact-view-opt-highlightAlternatingLines-desc = 数式を1行おきにハイライトし、互いに区別しやすくします。
+compact-view-opt-hideEvaluations-name = 評価ビューを折りたたむ
+compact-view-opt-hideEvaluations-desc = 数式の評価ビューを横に表示します。フォーカスしたり、カーソルを合わせると表示されます。
 
 ## Multiline
-multiline-name = Multiline Expressions
-multiline-desc = 式を複数行に分割して、利用可能なスペースをより有効に活用します。Ctrl+M で手動で実行できます。
-multiline-opt-widthBeforeMultiline-name = Width Threshold (%)
-multiline-opt-widthBeforeMultiline-desc = 折り返しが発生する最小幅（ビューポートサイズに対するパーセンテージ）。モバイルでは、この値は3倍になります。
-multiline-opt-automaticallyMultilinify-name = Automatically Multilinify
-multiline-opt-automaticallyMultilinify-desc = 式を自動的に複数行に分割します。
-multiline-opt-multilinifyDelayAfterEdit-name = Edit Delay (ms)
-multiline-opt-multilinifyDelayAfterEdit-desc = 多行式は、このミリ秒の間、編集が行われなかった後に更新されるべきである。
+multiline-name = 改行つき数式
+multiline-desc = 数式を複数行に分割します。
+multiline-opt-widthBeforeMultiline-name = しきい値 (%)
+multiline-opt-widthBeforeMultiline-desc = 折り返しが発生する最小幅（表示域のサイズに対するパーセンテージ）。モバイルでは、この値は3倍になります。
+multiline-opt-automaticallyMultilinify-name = 入力中に改行を挿入する
+multiline-opt-automaticallyMultilinify-desc = 入力中に数式を自動的に複数行に分割するようにすると、Ctrl+M を使う必要がありません。
+multiline-opt-multilinifyDelayAfterEdit-name = 更新間隔 (ms)
+multiline-opt-multilinifyDelayAfterEdit-desc = 改行つき数式の自動折り返しは、ここで指定した時間編集が行われなければ更新されます。
+multiline-opt-spacesToNewlines-name = スペースを改行に変換
+multiline-opt-spacesToNewlines-desc = 3つの半角スペースを改行に変換する。Shift+Enter を押下することでも可能です。
+multiline-opt-determineLineBreaksAutomatically-name = 自動で数式を折り返す
+multiline-opt-determineLineBreaksAutomatically-desc = 改行位置を自動的に判断します。Ctrl+M を押下すると手動で改行できます。
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-name = 3つの半角スペースを含む数式をスキップ
+multiline-opt-disableAutomaticLineBreaksForHandAlignedExpressions-desc = 手動で追加した改行（3つの半角スペース）がある数式には自動的に改行を追加しません。
 
 ## Custom MathQuill Config
-custom-mathquill-config-name = Custom MathQuill Config
-custom-mathquill-config-desc = 方程式の入力方法を変更する。
-custom-mathquill-config-opt-superscriptOperators-name = Operators in Exponents
-custom-mathquill-config-opt-superscriptOperators-desc = 指数に "+" のような演算子を入力できるようにする。
-custom-mathquill-config-opt-noAutoSubscript-name = 自動添え字を無効
-custom-mathquill-config-opt-noAutoSubscript-desc = 変数名の後に入力された数字を添え字に自動的に入れるのを無効にする
-custom-mathquill-config-opt-noNEquals-name = Disable n= Sums
-custom-mathquill-config-opt-noNEquals-desc = 下限に'n='を自動的に置く和を無効にする。
-custom-mathquill-config-opt-subSupWithoutOp-name = オペランドなしの添え字/上付き文字
-custom-mathquill-config-opt-subSupWithoutOp-desc = 下付き文字と上付き文字は、前に何も付いていなくても指定できる。
-custom-mathquill-config-opt-allowMixedBrackets-name = 不一致のブラケットを許可
-custom-mathquill-config-opt-allowMixedBrackets-desc = すべての括弧が互いに一致するようにする（絶対値を含む）
+custom-mathquill-config-name = MathQuill のカスタム設定
+custom-mathquill-config-desc = 数式の入力方法を変更します。
+custom-mathquill-config-opt-superscriptOperators-name = 指数での演算子
+custom-mathquill-config-opt-superscriptOperators-desc = 指数に + のような演算子を入力できるようにします。
+custom-mathquill-config-opt-noAutoSubscript-name = 自動添え字を無効化
+custom-mathquill-config-opt-noAutoSubscript-desc = 変数名の後に入力された数字が自動で添え字に入る機能を無効化します。
+custom-mathquill-config-opt-noNEquals-name = 総和の n= を無効化
+custom-mathquill-config-opt-noNEquals-desc = 総和の下限に n= が自動的に入力される機能を無効化します。
+custom-mathquill-config-opt-subSupWithoutOp-name = オペランドなしの添え字 / 上付き文字
+custom-mathquill-config-opt-subSupWithoutOp-desc = 下付き文字と上付き文字を、前に何も付いていなくても指定できるようにします。
+custom-mathquill-config-opt-allowMixedBrackets-name = 不一致の括弧を許可
+custom-mathquill-config-opt-allowMixedBrackets-desc = すべての括弧が互いに一致するようにします（絶対値を含む）。
 custom-mathquill-config-opt-subscriptReplacements-name = 添え字の置換を許可
-custom-mathquill-config-opt-subscriptReplacements-desc = 記号や関数名を添え字で入力できるようにする
-custom-mathquill-config-opt-noPercentOf-name = Disable % of
-custom-mathquill-config-opt-noPercentOf-desc = '%'と入力すると、'% of'の代わりにパーセント文字が挿入される。
-custom-mathquill-config-opt-commaDelimiter-name = Comma Separators
-custom-mathquill-config-opt-commaDelimiter-desc = 数値の区切り文字としてカンマを挿入する
-custom-mathquill-config-opt-delimiterOverride-name = Custom Delimiter
-custom-mathquill-config-opt-delimiterOverride-desc = 数値の区切り文字として使用する文字列を設定する
-custom-mathquill-config-opt-leftIntoSubscript-name = Left/Right into Subscripts
-custom-mathquill-config-opt-leftIntoSubscript-desc = カーソルを左右に動かすと、上付き文字ではなく下付き文字になる
-custom-mathquill-config-opt-extendedGreek-name = More Greek Letters
-custom-mathquill-config-opt-extendedGreek-desc = サポートされているすべてのギリシャ文字の置き換えを有効にする
+custom-mathquill-config-opt-subscriptReplacements-desc = 記号や関数名を添え字で入力できるようにします。
+custom-mathquill-config-opt-noPercentOf-name = % of を無効化
+custom-mathquill-config-opt-noPercentOf-desc = % と入力すると代わりに % of が入力される機能を無効化します。
+custom-mathquill-config-opt-commaDelimiter-name = カンマ区切り
+custom-mathquill-config-opt-commaDelimiter-desc = 数値の区切り文字としてカンマを挿入します。
+custom-mathquill-config-opt-delimiterOverride-name = カスタム区切り文字
+custom-mathquill-config-opt-delimiterOverride-desc = 数値の区切り文字として使用する文字列を設定します。
+custom-mathquill-config-opt-leftIntoSubscript-name = 左右移動を下付き文字に
+custom-mathquill-config-opt-leftIntoSubscript-desc = カーソルを左右に動かすと、上付き文字ではなく下付き文字になります。
+custom-mathquill-config-opt-extendedGreek-name = より多くのギリシャ文字
+custom-mathquill-config-opt-extendedGreek-desc = サポートされているすべてのギリシャ文字の置き換えを有効にします。
+custom-mathquill-config-opt-lessFSpacing-name = f の周りのスペースを削減
+custom-mathquill-config-opt-lessFSpacing-desc = 文字 f の周りの余分なスペースを削減します。
+
+## Code Golf
+code-golf-name = 数式ゴルフ
+code-golf-desc = Desmos の数式ゴルファーのための補助ツール
+code-golf-width-in-pixels = 幅: { $pixels } px
+code-golf-symbol-count = 文字数: { $elements }
+code-golf-click-to-enable-folder = クリックするとゴルフの統計を有効化できます。
+code-golf-note-latex-byte-count = LaTeX 表現のバイト数 { $chars }
+
+## Syntax highlightAlternatingLines
+syntax-highlighting-name = シンタックスハイライト
+syntax-highlighting-desc = 数式のさまざまな部分に色をつけて判読性を向上する
+syntax-highlighting-opt-bracketPairColorization-name = 括弧の色付け
+syntax-highlighting-opt-bracketPairColorization-desc = 括弧に交互に色を適用し (例: ()[]{"{"}{"}"}||)、 一致する括弧のペアを見つけやすくします。
+syntax-highlighting-opt-bracketPairColorizationColors-name = 括弧の色
+syntax-highlighting-opt-bracketPairColorizationColors-desc = 括弧の色付けに使用する色の数と順序を設定します。
+syntax-highlighting-opt-bpcColorInText-name = 括弧内のテキストを色付けする
+syntax-highlighting-opt-bpcColorInText-desc = 括弧内のテキストに括弧の色を適用します。
+syntax-highlighting-opt-thickenBrackets-name = 括弧を太くする
+syntax-highlighting-opt-thickenBrackets-desc = 括弧を太くし、色付けを補助します。
+syntax-highlighting-opt-highlightBracketBlocks-name = 括弧のブロックをハイライト
+syntax-highlighting-opt-highlightBracketBlocks-desc = テキストカーソルを含む最小の括弧のペアをハイライトします。
+syntax-highlighting-opt-highlightBracketBlocksHover-name = ホバー時のハイライト
+syntax-highlighting-opt-highlightBracketBlocksHover-desc = マウスを含む最小の括弧のペアをハイライトします。
+syntax-highlighting-opt-underlineHighlightedRanges-name = ハイライト範囲に下線を引く
+syntax-highlighting-opt-underlineHighlightedRanges-desc = ハイライトされた範囲の下に濃い下線を引いて見やすくします。
+
+## Better Navigation
+better-navigation-name = 効率的な移動機能
+better-navigation-desc = Desmos の数式での移動をより簡単にするためのツール 
+better-navigation-opt-ctrlArrow-name = Ctrl+Arrow のサポート
+better-navigation-opt-ctrlArrow-desc = Ctrl+矢印キー または Ctrl+Shift+矢印キー を使用して、大きなテキストブロックをすばやくスキップします。Ctrl+Backspace を使用すると、大きなテキストブロックを削除できます。
+better-navigation-opt-scrollableExpressions-name = 数式のスクロールを有効化
+better-navigation-opt-scrollableExpressions-desc = 数式に水平スクロールバーを追加します。これは主にモバイルでのスクロールを簡単にするためのものです。


### PR DESCRIPTION
Because the original ja.ftl file contained some unnatural expressions that were machine-translated and lacked some localization, I have made overall improvements, including correction of mistranslations and unification of inconsistent notations.