### PR TITLE
Fix wrong screenshot scaling

### DIFF
--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -19,13 +19,13 @@ async function captureFrame(
   const width = vc.getCaptureWidthNumber();
   const height = vc.getCaptureHeightNumber();
   const targetPixelRatio = vc.getTargetPixelRatio();
-  // resolves the screenshot as a data URI
   const size = {
     width: width / targetPixelRatio,
     targetPixelRatio,
     height: height / targetPixelRatio,
     preserveAxisNumbers: true,
   };
+  // resolves the screenshot as a data URI
   const screenshot = vc.cc.is3dProduct() ? screenshot3d : screenshot2d;
   return await Promise.race([screenshot(vc, size), vc.awaitCancel()]);
 }
@@ -57,6 +57,7 @@ async function screenshot2d(vc: VideoCreator, size: ScreenshotOpts) {
     ...size,
     showLabels: true,
     mathBounds: clampedMathBounds,
+    mode: "contain" as "contain",
   };
   if (vc.fastScreenshots) {
     return await new Promise<string>((resolve) => {

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -57,7 +57,7 @@ async function screenshot2d(vc: VideoCreator, size: ScreenshotOpts) {
     ...size,
     showLabels: true,
     mathBounds: clampedMathBounds,
-    mode: "contain" as "contain",
+    mode: "contain" as const,
   };
   if (vc.fastScreenshots) {
     return await new Promise<string>((resolve) => {

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -212,9 +212,7 @@ export default class SelectCapture extends Component<{
             )}
           </If>
         </div>
-        <If
-          predicate={() => Math.abs(this.vc._getTargetPixelRatio() - 1) > 0.001}
-        >
+        <If predicate={() => this.vc.isPixelRatioValid()}>
           {() => (
             <div class="dsm-vc-pixel-ratio">
               <Checkbox

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -273,10 +273,17 @@ export default class VideoCreator extends PluginController {
     this.updateView();
   }
 
+  isPixelRatioValid() {
+    const UNIT_THRESHOLD = 0.001;
+    return this._getTargetPixelRatio() - 1 > UNIT_THRESHOLD;
+  }
+
   _getTargetPixelRatio() {
-    return (
+    // clamp to 1 because Desmos no longer support ratios less than 1
+    return Math.max(
+      1,
       this.captureWidth.getValue() /
-      this.calc.graphpaperBounds.pixelCoordinates.width
+        this.calc.graphpaperBounds.pixelCoordinates.width
     );
   }
 

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -148,6 +148,9 @@ export default class VideoCreator extends PluginController {
   deleteAll() {
     this.frames = [];
     this.previewIndex = 0;
+    if (this.isPlayingPreview) {
+      this.togglePlayingPreview();
+    }
     this.updateView();
   }
 


### PR DESCRIPTION
This PR fixes #920 with some caveats (see below)

Changes made
- screenshot mode set to "contain"
- pixel ratio is clamped to 1
- stop preview play when "delete all" is clicked

I believe there is no point in allowing pixel ratios that are less than 1 now that Desmos doesn't seem to support them anymore. As pointed out in the issue linked, this causes some screenshots below native resolution to actually increase in resolution. The drawback—which I think is reasonable—is that now these screenshots are no longer matched with what you see on screen (as if the same pixel ratio was checked on) as opposed to the default behavior.

The "contain" option fixes alignment problems with screenshots taken without fast screenshots. For some reason, these were preserving x instead which is odd because the default behavior according to the API is "contain".