### PR TITLE
Localize and fix Glesmos warning

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -24,6 +24,7 @@ GLesmos-label-toggle-glesmos = Render with GLesmos
 GLesmos-confirm-lines = Confirm lines
 GLesmos-confirm-lines-body = GLesmos line rendering can be slow. Be careful, especially for a list of layers.
 GLesmos-no-support = Unfortunately, your browser does not support GLesmos because it does not support WebGL2.
+GLesmos-not-enabled = Enable the GLesmos plugin to improve the performance of some implicits in this graph.
 # Missing: error messages
 
 ## Tips

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -53,7 +53,8 @@ export default class ManageMetadata extends PluginController {
 
   private syncFromMetadataNote() {
     const newMetadata = getMetadataFromListModel(this.calc);
-    if (!this.dsm.glesmos) {
+    // We could be in the middle of init, so we can't just do `!this.dsm.glesmos`.
+    if (!this.dsm.isPluginEnabled("GLesmos")) {
       if (
         Object.entries(newMetadata.expressions).some(
           ([id, e]) =>

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./sync";
 import { AllActions, DispatchedEvent } from "../../globals/extra-actions";
 import { ItemState } from "graph-state/state";
+import { format } from "#i18n";
 
 declare module "src/globals/extra-actions" {
   interface AllActions {
@@ -61,8 +62,8 @@ export default class ManageMetadata extends PluginController {
       ) {
         // list of glesmos expressions changed
         this.cc._showToast({
-          message:
-            "Enable the GLesmos plugin to improve the performance of some implicits in this graph",
+          // eslint-disable-next-line rulesdir/no-format-in-ts
+          message: format("GLesmos-not-enabled"),
         });
       }
     }

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -120,6 +120,10 @@ export type VanillaDispatchedEvent =
       token: keyof CalcController["__pendingImageUploads"];
       error: true;
     }
+  | {
+      type: "toast/show";
+      toast: Toast;
+    }
   | { type: "set-folder-collapsed"; id: string; isCollapsed: boolean }
   | { type: "set-item-colorLatex"; id: string; colorLatex: string }
   | { type: "set-note-text"; id: string; text: string };
@@ -337,6 +341,7 @@ interface CalcPrivate {
     areImagesEnabled: () => boolean;
     scrollSelectedItemIntoView: () => void;
     s: (identifier: string, placeables?: Record<string, any> | null) => string;
+    runAfterDispatch: (cb: () => void) => void;
   };
   _calc: {
     globalHotkeys: TopLevelComponents;


### PR DESCRIPTION
When you load a GLesmos-enabled graph but you don't have GLesmos enabled, we show a warning. The current behavior is quite bugged.

1. Localize the message (cuz why not)
2. If GLesmos is enabled on the first load of the page, we previously still showed a warning because it wasn't loaded at the time of the event that triggers the message. This fixes that by checking if GLesmos will be enabled.
3. When navigating between graphs in the shell menu, the toast was previously replaced by a toast like "Opened 'Untitled Graph'". Now, we replace that with the GLesmos message.