### PR TITLE
Fix broken replacements for override-keystroke

### DIFF
--- a/src/core-plugins/override-keystroke/override-keystroke.replacements
+++ b/src/core-plugins/override-keystroke/override-keystroke.replacements
@@ -9,6 +9,7 @@
 *Find* => `parentMQ`
 ```js
 didMountMathquill($) {
+  var $, $;
   this.cachedConfig = this.getCacheableMQConfig();
   __MQbody__
 ```


### PR DESCRIPTION
Just added one line to fix replacement error for override-keystroke.