### PR TITLE
Reduce goBack count when trimming leading numbers

### DIFF
--- a/src/plugins/intellisense/intellisense.int.test.ts
+++ b/src/plugins/intellisense/intellisense.int.test.ts
@@ -1,4 +1,4 @@
-import { testWithPage } from "../../tests/puppeteer-utils";
+import { testWithPage } from "#tests";
 
 const delay = async (ms: number) =>
   // eslint-disable-next-line rulesdir/no-timeouts-in-intellisense
@@ -152,6 +152,11 @@ describe("Intellisense", () => {
       await driver.keyboard.type("alphaabc");
       await wiggle();
       await driver.assertSelectedItemLatex("\\alpha_{abc}");
+      await driver.keyboard.press("Escape");
+      await driver.keyboard.press("Enter");
+      await driver.keyboard.type("2foo");
+      await wiggle();
+      await driver.assertSelectedItemLatex("2f_{oo}");
       await driver.keyboard.press("Escape");
       await driver.keyboard.press("Enter");
 


### PR DESCRIPTION
Fixes #955. The problem was that intellisense scans backwards including numbers, so `ab2cd` can auto-subscriptify to `a_{b2cd}`. However, it trims leading digits, so `3ab2cd` doesn't try auto-subscriptifying to `3_{ab2cd}`; it goes to `a_{b2cd}` instead. But the calculation for how many times to press "backspace" wasn't reduced when trimming the leading digits.