### PR TITLE
Upgrade prettier to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "less": "^4.2.0",
         "minimist-lite": "^2.2.1",
         "node-fetch": "^3.3.2",
-        "prettier": "^2.8.8",
+        "prettier": "^3.5.3",
         "puppeteer": "^24.0.0",
         "ts-jest": "^29.1.2",
         "tsutils": "^3.21.0",
@@ -9498,16 +9498,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -18052,9 +18052,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "test:integration": "jest --config ./jest-config/jest-integration.config.js --run-in-band",
     "test:integration-local": "jest --config ./jest-config/jest-integration-local.config.js --run-in-band"
   },
+  "prettier": {
+    "trailingComma": "es5"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/DesModder/DesModder"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "less": "^4.2.0",
     "minimist-lite": "^2.2.1",
     "node-fetch": "^3.3.2",
-    "prettier": "^2.8.8",
+    "prettier": "^3.5.3",
     "puppeteer": "^24.0.0",
     "ts-jest": "^29.1.2",
     "tsutils": "^3.21.0",

--- a/src/DCGView.ts
+++ b/src/DCGView.ts
@@ -13,7 +13,7 @@ type ToFunc<T> = {
 };
 
 export abstract class ClassComponent<
-  PropsType extends GenericProps = Record<string, unknown>
+  PropsType extends GenericProps = Record<string, unknown>,
 > {
   props!: ToFunc<PropsType>;
   children!: unknown;

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -2,7 +2,7 @@ import { ConfigItem, GenericSettings } from ".";
 import DSM from "#DSM";
 
 export class PluginController<
-  Settings extends GenericSettings | undefined = undefined
+  Settings extends GenericSettings | undefined = undefined,
 > {
   static descriptionLearnMore?: string = undefined;
   static forceEnabled?: boolean = undefined;

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -12,7 +12,10 @@ export class PluginController<
   calc = this.dsm.calc;
   cc = this.calc.controller;
 
-  constructor(readonly dsm: DSM, public settings: Settings) {}
+  constructor(
+    readonly dsm: DSM,
+    public settings: Settings
+  ) {}
 
   afterEnable() {}
   afterConfigChange() {}

--- a/src/plugins/compact-view/compact.less
+++ b/src/plugins/compact-view/compact.less
@@ -54,7 +54,9 @@
       transform: translate(0%, -85%);
       .dcg-evaluation {
         background-color: #f5f5f5;
-        transition: transform 0.125s, max-width 0.125s;
+        transition:
+          transform 0.125s,
+          max-width 0.125s;
         transition-delay: overflow 0.25s;
         overflow: hidden;
         font-size: 0.8em;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -87,7 +87,7 @@ export type GenericSettings = Record<string, any>;
  * afterDisable
  */
 export interface PluginInstance<
-  Settings extends GenericSettings | undefined = GenericSettings | undefined
+  Settings extends GenericSettings | undefined = GenericSettings | undefined,
 > {
   afterEnable(): void;
   afterConfigChange(): void;
@@ -107,7 +107,7 @@ export interface PluginInstance<
 }
 
 export interface Plugin<
-  Settings extends GenericSettings | undefined = GenericSettings | undefined
+  Settings extends GenericSettings | undefined = GenericSettings | undefined,
 > {
   /** The ID is fixed permanently, even for future releases. It is kebab
    * case. If you rename the plugin, keep the ID the same for settings sync */

--- a/src/plugins/intellisense/view.tsx
+++ b/src/plugins/intellisense/view.tsx
@@ -76,7 +76,7 @@ export class JumpToDefinitionMenu extends Component<{
                 >
                   {([e, i]: [
                     JumpToDefinitionMenuInfo["idents"][number],
-                    number
+                    number,
                   ]) => (
                     <li
                       onClick={() => {

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -455,8 +455,8 @@ export default class Multiline extends PluginController<Config> {
       if (linesPassed === 1) {
         cursorPositions.push(
           isNextRight
-            ? next?.getBoundingClientRect().right ?? 0
-            : next?.getBoundingClientRect().left ?? 0
+            ? (next?.getBoundingClientRect().right ?? 0)
+            : (next?.getBoundingClientRect().left ?? 0)
         );
       }
 

--- a/src/plugins/multiline/verticalify.ts
+++ b/src/plugins/multiline/verticalify.ts
@@ -144,8 +144,8 @@ export function verticalify(
           bracketType === "curly"
             ? "piecewise"
             : bracketType === "square"
-            ? "list"
-            : context.containerType,
+              ? "list"
+              : context.containerType,
       },
       options
     );

--- a/src/plugins/pin-expressions/components/PinnedPanel.tsx
+++ b/src/plugins/pin-expressions/components/PinnedPanel.tsx
@@ -15,7 +15,7 @@ export function PinnedPanel(pe: PinExpressions, listView: ListView) {
     >
       <For
         each={() =>
-          pe.dsm.textMode?.inTextMode ? [] : pe.cc?.getAllItemModels?.() ?? []
+          pe.dsm.textMode?.inTextMode ? [] : (pe.cc?.getAllItemModels?.() ?? [])
         }
         key={(model) => (model as any).guid}
       >

--- a/src/plugins/show-tips/Tip.less
+++ b/src/plugins/show-tips/Tip.less
@@ -20,7 +20,9 @@
   .dsm-usage-tip {
     background: white;
     position: relative;
-    transition: bottom 0.4s, height 0.4s;
+    transition:
+      bottom 0.4s,
+      height 0.4s;
     bottom: 0px;
 
     // Color and font-size matching unresolved detail warning

--- a/src/plugins/text-mode/lezer/completions.ts
+++ b/src/plugins/text-mode/lezer/completions.ts
@@ -95,10 +95,10 @@ export function completions(tm: TextMode, context: CompletionContext) {
       parent.name === "BlockInner" && parent.parent!.name === "Folder"
         ? FOLDER_COMPLETIONS
         : parent.name === "Program"
-        ? PROGRAM_COMPLETIONS
-        : parent.name === "StyleMapping" || parent.name === "MappingEntry"
-        ? styleCompletions(tm, parent)
-        : [],
+          ? PROGRAM_COMPLETIONS
+          : parent.name === "StyleMapping" || parent.name === "MappingEntry"
+            ? styleCompletions(tm, parent)
+            : [],
   };
 }
 
@@ -167,22 +167,26 @@ function styleCompletionsFromDefaults(defaults: AnyHydrated): Completion[] {
         value === null
           ? macroExpandWithSelection(key + ": ", "", ",")
           : typeof value === "object"
-          ? "type" in value
-            ? macroExpandWithSelection(
-                key + ": ",
-                astToText(childLatexToAST(value)),
-                ","
-              )
-            : macroExpandWithSelection(key + ": @{ ", "", " },")
-          : typeof value === "string"
-          ? macroExpandWithSelection(
-              key + ': "',
-              // string stringify will always start and end with `"`
-              JSON.stringify(value).slice(1, -1),
-              '",'
-            )
-          : // I don't know if this last case is reachable
-            macroExpandWithSelection(key + ": ", JSON.stringify(value), ","),
+            ? "type" in value
+              ? macroExpandWithSelection(
+                  key + ": ",
+                  astToText(childLatexToAST(value)),
+                  ","
+                )
+              : macroExpandWithSelection(key + ": @{ ", "", " },")
+            : typeof value === "string"
+              ? macroExpandWithSelection(
+                  key + ': "',
+                  // string stringify will always start and end with `"`
+                  JSON.stringify(value).slice(1, -1),
+                  '",'
+                )
+              : // I don't know if this last case is reachable
+                macroExpandWithSelection(
+                  key + ": ",
+                  JSON.stringify(value),
+                  ","
+                ),
     });
   }
   return completions;

--- a/src/plugins/text-mode/view/plugins/styleCircles.ts
+++ b/src/plugins/text-mode/view/plugins/styleCircles.ts
@@ -41,7 +41,10 @@ class StyleCircleMarker extends GutterMarker {
   unsub: (() => void) | undefined;
   div: HTMLElement | undefined;
 
-  constructor(readonly id: string, readonly model: ItemModel) {
+  constructor(
+    readonly id: string,
+    readonly model: ItemModel
+  ) {
     super();
   }
 

--- a/src/plugins/text-mode/view/plugins/styleMappingWidgets/index.ts
+++ b/src/plugins/text-mode/view/plugins/styleMappingWidgets/index.ts
@@ -95,8 +95,8 @@ function stylePath(view: EditorView, node: SyntaxNode): string {
   return node.name === "StyleMapping"
     ? stylePath(view, node.parent!)
     : node.name === "MappingEntry"
-    ? stylePath(view, node.parent!) +
-      "." +
-      view.state.doc.sliceString(node.firstChild!.from, node.firstChild!.to)
-    : "";
+      ? stylePath(view, node.parent!) +
+        "." +
+        view.state.doc.sliceString(node.firstChild!.from, node.firstChild!.to)
+      : "";
 }

--- a/src/plugins/text-mode/view/plugins/styleMappingWidgets/inlineToggleWidget.tsx
+++ b/src/plugins/text-mode/view/plugins/styleMappingWidgets/inlineToggleWidget.tsx
@@ -4,7 +4,10 @@ import { EditorView, WidgetType } from "@codemirror/view";
 import { jsx } from "#utils/utils.ts";
 
 class InlineToggleWidget extends WidgetType {
-  constructor(readonly value: string, readonly path: string) {
+  constructor(
+    readonly value: string,
+    readonly path: string
+  ) {
     super();
   }
 

--- a/src/plugins/video-creator/components/PreviewCarousel.less
+++ b/src/plugins/video-creator/components/PreviewCarousel.less
@@ -99,7 +99,10 @@
   left: 0;
   padding: 4px;
   color: black;
-  text-shadow: -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white,
+  text-shadow:
+    -1px -1px 0 white,
+    1px -1px 0 white,
+    -1px 1px 0 white,
     1px 1px 0 white;
 }
 

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -202,8 +202,8 @@ export default class VideoCreator extends PluginController {
     return this.isCaptureMethodValid(this.#captureMethod)
       ? this.#captureMethod
       : this.isCaptureMethodValid("once")
-      ? "once"
-      : "ntimes";
+        ? "once"
+        : "ntimes";
   }
 
   isValidNumber(s: string) {

--- a/src/plugins/wakatime/heartbeat.ts
+++ b/src/plugins/wakatime/heartbeat.ts
@@ -71,7 +71,7 @@ export async function sendHeartbeat(
       type: "heartbeat-error",
       isAuthError: false,
       message:
-        typeof e === "object" && e !== null ? (e as any).message ?? e : e,
+        typeof e === "object" && e !== null ? ((e as any).message ?? e) : e,
     });
   }
 }

--- a/src/preload/replacementHelpers/replacements.md
+++ b/src/preload/replacementHelpers/replacements.md
@@ -101,7 +101,7 @@ return $DCGView.createElement(
 ```
 ````
 
-Note that the return value is not specified (there is no `` => `name`  ``). The point of this code block is to find what the `__rest__` pattern matches.
+Note that the return value is not specified (there is no ``=> `name` ``). The point of this code block is to find what the `__rest__` pattern matches.
 
 ### Command `*Find_surrounding_template*`
 

--- a/src/preload/replacementHelpers/tokenize.ts
+++ b/src/preload/replacementHelpers/tokenize.ts
@@ -137,10 +137,10 @@ function* _patternTokensRaw(str: string): Generator<PatternToken> {
     yield token.type !== "IdentifierName"
       ? token
       : /^__\w*__$/.test(token.value)
-      ? { type: "PatternBalanced", value: token.value }
-      : token.value.startsWith("$")
-      ? { type: "PatternIdentifier", value: token.value }
-      : token;
+        ? { type: "PatternBalanced", value: token.value }
+        : token.value.startsWith("$")
+          ? { type: "PatternIdentifier", value: token.value }
+          : token;
   }
 }
 

--- a/src/utils/listenerHelpers.ts
+++ b/src/utils/listenerHelpers.ts
@@ -73,10 +73,13 @@ export function hookIntoFunction<
       for (const h of handlersArray) {
         let stop = false;
         let ret: ReturnType<Fn> | undefined;
-        h.fn((r: ReturnType<Fn>) => {
-          stop = true;
-          ret = r;
-        }, ...args);
+        h.fn(
+          (r: ReturnType<Fn>) => {
+            stop = true;
+            ret = r;
+          },
+          ...args
+        );
         if (stop) return ret!;
       }
 

--- a/src/utils/listenerHelpers.ts
+++ b/src/utils/listenerHelpers.ts
@@ -53,7 +53,7 @@ type MaybeHookedFunction<Fn extends (...args: any[]) => any> =
 export function hookIntoFunction<
   Key extends string,
   Obj extends Record<Key, (...args: any[]) => any>,
-  Fn extends Obj[Key]
+  Fn extends Obj[Key],
 >(
   obj: Obj,
   prop: Key,

--- a/text-mode-core/aug/augLatexToRaw.ts
+++ b/text-mode-core/aug/augLatexToRaw.ts
@@ -336,8 +336,8 @@ export function identifierToString(
     main.length === 1
       ? main
       : cfg.commandNames.has(main)
-      ? "\\" + main
-      : `\\operatorname{${main}}`;
+        ? "\\" + main
+        : `\\operatorname{${main}}`;
   const end = subscript ? `_{${subscript}}` : "";
   return start + end;
 }

--- a/text-mode-core/aug/augNeedsParens.ts
+++ b/text-mode-core/aug/augNeedsParens.ts
@@ -116,8 +116,8 @@ function binopLeftPower(name: BinopName): number {
   return name === "Divide"
     ? POWERS.top - 1
     : name === "Exponent"
-    ? POWERS.power + 1
-    : binopPower(name) - 1;
+      ? POWERS.power + 1
+      : binopPower(name) - 1;
 }
 
 // This node can hold anything with power greater than (return value) on its right

--- a/text-mode-core/aug/rawToAug.ts
+++ b/text-mode-core/aug/rawToAug.ts
@@ -164,7 +164,7 @@ function tryRawNonFolderToAug(
                 cfg,
                 item.fillOpacity === "0"
                   ? "2^{-99}"
-                  : item.fillOpacity ?? (item.fill ? "0.4" : undefined)
+                  : (item.fillOpacity ?? (item.fill ? "0.4" : undefined))
               ),
         regression: item.residualVariable
           ? {
@@ -230,7 +230,7 @@ function tryRawNonFolderToAug(
         center: parseLatex(cfg, item.center ?? "(0,0)"),
         angle: parseLatex(cfg, item.angle ?? "0"),
         // opacity = 0 corresponds to hidden: true
-        opacity: parseLatex(cfg, item.hidden ? "0" : item.opacity ?? "1"),
+        opacity: parseLatex(cfg, item.hidden ? "0" : (item.opacity ?? "1")),
         foreground: item.foreground ?? false,
         draggable: item.draggable ?? false,
         clickableInfo: item.clickableInfo?.latex

--- a/text-mode-core/aug/rawToAug.ts
+++ b/text-mode-core/aug/rawToAug.ts
@@ -327,28 +327,28 @@ function columnExpressionCommon(
       item.pointSize === "0"
         ? { size: parseLatex(cfg, "0") }
         : item.points === true ||
-          item.pointOpacity !== undefined ||
-          item.pointSize !== undefined ||
-          item.dragMode !== undefined
-        ? {
-            opacity: parseMaybeLatex(cfg, item.pointOpacity),
-            size: parseMaybeLatex(cfg, item.pointSize),
-            style: item.pointStyle,
-            dragMode: item.dragMode,
-          }
-        : undefined,
+            item.pointOpacity !== undefined ||
+            item.pointSize !== undefined ||
+            item.dragMode !== undefined
+          ? {
+              opacity: parseMaybeLatex(cfg, item.pointOpacity),
+              size: parseMaybeLatex(cfg, item.pointSize),
+              style: item.pointStyle,
+              dragMode: item.dragMode,
+            }
+          : undefined,
     lines:
       item.lines === false || item.lineOpacity === "0" || item.lineWidth === "0"
         ? { width: parseLatex(cfg, "0") }
         : item.lines === true ||
-          item.lineOpacity !== undefined ||
-          item.lineWidth !== undefined
-        ? {
-            opacity: parseMaybeLatex(cfg, item.lineOpacity),
-            width: parseMaybeLatex(cfg, item.lineWidth),
-            style: item.lineStyle,
-          }
-        : undefined,
+            item.lineOpacity !== undefined ||
+            item.lineWidth !== undefined
+          ? {
+              opacity: parseMaybeLatex(cfg, item.lineOpacity),
+              width: parseMaybeLatex(cfg, item.lineWidth),
+              style: item.lineStyle,
+            }
+          : undefined,
   };
 }
 

--- a/text-mode-core/down/astToAug.ts
+++ b/text-mode-core/down/astToAug.ts
@@ -19,7 +19,10 @@ import type { Diagnostic } from "@codemirror/lint";
 import type { GrapherState } from "#graph-state";
 
 export class DownState extends DiagnosticsState {
-  constructor(public readonly cfg: Config, diagnostics: Diagnostic[]) {
+  constructor(
+    public readonly cfg: Config,
+    diagnostics: Diagnostic[]
+  ) {
     super(diagnostics);
   }
 

--- a/text-mode-core/down/astToAug.ts
+++ b/text-mode-core/down/astToAug.ts
@@ -345,33 +345,33 @@ function columnExpressionCommonStyle(
       style.points === true
         ? {}
         : style.points === false
-        ? { size: constant(0) }
-        : style.points
-        ? exprEvalSame(style.points.opacity, 0) ||
-          exprEvalSame(style.points.size, 0)
           ? { size: constant(0) }
-          : {
-              opacity: style.points.opacity,
-              size: style.points.size,
-              style: style.points.style,
-              dragMode: style.points.drag,
-            }
-        : undefined,
+          : style.points
+            ? exprEvalSame(style.points.opacity, 0) ||
+              exprEvalSame(style.points.size, 0)
+              ? { size: constant(0) }
+              : {
+                  opacity: style.points.opacity,
+                  size: style.points.size,
+                  style: style.points.style,
+                  dragMode: style.points.drag,
+                }
+            : undefined,
     lines:
       style.lines === true
         ? {}
         : style.lines === false
-        ? { width: constant(0) }
-        : style.lines
-        ? exprEvalSame(style.lines.opacity, 0) ||
-          exprEvalSame(style.lines.width, 0)
           ? { width: constant(0) }
-          : {
-              opacity: style.lines.opacity,
-              width: style.lines.width,
-              style: style.lines.style,
-            }
-        : undefined,
+          : style.lines
+            ? exprEvalSame(style.lines.opacity, 0) ||
+              exprEvalSame(style.lines.width, 0)
+              ? { width: constant(0) }
+              : {
+                  opacity: style.lines.opacity,
+                  width: style.lines.width,
+                  style: style.lines.style,
+                }
+            : undefined,
   };
   return res;
 }

--- a/text-mode-core/down/textToAST.ts
+++ b/text-mode-core/down/textToAST.ts
@@ -1243,7 +1243,7 @@ function binaryParselet(
     assertLeftIsExpression(ps, left, token, ex);
     const right = parseExpr(
       ps,
-      rightAssociative ?? false ? minus1(bp) : bp,
+      (rightAssociative ?? false) ? minus1(bp) : bp,
       `right side of ${op}`,
       ex
     );

--- a/text-mode-core/down/textToAST.ts
+++ b/text-mode-core/down/textToAST.ts
@@ -89,7 +89,11 @@ class ParseState extends DiagnosticsState {
   private readonly rawIDs: (RawIDRange | undefined)[];
   private readonly rawIDsAll: Set<string>;
 
-  constructor(public cfg: Config, input: string, incr: IncrementalState) {
+  constructor(
+    public cfg: Config,
+    input: string,
+    incr: IncrementalState
+  ) {
     super();
     this.lexer = moo.compile(rules);
     this.lexer.reset(input);

--- a/text-mode-core/down/textToAug.unit.test.ts
+++ b/text-mode-core/down/textToAug.unit.test.ts
@@ -1164,8 +1164,8 @@ describe("Automatic IDs", () => {
           e.type === "folder"
             ? e.children.map((f) => f.id)
             : e.type === "table"
-            ? e.columns.map((f) => f.id)
-            : []
+              ? e.columns.map((f) => f.id)
+              : []
         );
         return arr;
       })

--- a/text-mode-core/prettier-doc/debug.ts
+++ b/text-mode-core/prettier-doc/debug.ts
@@ -102,16 +102,16 @@ export function printDocToDebug(doc: Doc) {
       return doc.n === Number.NEGATIVE_INFINITY
         ? "dedentToRoot(" + printDoc(doc.contents) + ")"
         : typeof doc.n === "number" && doc.n < 0
-        ? "dedent(" + printDoc(doc.contents) + ")"
-        : typeof doc.n !== "string" &&
-          typeof doc.n !== "number" &&
-          doc.n.type === "root"
-        ? "markAsRoot(" + printDoc(doc.contents) + ")"
-        : "align(" +
-          JSON.stringify(doc.n) +
-          ", " +
-          printDoc(doc.contents) +
-          ")";
+          ? "dedent(" + printDoc(doc.contents) + ")"
+          : typeof doc.n !== "string" &&
+              typeof doc.n !== "number" &&
+              doc.n.type === "root"
+            ? "markAsRoot(" + printDoc(doc.contents) + ")"
+            : "align(" +
+              JSON.stringify(doc.n) +
+              ", " +
+              printDoc(doc.contents) +
+              ")";
     }
 
     if (doc.type === DT.IfBreak) {

--- a/text-mode-core/prettier-doc/printer.ts
+++ b/text-mode-core/prettier-doc/printer.ts
@@ -575,8 +575,8 @@ export function printDocToString(doc: Doc, options: Options): PrintedDoc {
               doc.type === DT.IfBreak
                 ? doc.breakContents
                 : doc.negate
-                ? doc.contents
-                : indent(doc.contents);
+                  ? doc.contents
+                  : indent(doc.contents);
             if (breakContents) {
               cmds.push({ ind, mode, doc: breakContents });
             }
@@ -586,8 +586,8 @@ export function printDocToString(doc: Doc, options: Options): PrintedDoc {
               doc.type === DT.IfBreak
                 ? doc.flatContents
                 : doc.negate
-                ? indent(doc.contents)
-                : doc.contents;
+                  ? indent(doc.contents)
+                  : doc.contents;
             if (flatContents) {
               cmds.push({ ind, mode, doc: flatContents });
             }

--- a/text-mode-core/up/astToText.ts
+++ b/text-mode-core/up/astToText.ts
@@ -36,8 +36,8 @@ class EmitContext {
         ? []
         : builders.softline
       : noNewlines
-      ? " "
-      : builders.line;
+        ? " "
+        : builders.line;
     this.hardline = noNewlines ? [] : builders.hardline;
     this.softline = noNewlines ? [] : builders.softline;
     this.optionalSpace = noOptionalSpaces ? [] : " ";
@@ -637,10 +637,10 @@ function numToText(num: number): Doc {
   return isFinite(num)
     ? num.toString().replace("e+", "e")
     : num > 0
-    ? "infty"
-    : num < 0
-    ? "-infty"
-    : "NaN";
+      ? "infty"
+      : num < 0
+        ? "-infty"
+        : "NaN";
 }
 
 function parenthesize(ctx: EmitContext, doc: Doc): Doc {

--- a/text-mode-core/up/augToAST.ts
+++ b/text-mode-core/up/augToAST.ts
@@ -312,16 +312,16 @@ function columnToAST(col: Aug.TableColumnAug): TextAST.TableColumn {
             values: col.values.map((e) => childLatexToAST(e)),
           }
         : col.latex.type === "Identifier"
-        ? {
-            type: "BinaryExpression",
-            op: "=",
-            left: childLatexToAST(col.latex),
-            right: {
-              type: "ListExpression",
-              values: col.values.map(childLatexToAST),
-            },
-          }
-        : childLatexToAST(col.latex),
+          ? {
+              type: "BinaryExpression",
+              op: "=",
+              left: childLatexToAST(col.latex),
+              right: {
+                type: "ListExpression",
+                values: col.values.map(childLatexToAST),
+              },
+            }
+          : childLatexToAST(col.latex),
     style: styleMapping({
       id: idToString(col.id),
       ...columnExpressionCommonStyle(col),


### PR DESCRIPTION
Upgraded prettier from v2.8.8 to v3.5.3 and applied some code style fixes. 

Lint failure is caused by `trailingComma` now defaulting to `all`, which was `es5` until v2. I set it to `es5` for now, as running prettier as is would result in 120+ more file differences. If we should adopt this change, just fix them and then merge. Otherwise create a prettier config file with `trailingComma` set to `es5`. As you can see, trailing commas are added in type parameters despite opting out of this setting (b361339151259093fecc3ffbff7b638289e0ee18), but this is unavoidable (refer to https://github.com/prettier/prettier/issues/15142).

As for .prettierignore, I did nothing particular. Prettier now takes .gitignore into account in addition to .prettierignore, but it is fine as is. Of course, I'll leave these preferences to maintainers.

