### PR TITLE
Paste Image: Fix inappropriate warnings when pasting plain text

### DIFF
--- a/src/plugins/paste-image/index.ts
+++ b/src/plugins/paste-image/index.ts
@@ -19,6 +19,7 @@ export default class PasteImage extends PluginController {
 
   _pasteHandler(e: ClipboardEvent) {
     const clipboardFiles = e.clipboardData?.files;
+    if (!clipboardFiles?.length) return;
     if (!this.cc.areImagesEnabled()) {
       this.cc._showToast({
         // eslint-disable-next-line rulesdir/no-format-in-ts
@@ -32,7 +33,7 @@ export default class PasteImage extends PluginController {
             message: format("paste-image-error-another-upload-in-progress"),
           }),
       });
-    } else if (clipboardFiles?.length) {
+    } else {
       const { 0: nonImageFiles, 1: imageFiles } = Object.groupBy(
         clipboardFiles,
         ({ type: mimeType }) => +/image\/*/.test(mimeType)


### PR DESCRIPTION
When adding checks by `areImagesEnabled()` and `isUploadingImages()`, I forgot to exclude cases where `clipboardFiles.length === 0`, i.e. when plain text is pasted. For example, if we paste plain text in 3D calculator where images are not enabled, we get a `paste-image-error-images-not-enabled` warning.
This PR fixes the flow to first exclude such cases (return early).