### PR TITLE
Force string placeholder

### DIFF
--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -117,7 +117,7 @@ export abstract class InlineMathInputViewComponent extends ClassComponent<{
   isFocused: boolean;
   ariaLabel: string;
   // ariaPostLabel: string;
-  placeholder?: string;
+  placeholder: string;
   handleLatexChanged: (s: string) => void;
   handlePressedKey?: (key: string, e: KeyboardEvent) => void;
   hasError?: boolean;

--- a/src/plugins/code-golf/golf-model.ts
+++ b/src/plugins/code-golf/golf-model.ts
@@ -227,6 +227,7 @@ function golfStatsForExpr(cc: CalcController, latex: string): GolfStats {
     handleFocusChanged: () => () => false,
     ariaLabel: () => "",
     controller: () => cc,
+    placeholder: () => "",
   });
 
   const stats = {

--- a/src/plugins/video-creator/components/CaptureMethod.tsx
+++ b/src/plugins/video-creator/components/CaptureMethod.tsx
@@ -58,6 +58,7 @@ export default class SelectCapture extends Component<{
                       this.vc.updateFocus("capture-slider-var", b)
                     }
                     controller={this.vc.cc}
+                    placeholder=""
                   />
                 </span>
                 <StaticMathQuillView latex="=" />

--- a/src/plugins/video-creator/components/ManagedNumberInput.tsx
+++ b/src/plugins/video-creator/components/ManagedNumberInput.tsx
@@ -80,7 +80,7 @@ export default class ManagedNumberInput extends Component<ManagedNumberInputPara
           "dsm-suffix-degree-per-sec": this.props.numberUnits?.() === "°/s",
           "dsm-suffix-radian-per-sec": this.props.numberUnits?.() === "rad/s",
         })}
-        placeholder={() => this.props.data().getDefaultLatex()}
+        placeholder={() => this.props.data().getDefaultLatex() ?? ""}
         ariaLabel={() => this.props.ariaLabel()}
         handleLatexChanged={(latex) => {
           this.props.data().setLatexWithCallbacks(latex);


### PR DESCRIPTION
This fixes error logged to console when the magic button (auto-detect dimensions) is pressed when capture width or height is empty. Desmos uses `getPlaceholder().trim()` instead of `getPlaceholder()?.trim()`.