### PR TITLE
Support browser action to open calculator in firefox

### DIFF
--- a/public/firefox/manifest.json
+++ b/public/firefox/manifest.json
@@ -7,6 +7,13 @@
     "48": "icon48.png",
     "128": "icon128.png"
   },
+  "browser_action": {
+    "default_icon": {
+      "48": "icon48.png",
+      "128": "icon128.png"
+    },
+    "default_title": "DesModder"
+  },
   "background": {
     "scripts": ["background.js"]
   },

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,9 +9,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   return true;
 });
 
+// Open /calculator when the browser action is clicked.
 if (BROWSER === "chrome") {
-  // FIREFOX TODO: find Firefox equivalent. chrome.browserAction?
   chrome.action.onClicked?.addListener(() => {
+    void chrome.tabs.create({
+      url: "https://www.desmos.com/calculator",
+    });
+  });
+} else {
+  // MV2, see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction
+  chrome.browserAction.onClicked?.addListener(() => {
     void chrome.tabs.create({
       url: "https://www.desmos.com/calculator",
     });


### PR DESCRIPTION
Closes #981

Press the DesModder icon in the toolbar, or click DesModder from the puzzle piece extension menu to open desmos.