### PR TITLE
Fix compact-view default font ratio

### DIFF
--- a/src/plugins/compact-view/compact.less
+++ b/src/plugins/compact-view/compact.less
@@ -12,9 +12,11 @@
       max(var(--bracket-font-size-factor), var(--minimum-font-size))
     );
   }
-  .dcg-main,
+  .dcg-main {
+    font-size: calc(1.1 * (16 / 18) * var(--math-font-size));
+  }
   .dcg-evaluation-container {
-    font-size: var(--math-font-size);
+    font-size: calc((16 / 18) * var(--math-font-size));
   }
 
   &.compact-view-no-separating-lines {


### PR DESCRIPTION
This is a quality of life change.

The default font size for expressions is 110% above the regular font size. That means that evaluation containers have a font size of 16 px while expressions have a font size of roughly 17.6 px. Default math font size now reflects the actual default (16 px).

Now when the spacing slider is all the way to the left, Desmos has a _default feel_. Previously you had to choose between the expressions or evaluation containers having a larger font-size than they normally do. This change was made to remove visual snags if all you want to enable is the "hide folder toggle" or "no separating lines" but keep the scaling off.