### PR TITLE
Fix broken replacements for Better Evaluation View

### DIFF
--- a/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
@@ -2,7 +2,7 @@ import { Driver, clean, testWithPage } from "#tests";
 
 async function expectEval(driver: Driver, latexExpected: string) {
   const latexFound = await driver.$eval(
-    ".dcg-evaluation-html .dcg-mq-root-block",
+    ".dcg-evaluation-container .dcg-mq-root-block",
     (el) => (el as any).mqBlockNode.latex()
   );
   expect(latexFound).toBe(latexExpected);
@@ -10,7 +10,7 @@ async function expectEval(driver: Driver, latexExpected: string) {
 
 async function expectEvalPlain(driver: Driver, textExpected: string) {
   const textFound = await driver.$eval(
-    ".dcg-evaluation-html",
+    ".dcg-evaluation-container",
     (el) => (el as HTMLElement).innerText
   );
   expect(textFound).toBe(textExpected);
@@ -20,16 +20,16 @@ const COLOR_SWATCH = ".dcg-color-swatch";
 
 testWithPage("List", async (driver) => {
   await driver.focusIndex(0);
-  await driver.setLatexAndSync("[1,2,3]");
+  await driver.setLatexAndSync("[1,2,3]+0");
   await expectEval(driver, "\\left[1,2,3\\right]");
 
   // It updates when you edit the latex
-  await driver.setLatexAndSync("[1,2,3,4]");
+  await driver.setLatexAndSync("[1,2,3,4]+0");
   await expectEval(driver, "\\left[1,2,3,4\\right]");
 
-  // It gets reset on disabling lists
+  // It gets reset on disabling lists, and shows the native list view instead.
   await driver.setPluginSetting("better-evaluation-view", "lists", false);
-  await expectEvalPlain(driver, "4 element list");
+  await expectEvalPlain(driver, "equals\n=\n1\n1\n2\n2\n3\n3\n4\n4");
 
   // Clean up
   await driver.clean();

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -65,16 +65,33 @@ list: () => DSM.replaceElement(
 
 *Find* => `list`
 ```js
-()=>this.getEvaluationRHS())({
+()=>this.cachedEvaluationRHS)({
 list: $rhs => $Dcgview.createElement(__oldList__)
 ```
 
 *Replace* `list` with
 ```js
-()=>this.getEvaluationRHS())({
+()=>this.cachedEvaluationRHS)({
 list: $rhs => DSM.replaceElement(
   () => $Dcgview.createElement(__oldList__),
-  () => DSM.betterEvaluationView?.listEvaluation(() => this.props.val())
+  () => DSM.betterEvaluationView?.listEvaluation(() => {
+    const itemModel = this.controller.getItemModel(this.props.id());
+    // get untruncated value
+    return itemModel.formula.typed_constant_value.value;
+  })
+)
+```
+
+*Find* => `emptyList`
+```js
+emptyList: () => $emptyListDcgview.createElement(__oldEmptyList__)
+```
+
+*Replace* `emptyList` with
+```js
+emptyList: () => DSM.replaceElement(
+  () => $emptyListDcgview.createElement(__oldEmptyList__),
+  () => DSM.betterEvaluationView?.listEvaluation(() => [])
 )
 ```
 

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -8,11 +8,13 @@
 
 *Find* => `undefined`
 ```js
-undefined: () =>  $Dcgview.createElement(
-    'span',
-    null,
-    $.const("undefined")
-  )
+undefined: ()=> $Dcgview.createElement(
+  $ViewClass,
+  {
+    ...this.props,
+    content: () => this.controller.s("shared-calculator-label-undefined")
+  }
+)
 ```
 
 *Replace* `undefined` with
@@ -28,9 +30,11 @@ undefined: () => $Dcgview.Components.IfElse(
         }
       ),
       false: () => $Dcgview.createElement(
-        "span",
-        null,
-        $Dcgview.const("undefined")
+        $ViewClass,
+        {
+          ...this.props,
+          content: () => this.controller.s("shared-calculator-label-undefined")
+        }
       )
     }
   )

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -125,7 +125,7 @@ rgbcolor: $rhs => $Dcgview.createElement(__swatch__)
 ```js
 rgbcolor: $rhs => DSM.replaceElement(
   () => $Dcgview.createElement(__swatch__),
-  () => DSM.betterEvaluationView?.colorEvaluation(() => this.props.val())
+  () => DSM.betterEvaluationView?.colorEvaluation(() => this.getEvaluationRHS().val)
 )
 ```
 

--- a/src/plugins/better-evaluation-view/components/ColorEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ColorEvaluation.tsx
@@ -3,31 +3,33 @@ import { StaticMathQuillView } from "#components";
 
 function _ColorEvaluation(val: () => string | string[]) {
   return (
-    <StaticMathQuillView
-      latex={() => {
-        const value = val();
-        const length = 6;
-        if (Array.isArray(value)) {
-          const color = value.map(rgb);
-          return (
-            "\\operatorname{rgb}\\left(\\left[" +
-            color
-              .slice(0, length)
-              .map((clist) => `\\left(${clist.join(",")}\\right)`)
-              .join(",") +
-            (color.length > length
-              ? `\\textcolor{gray}{...\\mathit{${
-                  color.length - length
-                }\\ more}}`
-              : "") +
-            "\\right]\\right)"
-          );
-        } else {
-          const color = rgb(value);
-          return "\\operatorname{rgb}\\left(" + color.join(",") + "\\right)";
-        }
-      }}
-    />
+    <div class="dcg-evaluation-view__wrapped-value">
+      <StaticMathQuillView
+        latex={() => {
+          const value = val();
+          const length = 6;
+          if (Array.isArray(value)) {
+            const color = value.map(rgb);
+            return (
+              "\\operatorname{rgb}\\left(\\left[" +
+              color
+                .slice(0, length)
+                .map((clist) => `\\left(${clist.join(",")}\\right)`)
+                .join(",") +
+              (color.length > length
+                ? `\\textcolor{gray}{...\\mathit{${
+                    color.length - length
+                  }\\ more}}`
+                : "") +
+              "\\right]\\right)"
+            );
+          } else {
+            const color = rgb(value);
+            return "\\operatorname{rgb}\\left(" + color.join(",") + "\\right)";
+          }
+        }}
+      />
+    </div>
   );
 }
 

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -4,28 +4,32 @@ import { StaticMathQuillView } from "#components";
 
 export function ListEvaluation(val: () => string[]) {
   return (
-    <StaticMathQuillView
-      latex={() => {
-        const values = val();
-        const labelOptions = {
-          smallCutoff: 0.00001,
-          bigCutoff: 1000000,
-          digits: 5,
-          displayAsFraction: false,
-        };
-        const length = 20;
-        const labels = values
-          .slice(0, length)
-          .map((label) => truncatedLatexLabel(label, labelOptions));
-        return (
-          "\\left[" +
-          labels.join(",") +
-          (values.length > length
-            ? `\\textcolor{gray}{...\\mathit{${values.length - length}\\ more}}`
-            : "") +
-          "\\right]"
-        );
-      }}
-    />
+    <div class="dcg-evaluation-view__wrapped-value">
+      <StaticMathQuillView
+        latex={() => {
+          const values = val();
+          const labelOptions = {
+            smallCutoff: 0.00001,
+            bigCutoff: 1000000,
+            digits: 5,
+            displayAsFraction: false,
+          };
+          const length = 20;
+          const labels = values
+            .slice(0, length)
+            .map((label) => truncatedLatexLabel(label, labelOptions));
+          return (
+            "\\left[" +
+            labels.join(",") +
+            (values.length > length
+              ? `\\textcolor{gray}{...\\mathit{${
+                  values.length - length
+                }\\ more}}`
+              : "") +
+            "\\right]"
+          );
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
- `this.props.val()` is not working anymore, so I replaced them with `this.getEvaluationRHS().val` or `itemModel.formula.typed_constant_value.value`. For lists, the latter is not affected by truncation and always return all the elements.
- Added a replacement for `emptyList`
- Wrapped `StaticMathQuillView` with `div.dcg-evaluation-view__wrapped-value` to apply evaluation view styles