### PR TITLE
Fix preload to work with shared_calculator_desktop

### DIFF
--- a/public/chrome/net_request_rules.json
+++ b/public/chrome/net_request_rules.json
@@ -145,5 +145,25 @@
     "condition": {
       "urlFilter": "*://*.desmos.com:*/*/calculator_3d-*.js|"
     }
+  },
+  {
+    "id": 11,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "*://*.desmos.com/*/shared_calculator_desktop-*.js|"
+    }
+  },
+  {
+    "id": 12,
+    "priority": 1,
+    "action": {
+      "type": "block"
+    },
+    "condition": {
+      "urlFilter": "*://*.desmos.com:*/*/shared_calculator_desktop-*.js|"
+    }
   }
 ]

--- a/src/background.ts
+++ b/src/background.ts
@@ -33,6 +33,7 @@ if (BROWSER === "firefox") {
         "https://*.desmos.com/assets/build/calculator_desktop-*.js",
         "https://*.desmos.com/assets/build/calculator_geometry-*.js",
         "https://*.desmos.com/assets/build/calculator_3d-*.js",
+        "https://*.desmos.com/assets/build/shared_calculator_desktop-*.js",
       ],
     },
     ["blocking"]

--- a/src/plugins/set-primary-color/clean-css.mjs
+++ b/src/plugins/set-primary-color/clean-css.mjs
@@ -5,7 +5,7 @@
  * overrides.less, replacing primary-based colors with var(--variable) and
  * keeping only those rules
  *
- * First copy `calculator_desktop-[hash].css` into `src/plugins/set-primary-color/raw.css`
+ * First copy `shared_calculator_desktop-[hash].css` into `src/plugins/set-primary-color/raw.css`
  *
  * Usage once `raw.css` is obtained:
  *   cd src/plugins/set-primary-color/

--- a/src/plugins/video-creator/video-creator.int.test.ts
+++ b/src/plugins/video-creator/video-creator.int.test.ts
@@ -1,4 +1,4 @@
-import { clean, testWithPage } from "#tests";
+import { testWithPage } from "#tests";
 
 const CAPTURE = ".dsm-menu-container .dsm-vc-capture-menu";
 const PREVIEW = ".dsm-menu-container .dsm-vc-preview-menu";
@@ -35,7 +35,5 @@ describe("Video Creator", () => {
 
     // Click graphpaper to close menu
     await driver.click(".dcg-graph-outer");
-
-    return clean;
   });
 });

--- a/src/preload/script.ts
+++ b/src/preload/script.ts
@@ -13,8 +13,8 @@ import { fullReplacementCached } from "./replacementHelpers/cacheReplacement";
 
 /* This script is loaded at document_start, before the page's scripts */
 
-/** The calculator is not loaded as soon as toplevel/calculator_desktop is
- * loaded; toplevel/calculator_desktop sneakily contains a thenable, so it
+/** The calculator is not loaded as soon as shared_calculator_desktop is
+ * loaded; shared_calculator_desktop sneakily contains a thenable, so it
  * returns before actually initializing the calculator. This leads to a race
  * condition, so poll for Calc being ready. */
 function tryRunDesModder() {
@@ -30,6 +30,7 @@ function runDesModder() {
 
 function getCalcDesktopURL() {
   const script: HTMLScriptElement | null =
+    document.querySelector("script[src*='shared_calculator_desktop']") ??
     document.querySelector("script[src*='calculator_desktop']") ??
     document.querySelector("script[src*='calculator_geometry']") ??
     document.querySelector("script[src*='calculator_3d']");

--- a/src/tests/puppeteer-utils.ts
+++ b/src/tests/puppeteer-utils.ts
@@ -258,7 +258,7 @@ export class Driver {
       ".dcg-keys-container[aria-hidden]"
     );
     // There's no visible mathquill, except those that are children of keypad
-    // (which don't get removed rom the DOM tree)
+    // (which don't get removed from the DOM tree)
     const allMathquillAreInKeypad = await this.page.$$eval(
       ".dcg-mq-root-block:not(.dcg-mq-empty)",
       (elems) => elems.every((e) => e.closest(".dcg-keypad"))

--- a/src/tests/setup-unit.js
+++ b/src/tests/setup-unit.js
@@ -8,7 +8,7 @@ module.exports = async function () {
   const SERVER = "https://desmos.com";
   const CACHE_FOLDER = "node_modules/.cache/desmos";
   const CALC_DESKTOP = `${CACHE_FOLDER}/calculator_desktop.js`;
-  const PREFIX = '<script src="/assets/build/calculator_desktop';
+  const PREFIX = '<script src="/assets/build/shared_calculator_desktop';
 
   const calculatorLink = `${SERVER}/calculator`;
 


### PR DESCRIPTION
Desmos switched JS urls from `calculator_3d-*.js`, `calculator_desktop-*.js`, and `calculator_geometry-*.js` to a single `shared_calculator_desktop-*.js`. Fix blocking and preload to work with the new URL.

I'm keeping in the old URLs in case they change back. They can in theory be removed in the future.

Fixes #970