### PR TITLE
Fix broken call to get graph title

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -166,7 +166,7 @@ export interface TimingData {
 }
 
 export interface TopLevelComponents {
-  headerController: {
+  mygraphsController: {
     graphsController: {
       getCurrentGraphTitle: () => string | undefined;
     };

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -41,7 +41,7 @@ export function truncatedLatexLabel(label: any, labelOptions: any) {
 }
 
 export function getCurrentGraphTitle(calc: Calc): string | undefined {
-  return calc._calc.globalHotkeys?.headerController?.graphsController?.getCurrentGraphTitle?.();
+  return calc._calc.globalHotkeys?.mygraphsController?.graphsController?.getCurrentGraphTitle?.();
 }
 
 export const List = Fragile.List;


### PR DESCRIPTION
The function `getCurrentGraphTitle` broke because a property changed in the `calc` object. This PR fixes the issue.

It is a very minor issue, but I thought of making it a PR before I forget.

Funny enough, I [fixed this same issue in my old user-script](https://github.com/SlimRunner/desmos-scripts-addons/commit/5a9fe674d85ee6abff42aabf5fcdcc83e1237e14) about a month ago, and even though I got that snippet from fireflame, I did not connect the dots until today that it was likely broken here too.