### PR TITLE
Manage metadata: merge when loaded from link, don't create folder, delete duplicates

### DIFF
--- a/metadata/manage.ts
+++ b/metadata/manage.ts
@@ -52,6 +52,18 @@ export function mergeMetadata(target: Metadata, source: Metadata) {
   }
 }
 
+/** Create a new metadata by replacing all IDs `from` with `oldIdToNewId[from]`. */
+export function metadataWithIdsMapped(
+  oldMetadata: Metadata,
+  oldIdToNewId: Map<string, string>
+) {
+  const out = getBlankMetadata();
+  for (const [id, value] of Object.entries(oldMetadata.expressions)) {
+    out.expressions[oldIdToNewId.get(id) ?? id] = value;
+  }
+  return out;
+}
+
 function getDefaultValue(key: keyof Expression) {
   switch (key) {
     case "pinned":

--- a/metadata/manage.ts
+++ b/metadata/manage.ts
@@ -42,6 +42,16 @@ export function changeExprInMetadata(
   }
 }
 
+/**
+ * Mutate `target` by inserting the metadata from `source`.
+ */
+export function mergeMetadata(target: Metadata, source: Metadata) {
+  for (const [id, obj] of Object.entries(source.expressions)) {
+    if (!obj) continue;
+    changeExprInMetadata(target, id, obj);
+  }
+}
+
 function getDefaultValue(key: keyof Expression) {
   switch (key) {
     case "pinned":

--- a/metadata/migrate.ts
+++ b/metadata/migrate.ts
@@ -1,7 +1,12 @@
 import Metadata from "./interface";
+import { getBlankMetadata } from "./manage";
 import migrate1to2 from "./migrations/migrate1to2";
 
 export default function migrateToLatest(metadata: any): Metadata {
+  return migrateToLatestMaybe(metadata) ?? getBlankMetadata();
+}
+
+export function migrateToLatestMaybe(metadata: any): Metadata | undefined {
   if ("pinnedExpressions" in metadata) {
     /* Discriminate version 1 by using the presence of the pinnedExpressions
     property (it was the only property) */
@@ -9,10 +14,13 @@ export default function migrateToLatest(metadata: any): Metadata {
   }
   if (metadata.version !== 2) {
     // Something went wrong with migration. Just return a blank metadata
-    return {
-      version: 2,
-      expressions: {},
-    };
+    return undefined;
+  }
+  if (
+    !("expressions" in metadata) ||
+    typeof metadata.expressions !== "object"
+  ) {
+    return undefined;
   }
   return metadata;
 }

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -69,6 +69,9 @@ export default class DSM extends TransparentPlugins {
   }
 
   updateTheComputedWorld() {
+    for (const [_id, plugin] of this.enabledPluginsSorted()) {
+      plugin?.beforeUpdateTheComputedWorld?.();
+    }
     this.vanillaUpdateTheComputedWorld();
     for (const [_id, plugin] of this.enabledPluginsSorted()) {
       plugin?.afterUpdateTheComputedWorld?.();

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -13,7 +13,6 @@ import { postMessageUp, mapToRecord, recordToMap } from "#utils/messages.ts";
 
 export default class DSM extends TransparentPlugins {
   cc = this.calc.controller;
-  initDone = false;
   /**
    * pluginsEnabled keeps track of what plugins the user wants enabled,
    * regardless of forceDisabled settings.
@@ -118,8 +117,6 @@ export default class DSM extends TransparentPlugins {
       if (this.isPluginEnabled(id)) this._enablePlugin(id);
     }
     this.pillboxMenus?.updateMenuView();
-    this.initDone = true;
-    this.metadata?.checkForMetadataChange();
     // The graph loaded before DesModder loaded, so DesModder was not available to
     // return true when asked isGlesmosMode. Refresh those expressions now
     this.glesmos?.checkGLesmos();

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -4,7 +4,7 @@ import GraphMetadata, {
 } from "#metadata/interface.ts";
 import { getBlankMetadata, changeExprInMetadata } from "#metadata/manage.ts";
 import {
-  consolidateMetadataNotes,
+  deleteJunkMetadataNotes,
   getMetadataFromListModel,
   setMetadataInListModel,
   transferMetadata,
@@ -99,7 +99,7 @@ export default class ManageMetadata extends PluginController {
   }
 
   beforeUpdateTheComputedWorld() {
-    consolidateMetadataNotes(this.calc);
+    deleteJunkMetadataNotes(this.calc);
   }
 
   afterUpdateTheComputedWorld() {

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -3,7 +3,11 @@ import GraphMetadata, {
   Expression as MetadataExpression,
 } from "#metadata/interface.ts";
 import { getBlankMetadata, changeExprInMetadata } from "#metadata/manage.ts";
-import { getMetadataFromListModel, setMetadataInListModel } from "./sync";
+import {
+  consolidateMetadataNotes,
+  getMetadataFromListModel,
+  setMetadataInListModel,
+} from "./sync";
 import { AllActions, DispatchedEvent } from "../../globals/extra-actions";
 
 declare module "src/globals/extra-actions" {
@@ -90,6 +94,10 @@ export default class ManageMetadata extends PluginController {
         >;
     }
     return undefined;
+  }
+
+  beforeUpdateTheComputedWorld() {
+    consolidateMetadataNotes(this.calc);
   }
 
   afterUpdateTheComputedWorld() {

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -3,7 +3,7 @@ import GraphMetadata, {
   Expression as MetadataExpression,
 } from "#metadata/interface.ts";
 import { getBlankMetadata, changeExprInMetadata } from "#metadata/manage.ts";
-import { getMetadata, setMetadata } from "./sync";
+import { getMetadataFromListModel, setMetadataInListModel } from "./sync";
 import { AllActions, DispatchedEvent } from "../../globals/extra-actions";
 
 declare module "src/globals/extra-actions" {
@@ -16,6 +16,21 @@ declare module "src/globals/extra-actions" {
   }
 }
 
+/**
+ * There is no field that we can trust to contain arbitrary values upon
+ * which to store metadata, so we store the metadata on a note, so
+ * it serializes nicely to JSON.
+ *
+ * The `dsm-metadata` note in the current `listModel` is the source of truth.
+ * Events which affect metadata directly change the string JSON in the note,
+ * and in the `graphMetadata` model. If the note changes without the
+ * `graphMetadata` model, then `afterUpdateTheComputedWorld` corrects the
+ * `graphMetadata` model by filling in the parsed JSON.
+ *
+ * The only reason besides performance we keep `graphMetadata` as a property
+ * is to make it easy to show a toast when new expressions are GLesmos but
+ * GLesmos is disabled.
+ */
 export default class ManageMetadata extends PluginController {
   static id = "manage-metadata" as const;
   static enabledByDefault = true;
@@ -23,24 +38,14 @@ export default class ManageMetadata extends PluginController {
 
   graphMetadata: GraphMetadata = getBlankMetadata();
 
-  afterEnable() {
-    this.calc.observeEvent("change.dsm-main-controller", () => {
-      this.checkForMetadataChange();
-    });
-    this.checkForMetadataChange();
-  }
-
   beforeDisable() {
     throw new Error(
       "Programming Error: core plugin Manage Metadata should not be disableable"
     );
   }
 
-  checkForMetadataChange() {
-    if (!this.dsm.initDone) {
-      return;
-    }
-    const newMetadata = getMetadata(this.calc);
+  private syncFromMetadataNote() {
+    const newMetadata = getMetadataFromListModel(this.calc);
     if (!this.dsm.glesmos) {
       if (
         Object.entries(newMetadata.expressions).some(
@@ -56,12 +61,14 @@ export default class ManageMetadata extends PluginController {
       }
     }
     this.graphMetadata = newMetadata;
+
+    // This should really be in updateViews(), but not critical.
     this.dsm.pinExpressions?.applyPinnedStyle();
   }
 
   private _updateExprMetadata(id: string, obj: Partial<MetadataExpression>) {
     changeExprInMetadata(this.graphMetadata, id, obj);
-    setMetadata(this.calc, this.graphMetadata);
+    setMetadataInListModel(this.calc, this.graphMetadata);
   }
 
   /** Called from inside a couple dispatched functions. */
@@ -83,6 +90,10 @@ export default class ManageMetadata extends PluginController {
         >;
     }
     return undefined;
+  }
+
+  afterUpdateTheComputedWorld() {
+    this.syncFromMetadataNote();
   }
 
   getDsmItemModel(id: string) {

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -7,8 +7,10 @@ import {
   consolidateMetadataNotes,
   getMetadataFromListModel,
   setMetadataInListModel,
+  transferMetadata,
 } from "./sync";
 import { AllActions, DispatchedEvent } from "../../globals/extra-actions";
+import { ItemState } from "graph-state/state";
 
 declare module "src/globals/extra-actions" {
   interface AllActions {
@@ -113,5 +115,13 @@ export default class ManageMetadata extends PluginController {
       ...v,
       id,
     }));
+  }
+
+  transferMetadata(
+    currentList: ItemState[],
+    newList: ItemState[],
+    oldIdToNewId: Map<string, string>
+  ) {
+    transferMetadata(currentList, newList, oldIdToNewId);
   }
 }

--- a/src/core-plugins/manage-metadata/manage-metadata.replacements
+++ b/src/core-plugins/manage-metadata/manage-metadata.replacements
@@ -28,3 +28,64 @@ case "expression": $from =
 __body__;
 DSM.metadata?.duplicateMetadata($to.id, $from.id)
 ```
+
+## Convert IDs when loading graph from a link
+
+*Description* `Transfer expression IDs for metadata when a link is pasted into a blank expression`
+
+*Find* => `body`
+
+```js
+for (let $I = 0; $I < $newList.length; $I++) {
+    let $newId = $r.generateId(),
+        $expr = $newList[$I];
+    if ($expr.type === "folder")
+        if ($m) {
+            $n();
+            return
+        } else {
+            $y[$expr.id] = $newId,
+            $expr.id = $newId;
+            continue
+        }
+    $expr.folderId ? $expr.folderId = $y[$expr.folderId] : $h ? $expr.folderId = $p.id : $u && ($expr.folderId = $p.folderId),
+    $expr.id = $newId
+}
+let $v = $exports[____]($w),
+    $E = 0;
+for (; $E < $currentList.length; ) {
+    ____
+}
+let $k = $h ? $E + 1 : $E,
+    $T = $h ? 0 : 1;
+$currentList.splice($k, $T, ...$newList),
+```
+
+*Find* inside `body` => `firstFor`
+
+```js
+for (let $ = 0; $ < $.length; $++) {
+    let $ = $.generateId(),
+        $ = $[$];
+```
+
+*Replace* `firstFor` with
+
+```js
+const dsmOldIdToNewId = new window.Map();
+__firstFor__
+    dsmOldIdToNewId.set($expr.id, $newId);
+```
+
+*Find* inside `body` => `splice`
+
+```js
+$.splice($, $, ...$)
+```
+
+*Replace* `splice` with
+
+```js
+__splice__,
+DSM?.metadata?.transferMetadata($currentList, $newList, dsmOldIdToNewId)
+```

--- a/src/core-plugins/manage-metadata/manage-metadata.replacements
+++ b/src/core-plugins/manage-metadata/manage-metadata.replacements
@@ -28,22 +28,3 @@ case "expression": $from =
 __body__;
 DSM.metadata?.duplicateMetadata($to.id, $from.id)
 ```
-
-## Check/update DesModder metadata before allowing statements to update.
-
-Allows correct checking of the .glesmos metadata; otherwise, we run into `Calc.observeEvent("change")` triggering after addStatement sends the data to the worker. We need the correct `.glesmos` property before addStatement.
-
-*Description* `Check GLesmos metatata before calculating a statement`
-
-*plugin* `GLesmos`
-
-*Find*
-```js
-requestParseForAllItems() {__body__}
-```
-
-*Replace* `body` with
-```js
-DSM.metadata?.checkForMetadataChange();
-__body__
-```

--- a/src/core-plugins/manage-metadata/sync.ts
+++ b/src/core-plugins/manage-metadata/sync.ts
@@ -1,10 +1,6 @@
 import Metadata from "#metadata/interface.ts";
 import { migrateToLatestMaybe } from "#metadata/migrate.ts";
-import {
-  getBlankMetadata,
-  isBlankMetadata,
-  mergeMetadata,
-} from "#metadata/manage.ts";
+import { getBlankMetadata, isBlankMetadata } from "#metadata/manage.ts";
 import {
   type Calc,
   CalcController,
@@ -122,6 +118,7 @@ export function consolidateMetadataNotes(calc: Calc) {
   for (const item of cc.getAllItemModels()) {
     if (item.id === ID_METADATA) continue;
     if (item.type !== "text") continue;
+    if (item.readonly) continue;
     if (!isItemSecret(cc, item)) continue;
     const metadata = getMetadataFromTextItemMaybe(item);
     if (metadata === undefined) continue;
@@ -137,14 +134,7 @@ export function consolidateMetadataNotes(calc: Calc) {
   if (toRemove.size === 0) {
     return;
   }
-  const { deletedItems } = cc.removeListOfItems([...toRemove.keys()]);
-  const graphMetadata = _getMetadataFromListModel(cc);
-  for (const item of deletedItems) {
-    const metadata = toRemove.get(item.id);
-    if (!metadata) continue;
-    mergeMetadata(graphMetadata, metadata);
-  }
-  setMetadataInListModel(calc, graphMetadata);
+  cc.removeListOfItems([...toRemove.keys()]);
 }
 
 function isItemSecret(cc: CalcController, item: ItemModel): boolean {

--- a/src/core-plugins/manage-metadata/sync.ts
+++ b/src/core-plugins/manage-metadata/sync.ts
@@ -1,7 +1,17 @@
 import Metadata from "#metadata/interface.ts";
-import migrateToLatest from "#metadata/migrate.ts";
-import { getBlankMetadata, isBlankMetadata } from "#metadata/manage.ts";
-import { type Calc, Console } from "#globals";
+import { migrateToLatestMaybe } from "#metadata/migrate.ts";
+import {
+  getBlankMetadata,
+  isBlankMetadata,
+  mergeMetadata,
+} from "#metadata/manage.ts";
+import {
+  type Calc,
+  CalcController,
+  Console,
+  ItemModel,
+  TextModel,
+} from "#globals";
 import { List } from "#utils/depUtils.ts";
 import { FolderState, TextState } from "graph-state/state";
 
@@ -28,23 +38,37 @@ The text content of dsm-metadata is in JSON format
 const ID_METADATA = "dsm-metadata";
 const ID_METADATA_FOLDER = "dsm-metadata-folder";
 
-function getMetadataExpr(calc: Calc) {
-  return calc.controller.getItemModel(ID_METADATA);
+function getMetadataExpr(cc: CalcController) {
+  return cc.getItemModel(ID_METADATA);
+}
+
+function _getMetadataFromListModel(cc: CalcController) {
+  const expr = getMetadataExpr(cc);
+  if (expr === undefined) return getBlankMetadata();
+  if (expr.type === "text") {
+    const metadata = getMetadataFromTextItemMaybe(expr);
+    if (metadata) {
+      return metadata;
+    }
+  }
+
+  Console.warn("Invalid dsm-metadata. Ignoring");
+  return getBlankMetadata();
 }
 
 export function getMetadataFromListModel(calc: Calc) {
-  const expr = getMetadataExpr(calc);
-  if (expr === undefined) return getBlankMetadata();
-  if (expr.type === "text" && expr.text !== undefined) {
-    try {
-      const parsed = JSON.parse(expr.text);
-      return migrateToLatest(parsed);
-    } catch {
-      // Fallthrough to below Invalid case.
-    }
+  return _getMetadataFromListModel(calc.controller);
+}
+
+function getMetadataFromTextItemMaybe(expr: TextModel): Metadata | undefined {
+  if (!expr.text) return undefined;
+  if (!expr.text.startsWith("{")) return undefined;
+  try {
+    const parsed = JSON.parse(expr.text);
+    return migrateToLatestMaybe(parsed);
+  } catch {
+    return undefined;
   }
-  Console.warn("Invalid dsm-metadata. Ignoring");
-  return getBlankMetadata();
 }
 
 function addItemToEnd(calc: Calc, state: FolderState | TextState) {
@@ -79,4 +103,67 @@ function cleanMetadata(calc: Calc, metadata: Metadata) {
       delete metadata.expressions[id];
     }
   }
+}
+
+/**
+ * We assume there's only at most one text expr with ID "dsm-metadata,"
+ * which Desmos does guarantee. But importing or pasting graphs may
+ * end up inserting new dsm-metadata text.
+ * Here, we detect statements that look like pasted metadata expressions:
+ *  - Secret, or inside a secret folder.
+ *  - Text statement
+ *  - Text starts with "{"
+ *  - Parses as valid metadata.
+ * They are removed and all merged into a single metadata expression.
+ */
+export function consolidateMetadataNotes(calc: Calc) {
+  const cc = calc.controller;
+  const toRemove = new Map<string, Metadata>();
+  for (const item of cc.getAllItemModels()) {
+    if (item.id === ID_METADATA) continue;
+    if (item.type !== "text") continue;
+    if (!isItemSecret(cc, item)) continue;
+    const metadata = getMetadataFromTextItemMaybe(item);
+    if (metadata === undefined) continue;
+    const toDelete = idToDelete(cc, item);
+    toRemove.set(toDelete, metadata);
+    if (toRemove.size > 10) {
+      // `cc.removeListOfItems` is currently a quadratic algorithm
+      // since it just removes one item at a time. Give up instead
+      // of freezing the page.
+      return;
+    }
+  }
+  if (toRemove.size === 0) {
+    return;
+  }
+  const { deletedItems } = cc.removeListOfItems([...toRemove.keys()]);
+  const graphMetadata = _getMetadataFromListModel(cc);
+  for (const item of deletedItems) {
+    const metadata = toRemove.get(item.id);
+    if (!metadata) continue;
+    mergeMetadata(graphMetadata, metadata);
+  }
+  setMetadataInListModel(calc, graphMetadata);
+}
+
+function isItemSecret(cc: CalcController, item: ItemModel): boolean {
+  if (item.secret) return true;
+  if (item.type === "folder") return false;
+  const parentFolder = item.folderId && cc.getItemModel(item.folderId);
+  return !!parentFolder && !!parentFolder.secret;
+}
+
+/** If the expr is the only expr in its folder, delete the folder entirely. */
+function idToDelete(cc: CalcController, item: ItemModel): string {
+  const parentFolder = item.folderId && cc.getItemModel(item.folderId);
+  if (parentFolder) {
+    const hasSibling =
+      cc.getItemModelByIndex(item.index - 1) !== parentFolder ||
+      cc.getItemModelByIndex(item.index + 1)?.folderId === item.folderId;
+    if (!hasSibling) {
+      return item.folderId!;
+    }
+  }
+  return item.id;
 }

--- a/src/core-plugins/manage-metadata/sync.ts
+++ b/src/core-plugins/manage-metadata/sync.ts
@@ -32,12 +32,16 @@ function getMetadataExpr(calc: Calc) {
   return calc.controller.getItemModel(ID_METADATA);
 }
 
-export function getMetadata(calc: Calc) {
+export function getMetadataFromListModel(calc: Calc) {
   const expr = getMetadataExpr(calc);
   if (expr === undefined) return getBlankMetadata();
   if (expr.type === "text" && expr.text !== undefined) {
-    const parsed = JSON.parse(expr.text);
-    return migrateToLatest(parsed);
+    try {
+      const parsed = JSON.parse(expr.text);
+      return migrateToLatest(parsed);
+    } catch {
+      // Fallthrough to below Invalid case.
+    }
   }
   Console.warn("Invalid dsm-metadata. Ignoring");
   return getBlankMetadata();
@@ -47,7 +51,7 @@ function addItemToEnd(calc: Calc, state: FolderState | TextState) {
   calc.controller._addItemToEndFromAPI(calc.controller.createItemModel(state));
 }
 
-export function setMetadata(calc: Calc, metadata: Metadata) {
+export function setMetadataInListModel(calc: Calc, metadata: Metadata) {
   cleanMetadata(calc, metadata);
   List.removeItemById(calc.controller.listModel, ID_METADATA);
   List.removeItemById(calc.controller.listModel, ID_METADATA_FOLDER);

--- a/src/core-plugins/manage-metadata/sync.ts
+++ b/src/core-plugins/manage-metadata/sync.ts
@@ -13,21 +13,18 @@ import { FolderState, ItemState, TextState } from "graph-state/state";
 /*
 This file manages the metadata expressions. These are stored on the graph state as expressions and consist of:
 
-{
-  type: "folder",
-  id: "dsm-metadata-folder",
-  secret: true,
-  title: "DesModder Metadata"
-}
 
 {
   type: "text",
   id: "dsm-metadata",
-  folderId: "dsm-metadata-folder",
+  secret: true,
   text: "{\n  \"key\": value\n}"
 }
 
 The text content of dsm-metadata is in JSON format
+
+There used to be a folder with ID "dsm-metadata-folder". We no longer use it
+and instead remove the folder from existing graphs.
 */
 
 const ID_METADATA = "dsm-metadata";
@@ -89,15 +86,9 @@ export function setMetadataInListModel(calc: Calc, metadata: Metadata) {
   List.removeItemById(calc.controller.listModel, ID_METADATA_FOLDER);
   if (!isBlankMetadata(metadata)) {
     addItemToEnd(calc, {
-      type: "folder",
-      id: ID_METADATA_FOLDER,
-      secret: true,
-      title: "DesModder Metadata",
-    });
-    addItemToEnd(calc, {
       type: "text",
       id: ID_METADATA,
-      folderId: ID_METADATA_FOLDER,
+      secret: true,
       text: JSON.stringify(metadata),
     });
   }
@@ -109,20 +100,12 @@ export function setMetadataInListJSON(list: ItemState[], metadata: Metadata) {
   removeIDFromListJSON(list, ID_METADATA);
   removeIDFromListJSON(list, ID_METADATA_FOLDER);
   if (!isBlankMetadata(metadata)) {
-    list.push(
-      {
-        type: "folder",
-        id: ID_METADATA_FOLDER,
-        secret: true,
-        title: "DesModder Metadata",
-      },
-      {
-        type: "text",
-        id: ID_METADATA,
-        folderId: ID_METADATA_FOLDER,
-        text: JSON.stringify(metadata),
-      }
-    );
+    list.push({
+      type: "text",
+      id: ID_METADATA,
+      secret: true,
+      text: JSON.stringify(metadata),
+    });
   }
 }
 

--- a/src/core-plugins/manage-metadata/sync.ts
+++ b/src/core-plugins/manage-metadata/sync.ts
@@ -152,9 +152,10 @@ function cleanMetadataGivenList(list: ItemState[], metadata: Metadata) {
  *  - Text statement
  *  - Text starts with "{"
  *  - Parses as valid metadata.
- * They are removed and all merged into a single metadata expression.
+ * They are all removed. They were pasted without proper ID migration,
+ * so the IDs are wrong: there is no point merging them in to the existing metadata.
  */
-export function consolidateMetadataNotes(calc: Calc) {
+export function deleteJunkMetadataNotes(calc: Calc) {
   const cc = calc.controller;
   const toRemove = new Map<string, Metadata>();
   for (const item of cc.getAllItemModels()) {

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -288,6 +288,12 @@ interface CalcPrivate {
     };
     _addItemToEndFromAPI: (item: ItemModel) => void;
     _showToast: (toast: Toast) => void;
+    removeListOfItems: (ids: string[]) => {
+      // Might only return a subset of the models corresponding to `ids`
+      // if some of the `ids` correspond to readonly expressions.
+      deletedItems: ItemModel[];
+      readonlyItemsNotDeleted: number;
+    };
     getViewState: () => {
       viewport: {
         xmin: number;

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -31,6 +31,7 @@ interface ItemModelBase {
   renderShell: boolean;
   isHiddenFromUI: boolean;
   filteredBySearch?: boolean;
+  readonly?: boolean;
   dsmGolfStats?: GolfStats;
   dsmEnableGolfDespiteLength?: boolean;
 }

--- a/src/plugins/GLesmos/index.ts
+++ b/src/plugins/GLesmos/index.ts
@@ -40,7 +40,6 @@ export default class GLesmos extends PluginController {
   }
 
   isGlesmosMode(id: string) {
-    this.dsm.metadata?.checkForMetadataChange();
     return this.dsm.metadata?.getDsmItemModel(id)?.glesmos ?? false;
   }
 
@@ -67,7 +66,6 @@ export default class GLesmos extends PluginController {
   }
 
   isGLesmosLinesConfirmed(id: string) {
-    this.dsm.metadata?.checkForMetadataChange();
     return (
       this.dsm.metadata?.getDsmItemModel(id)?.glesmosLinesConfirmed ?? false
     );

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -101,6 +101,7 @@ export interface PluginInstance<
   handleDispatchedAction?: (
     evt: DispatchedEvent
   ) => "abort-later-handlers" | undefined;
+  beforeUpdateTheComputedWorld?: () => void;
   afterUpdateTheComputedWorld?: () => void;
 }
 

--- a/src/plugins/intellisense/state.tsx
+++ b/src/plugins/intellisense/state.tsx
@@ -8,7 +8,7 @@ import type { Calc, ItemModel } from "#globals";
 import { rootKeys } from "#plugins/find-replace/backend.ts";
 import Metadata from "metadata/interface";
 import { get } from "#utils/utils.ts";
-import { getMetadata } from "../../core-plugins/manage-metadata/sync";
+import { getMetadataFromListModel } from "../../core-plugins/manage-metadata/sync";
 
 function getOrMakeKey<K, V>(map: Map<K, V>, k: K, v: () => V) {
   if (map.has(k)) {
@@ -62,7 +62,7 @@ export class IntellisenseState {
   readonly cfg = buildConfigFromGlobals(Desmos, this.calc);
 
   constructor(public calc: Calc) {
-    this.metadata = getMetadata(calc);
+    this.metadata = getMetadataFromListModel(calc);
     this.cc.dispatcher.register((e) => {
       if (e.type === "on-evaluator-changes") {
         for (const id of Object.keys(e.changes)) {

--- a/src/tests/puppeteer-utils.ts
+++ b/src/tests/puppeteer-utils.ts
@@ -205,7 +205,6 @@ export class Driver {
       (enabled) => DSM.togglePluginsTo(enabled),
       this.enabledPluginsStart
     );
-    await this.evaluate(() => DSM.metadata?.checkForMetadataChange());
     const exitELM = await this.page.$(EXIT_ELM);
     if (exitELM) await exitELM.click();
     // Wait for settings to get sent back to the extension storage


### PR DESCRIPTION
Fixes https://github.com/DesModder/DesModder/issues/310:

1. When pasting a graph by link (with DesModder installed), merge the metadatas together.
2. Create a single secret note for dsm-metadata, instead of a regular note contained inside a secret folder.

A side-change to clean up junk notes with DesModder not installed:

3. Delete notes (and containing folders) that look like dsm-metadata but without the ID. These can be created when pasting a graph by link when DesModder is not installed. The IDs don't line up, so there is no point keeping them around.