### PR TITLE
Fixes to when golf stats are hidden.

### DIFF
--- a/src/plugins/code-golf/GolfStatsPanel.tsx
+++ b/src/plugins/code-golf/GolfStatsPanel.tsx
@@ -40,7 +40,12 @@ export class GolfStatsPanel extends Component<{
         {IfElse(() => !this.isDisabled(), {
           true: () => (
             <If
-              predicate={() => areStatsUseful(this.props.model().dsmGolfStats)}
+              predicate={() =>
+                // We always need to show stats for folders because drag-drop
+                // can change the stats for the folders.
+                this.props.model().type === "folder" ||
+                areStatsUseful(this.props.model().dsmGolfStats)
+              }
             >
               {() => (
                 <div class="dsm-code-golf-char-count-container">

--- a/src/plugins/code-golf/index.ts
+++ b/src/plugins/code-golf/index.ts
@@ -48,6 +48,6 @@ export default class CodeGolf extends PluginController {
   }
 
   afterUpdateTheComputedWorld() {
-    populateGolfStats(this.cc);
+    populateGolfStats(this);
   }
 }


### PR DESCRIPTION
1. Avoid issue where dragging the sole child of a folder would hide the folder stats, changing the folder's height.
2. Always compute golf stats for pinned expressions, instead of hiding once the true expression scrolls out of view.