### PR TITLE
Add a scroll event listener to `view.scrollDOM` that closes the item settings menu

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -9,6 +9,7 @@ export type { DispatchedEvent };
 export type VanillaDispatchedEvent =
   | {
       type:
+        | "close-item-settings-menu"
         | "close-graph-settings"
         | "open-expression-search"
         | "close-expression-search"


### PR DESCRIPTION
Closes #958
The event listener will be removed when unmounting the editor for compatibility. Usually GC works so I'm not sure if it is always necessary.