### PR TITLE
Prevent panic plugins showing twice in Menu

### DIFF
--- a/src/panic/panic.ts
+++ b/src/panic/panic.ts
@@ -1,4 +1,4 @@
-import { Console } from "../globals/window";
+import window, { Console } from "../globals/window";
 import { format } from "#i18n";
 import { PluginID } from "../plugins";
 import { Block } from "../preload/replacementHelpers/parse";
@@ -64,6 +64,9 @@ function addLabelledCheckboxItem(list: Element, plugin: string) {
 
 export const panickedPlugins = new Set<string>();
 function addPanickedPlugin(plugin: string) {
+  if (window.DesModderPreload?.pluginsForceDisabled.has(plugin as any)) {
+    return;
+  }
   Console.warn("Panicking for plugin", plugin);
   const panicPopover = ensurePanicPopover();
   document


### PR DESCRIPTION
This fixes #933

As noted in the issue above, force-disabled plugins which came in "groups" (related by dependencies) would essentially be able to be disabled an infinite number of times. The culprit was that the dependencies were not filtered by the list of force-disabled plugins.

I tested tested this by purposefully breaking random replacements with multiple dependencies. It seemed to work fine in all my tests. However, I am not sure yet if there is a cleaner way to achieve the same (without using `window` or `as any`), but it is currently just four lines.