### PR TITLE
Use Node.js v22 in GitHub Actions and update DEVELOPMENT.md

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: "npm"
       - run: npm ci
       - run: npm run lint
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: "npm"
       - run: npm ci
       - run: npm run test:unit
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: "npm"
       - run: npm ci
       - run: npm run build

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,7 +12,7 @@ If you're looking for in-depth development documentation, see:
 1. Remove the existing extension to avoid conflict. If you plan to be editing DesModder, I suggest opening a [separate Chrome profile](https://support.google.com/chrome/answer/2364824) so that you still have the stable extension in your main profile when you need it.
 2. Make sure you have `git` and `npm` installed.
 
-   - Ensure `node --version` is at least `v18.0.0`. If it isn't, `nvm use 18` should typically fix this.
+   - Ensure `node --version` is at least `v22.0.0`. If it isn't, `nvm use 22` should typically fix this.
    - Check that `npm --version` is at least `7.0.0` to avoid issues with overwriting the lockfile.
 
 3. Run `git clone https://github.com/DesModder/DesModder` to download the latest commit


### PR DESCRIPTION
Set `node-version` to 22.x in workflows/lint-and-test.yml and updated DEVELOPMENT.md accordingly. (Node.js v18 is going to be EOL at the end of April.)
This PR also allows several ECMAScript features (~~like import attributes~~This was my misunderstanding. It is backported to v18) to be available.