### PR TITLE
Fix future replacement errors

### DIFF
--- a/src/DCGView.ts
+++ b/src/DCGView.ts
@@ -80,8 +80,7 @@ export interface DCGViewModule {
   const: <T>(v: T) => () => T;
   createElement: <Props extends GenericProps>(
     comp: ComponentConstructor<Props>,
-    props: WithCommonProps<ToFunc<Props>>,
-    ...children: ComponentChild[]
+    props: WithCommonProps<ToFunc<Props>>
   ) => ComponentTemplate;
   // couldn't figure out type for `comp`, so I just put | any
   mountToNode: <Props extends GenericProps>(
@@ -101,6 +100,7 @@ interface CommonProps {
   class?: () => string;
   didMount?: (elem: HTMLElement) => void;
   willUnmount?: () => void;
+  children?: ComponentChild[];
 }
 type WithCommonProps<T> = Omit<T, keyof CommonProps> & CommonProps;
 export interface ComponentTemplate {
@@ -182,5 +182,6 @@ export function jsx<Props extends GenericProps>(
       fnProps[k] = props[k] as (...args: any[]) => any;
     }
   }
-  return DCGView.createElement(el, fnProps, ...children);
+  fnProps.children = children.length === 1 ? children[0] : children;
+  return DCGView.createElement(el, fnProps);
 }

--- a/src/DCGView.ts
+++ b/src/DCGView.ts
@@ -1,8 +1,9 @@
 import { Fragile } from "#globals";
+import { createElementWrapped } from "./preload/replaceElement";
 
 export const { DCGView } = Fragile;
 
-type OrConst<T> = {
+export type OrConst<T> = {
   [K in keyof T]: T[K] extends (...args: any[]) => any
     ? T[K]
     : T[K] | (() => T[K]);
@@ -183,5 +184,5 @@ export function jsx<Props extends GenericProps>(
     }
   }
   fnProps.children = children.length === 1 ? children[0] : children;
-  return DCGView.createElement(el, fnProps);
+  return createElementWrapped(el, fnProps);
 }

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -140,14 +140,15 @@ export function Match<Disc extends { type: string }>(
     [K in Disc["type"]]: (r: Disc & { type: K }) => ComponentChild;
   }
 ): ComponentTemplate {
-  return DCGView.createElement(
-    Switch,
-    { key: () => discriminant().type },
-    () => {
-      const d = discriminant();
-      return branches[d.type as Disc["type"]](d) as any;
-    }
-  );
+  return DCGView.createElement(Switch, {
+    key: () => discriminant().type,
+    children: [
+      () => {
+        const d = discriminant();
+        return branches[d.type as Disc["type"]](d) as any;
+      },
+    ],
+  });
 }
 
 export abstract class DStaticMathquillViewComponent extends ClassComponent<{

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -7,6 +7,7 @@ import {
   DCGView,
 } from "#DCGView";
 import window, { CalcController, Fragile } from "#globals";
+import { createElementWrapped } from "../preload/replaceElement";
 
 export abstract class CheckboxComponent extends ClassComponent<{
   checked: boolean;
@@ -140,7 +141,7 @@ export function Match<Disc extends { type: string }>(
     [K in Disc["type"]]: (r: Disc & { type: K }) => ComponentChild;
   }
 ): ComponentTemplate {
-  return DCGView.createElement(Switch, {
+  return createElementWrapped(Switch, {
     key: () => discriminant().type,
     children: [
       () => {
@@ -188,13 +189,15 @@ interface ModelAndController {
   controller: CalcController;
 }
 
+function children(template: any) {
+  return listWrap(template.children ?? template.props.children);
+}
+
 // <ExpressionIconView ... >
 export class ExpressionIconView extends Component<ModelAndController> {
   template() {
     const template = exprTemplate(this);
-    return listWrap(
-      template.props.children[1].props.children[1].props.children
-    )[0];
+    return children(children(children(template)[1])[1])[0];
   }
 }
 
@@ -207,7 +210,7 @@ function listWrap(x: unknown) {
 export class FooterView extends Component<ModelAndController> {
   template() {
     const template = exprTemplate(this);
-    return listWrap(template.props.children)[0].props.children[2];
+    return children(children(template)[0])[2];
   }
 }
 

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -192,8 +192,12 @@ interface ModelAndController {
 export class ExpressionIconView extends Component<ModelAndController> {
   template() {
     const template = exprTemplate(this);
-    return template.children[1].children[1].children[0];
+    return listWrap(template.children[1].children[1].children)[0];
   }
+}
+
+function listWrap(x: unknown) {
+  return Array.isArray(x) ? x : [x];
 }
 
 // <If predicate={this.shouldShowFooter}>
@@ -201,7 +205,7 @@ export class ExpressionIconView extends Component<ModelAndController> {
 export class FooterView extends Component<ModelAndController> {
   template() {
     const template = exprTemplate(this);
-    return template.children[0].children[2];
+    return listWrap(template.children)[0].children[2];
   }
 }
 

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -192,7 +192,9 @@ interface ModelAndController {
 export class ExpressionIconView extends Component<ModelAndController> {
   template() {
     const template = exprTemplate(this);
-    return listWrap(template.children[1].children[1].children)[0];
+    return listWrap(
+      template.props.children[1].props.children[1].props.children
+    )[0];
   }
 }
 
@@ -205,7 +207,7 @@ function listWrap(x: unknown) {
 export class FooterView extends Component<ModelAndController> {
   template() {
     const template = exprTemplate(this);
-    return listWrap(template.children)[0].children[2];
+    return listWrap(template.props.children)[0].props.children[2];
   }
 }
 

--- a/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
+++ b/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
@@ -12,7 +12,7 @@ Insert before the delete button but after the other buttons.
 
 *Find*
 ```js
-$['n'](
+$createElement(
   'span',
   {
     class: () => ({
@@ -21,10 +21,10 @@ $['n'](
     ),
     ____
   },
-  $DCGShared['n'](____),
-  $DCGShared['n'](____),
-  $DCGShared['n'](____),
-  $DCGShared['n'](____),
+  $createElement(____),
+  $createElement(____),
+  $createElement(____),
+  $createElement(____),
   __delete_button__
 )
 ```

--- a/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
+++ b/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
@@ -2,31 +2,18 @@
 
 *plugin* `pin-expressions` `folder-tools`
 
-TODO: work this into an API so it doesn't need a ton of injected code.
-
 ## Insert extra buttons
 
 Insert before the delete button but after the other buttons.
 
 *Description* `Show buttons like "pin" and "merge folder."`
 
-*Find*
+*Find* => `delete_button`
 ```js
-$createElement(
-  'span',
-  {
-    class: () => ({
-        'dcg-expression-edit-actions' ____
-      }
-    ),
-    ____
-  },
-  $createElement(____),
-  $createElement(____),
-  $createElement(____),
-  $createElement(____),
-  __delete_button__
-)
+$createElement($Tooltip, {
+  tooltip: () => this.controller.s("graphing-calculator-label-expression-delete-tooltip")
+  ____
+})
 ```
 
 *Replace* `delete_button` with

--- a/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
+++ b/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
@@ -22,6 +22,37 @@ DSM.insertElement(() => DSM.exprActionButtons.actionButtonsView(this.model())),
 __delete_button__
 ```
 
+### Alternative
+
+Insert before the delete button but after the other buttons.
+
+*Description* `Show buttons like "pin" and "merge folder."`
+
+*Find*
+```js
+.createElement(
+  'span',
+  {
+    class: () => ({
+        'dcg-expression-edit-actions' ____
+      }
+    ),
+    ____
+  },
+  $DCGView.createElement(____),
+  $DCGView.createElement(____),
+  $DCGView.createElement(____),
+  $DCGView.createElement(____),
+  __delete_button__
+)
+```
+
+*Replace* `delete_button` with
+```js
+DSM.insertElement(() => DSM.exprActionButtons.actionButtonsView(this.model())),
+__delete_button__
+```
+
 ## Allow pin/unpin and dump/merge without exiting ELM
 
 *Description* `Stay in "Edit List" mode after unpinning an expression or dumping a folder`

--- a/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
+++ b/src/core-plugins/expr-action-buttons/expr-action-buttons.replacements
@@ -12,7 +12,7 @@ Insert before the delete button but after the other buttons.
 
 *Find*
 ```js
-.createElement(
+$['n'](
   'span',
   {
     class: () => ({
@@ -21,10 +21,10 @@ Insert before the delete button but after the other buttons.
     ),
     ____
   },
-  $DCGView.createElement(____),
-  $DCGView.createElement(____),
-  $DCGView.createElement(____),
-  $DCGView.createElement(____),
+  $DCGShared['n'](____),
+  $DCGShared['n'](____),
+  $DCGShared['n'](____),
+  $DCGShared['n'](____),
   __delete_button__
 )
 ```

--- a/src/core-plugins/pillbox-menus/index.ts
+++ b/src/core-plugins/pillbox-menus/index.ts
@@ -4,6 +4,7 @@ import PillboxContainer from "./components/PillboxContainer";
 import PillboxMenu from "./components/PillboxMenu";
 import { DCGView } from "#DCGView";
 import { plugins, PluginID, ConfigItem } from "#plugins/index.ts";
+import { createElementWrapped } from "../../preload/replaceElement";
 
 export default class PillboxMenus extends PluginController<undefined> {
   static id = "pillbox-menus" as const;
@@ -45,7 +46,7 @@ export default class PillboxMenus extends PluginController<undefined> {
 
   pillboxButtonsView(horizontal: boolean): Inserter {
     return () =>
-      DCGView.createElement(PillboxContainer, {
+      createElementWrapped(PillboxContainer, {
         pm: () => this,
         horizontal: DCGView.const(horizontal),
       });
@@ -54,7 +55,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   pillboxMenuView(horizontal: boolean): Inserter {
     if (this.pillboxMenuOpen === null) return undefined;
     return () =>
-      DCGView.createElement(PillboxMenu, {
+      createElementWrapped(PillboxMenu, {
         pm: () => this,
         horizontal: DCGView.const(horizontal),
       });

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -20,7 +20,7 @@ DSM.pillboxMenus && $right.push("dsm-pillbox-menus"),
 *Find* => `case`
 ```js
 case "settings2d":
-  return $['n']($, ____);
+  return $createElement($, ____);
 ```
 
 *Replace* `case` with
@@ -51,7 +51,7 @@ this.controller.isGraphSettingsOpen() || DSM.pillboxMenus?.isSomePillboxMenuOpen
 
 *Find* => `from`
 ```js
-$DCGShared['n']($If, {
+$createElement($If, {
   predicate: () =>
     this.controller.isGeoUIActive() &&
     this.controller.getGraphSettings().config.settingsMenu &&

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -30,6 +30,34 @@ case "dsm-pillbox-menus":
   return DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonsView(false));
 ```
 
+### Alternative
+
+*Description* `Add pillbox buttons (like the DesModder button) in the graphing calculator`
+
+*Find* => `pushkey`
+```js
+this.shouldShowGeometrySettings() && $right.push("settings-geo"),
+```
+
+*Replace* `pushkey` with
+```js
+__pushkey__
+DSM.pillboxMenus && $right.push("dsm-pillbox-menus"),
+```
+
+*Find* => `case`
+```js
+case "settings2d":
+  return $.createElement($, ____);
+```
+
+*Replace* `case` with
+```js
+__case__
+case "dsm-pillbox-menus":
+  return DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonsView(false));
+```
+
 ## Bottom zero for our pillbox menus
 
 *Description* `Fix scrolling of pillbox menus (like the video creator menu)`
@@ -58,6 +86,26 @@ $createElement($If, {
     this.controller.isGraphSettingsOpen(),
   ____
 } ____)
+```
+
+*Replace* `from` with
+```js
+__from__,
+DSM.insertElement(() => DSM.pillboxMenus?.pillboxMenuView(true))
+```
+
+### Alternative
+
+*Description* `Allow showing pillbox menus (like the video creator menu) in the geometry calculator`
+
+*Find* => `from`
+```js
+$DCGView.createElement($If, {
+  predicate: () =>
+    this.controller.isGeoUIActive() &&
+    this.controller.getGraphSettings().config.settingsMenu &&
+    this.controller.isGraphSettingsOpen()
+}, ____)
 ```
 
 *Replace* `from` with
@@ -97,6 +145,42 @@ $createElement("div", {
 __children__,
 $createElement("div", {
     class: "dcg-arrow"
+}),
+```
+
+*Replace* `classes` with
+```js
+__classes__,
+"dcg-settings-container": this.controller.isNarrowGeometryHeader(),
+"dcg-left": this.controller.isNarrowGeometryHeader()
+```
+
+### Alternative
+
+*Description* `Move settings menu left in the geometry calculator (so it doesn't cover DesModder buttons)`
+It should be on the left to avoid covering up all the DesModder config stuff.
+
+*Find*
+```js
+return $DCGView.createElement("div", {
+    class: ()=>({
+        "dcg-geometry-settings-container": !0,
+        "dcg-popover": !0,
+        __classes__
+    }),
+    style: this.bindFn(this.getContainerStyle),
+    didMount: this.bindFn(this.didMountContainer),
+    didUnmount: this.bindFn(this.didUnmountContainer)
+}, $DCGView.createElement("div", { ____ },
+  __children__
+))
+```
+
+*Replace* `children` with
+```js
+__children__,
+$DCGView.createElement("div", {
+    class: $DCGView.const("dcg-arrow")
 }),
 ```
 

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -55,8 +55,9 @@ $createElement($If, {
   predicate: () =>
     this.controller.isGeoUIActive() &&
     this.controller.getGraphSettings().config.settingsMenu &&
-    this.controller.isGraphSettingsOpen()
-}, ____)
+    this.controller.isGraphSettingsOpen(),
+  ____
+} ____)
 ```
 
 *Replace* `from` with
@@ -73,25 +74,29 @@ It should be on the left to avoid covering up all the DesModder config stuff.
 
 *Find*
 ```js
-return $DCGView.createElement("div", {
-    class: ()=>({
-        "dcg-geometry-settings-container": !0,
-        "dcg-popover": !0,
-        __classes__
-    }),
-    style: this.bindFn(this.getContainerStyle),
-    didMount: this.bindFn(this.didMountContainer),
-    didUnmount: this.bindFn(this.didUnmountContainer)
-}, $DCGView.createElement("div", { ____ },
-  __children__
-))
+$createElement("div", {
+  class: () => ({
+      "dcg-geometry-settings-container": !0,
+      "dcg-popover": !0,
+      __classes__
+  }),
+  style: this.bindFn(this.getContainerStyle),
+  didMount: this.bindFn(this.didMountContainer),
+  didUnmount: this.bindFn(this.didUnmountContainer),
+  children: $createElement2("div", {
+    class: "dcg-popover-interior",
+    role: "region",
+    "aria-label": () => this.controller.s("graphing-calculator-label-tooltip-geometry-settings"),
+    children: [__children__]
+  })
+})
 ```
 
 *Replace* `children` with
 ```js
 __children__,
-$DCGView.createElement("div", {
-    class: $DCGView.const("dcg-arrow")
+$createElement("div", {
+    class: "dcg-arrow"
 }),
 ```
 

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -20,7 +20,7 @@ DSM.pillboxMenus && $right.push("dsm-pillbox-menus"),
 *Find* => `case`
 ```js
 case "settings2d":
-  return $.createElement($, ____);
+  return $['n']($, ____);
 ```
 
 *Replace* `case` with
@@ -51,7 +51,7 @@ this.controller.isGraphSettingsOpen() || DSM.pillboxMenus?.isSomePillboxMenuOpen
 
 *Find* => `from`
 ```js
-$DCGView.createElement($If, {
+$DCGShared['n']($If, {
   predicate: () =>
     this.controller.isGeoUIActive() &&
     this.controller.getGraphSettings().config.settingsMenu &&

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -11,15 +11,13 @@ adding an extra section to the menu view.
 
 *Find* => `element`
 ```js
-createElement(
+['n'](
   'div',
-  { class: $DCGView.const('dcg-options-menu-content') ____ },
-  $DCGView.createElement(
+  { class: 'dcg-options-menu-content' ____ },
+  $DCGShared['n'](
     'div',
     {
-      class: $DCGView.const(
-        'dcg-iconed-mathquill-row dcg-fill-opacity-row'
-      )
+      class: 'dcg-iconed-mathquill-row dcg-fill-opacity-row'
     }
     ____
   )
@@ -29,9 +27,9 @@ createElement(
 
 *Find* inside `element`
 ```js
-createElement(
+['n'](
   'div',
-  { class: $.const('dcg-options-menu-content') },
+  { class: 'dcg-options-menu-content' },
   __rest__
 )
 ```
@@ -40,7 +38,7 @@ createElement(
 
 *Find* inside `template`
 ```js
-createElement($ToggleView, {
+['n']($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-fill-visible")
 ```
 
@@ -60,23 +58,23 @@ Warning: this is duplicated above ("Add a fill menu option...").
 
 *Find* => `key`
 ```js
-{ class: $DCGView.const('dcg-iconed-mathquill-row dcg-line-opacity-row') }
+{ class: 'dcg-iconed-mathquill-row dcg-line-opacity-row' }
 ```
 
 *Find_surrounding_template* `key` => `template`
 
 *Find* inside `template`
 ```js
-createElement(
+['n'](
   'div',
-  { class: $.const('dcg-options-menu-content') },
+  { class: 'dcg-options-menu-content' },
   __rest__
 )
 ```
 
 *Find* inside `template`
 ```js
-createElement($ToggleView, {
+['n']($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
 ```
 
@@ -94,19 +92,19 @@ DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, f
 
 *Find* => `options`
 ```js
-$DCGView.createElement("div",
-  { class: $DCGView.const("dcg-options-flex-container") },
-  $DCGView.createElement("div",
-    { class: $DCGView.const("dcg-options-left-side") },
-    $DCGView.createElement("div", {
-      class: $DCGView.const("dcg-iconed-mathquill-row dcg-line-opacity-row")
+$DCGShared['n']("div",
+  { class: "dcg-options-flex-container" },
+  $DCGShared['n']("div",
+    { class: "dcg-options-left-side" },
+    $DCGShared['n']("div", {
+      class: "dcg-iconed-mathquill-row dcg-line-opacity-row"
 ```
 
 *Find_surrounding_template* `options` => `template`
 
 *Find* inside `template`
 ```js
-createElement($ToggleView, {
+['n']($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
 ```
 

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -11,10 +11,10 @@ adding an extra section to the menu view.
 
 *Find* => `element`
 ```js
-['n'](
+$createElement(
   'div',
   { class: 'dcg-options-menu-content' ____ },
-  $DCGShared['n'](
+  $createElement(
     'div',
     {
       class: 'dcg-iconed-mathquill-row dcg-fill-opacity-row'
@@ -27,7 +27,7 @@ adding an extra section to the menu view.
 
 *Find* inside `element`
 ```js
-['n'](
+$createElement(
   'div',
   { class: 'dcg-options-menu-content' },
   __rest__
@@ -38,7 +38,7 @@ adding an extra section to the menu view.
 
 *Find* inside `template`
 ```js
-['n']($ToggleView, {
+$createElement($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-fill-visible")
 ```
 
@@ -65,7 +65,7 @@ Warning: this is duplicated above ("Add a fill menu option...").
 
 *Find* inside `template`
 ```js
-['n'](
+$createElement(
   'div',
   { class: 'dcg-options-menu-content' },
   __rest__
@@ -74,7 +74,7 @@ Warning: this is duplicated above ("Add a fill menu option...").
 
 *Find* inside `template`
 ```js
-['n']($ToggleView, {
+$createElement($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
 ```
 
@@ -92,11 +92,11 @@ DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, f
 
 *Find* => `options`
 ```js
-$DCGShared['n']("div",
+$createElement("div",
   { class: "dcg-options-flex-container" },
-  $DCGShared['n']("div",
+  $createElement("div",
     { class: "dcg-options-left-side" },
-    $DCGShared['n']("div", {
+    $createElement("div", {
       class: "dcg-iconed-mathquill-row dcg-line-opacity-row"
 ```
 
@@ -104,7 +104,7 @@ $DCGShared['n']("div",
 
 *Find* inside `template`
 ```js
-['n']($ToggleView, {
+$createElement($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
 ```
 

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -43,6 +43,56 @@ Just add one more child.
 ]
 ```
 
+### Alternative
+
+Warning: this is duplicated below ("Add a lines menu option...") rather than
+adding an extra section to the menu view.
+
+*Description* `Add toggle in "fill" menu to enable GLesmos`
+
+*Find* => `element`
+```js
+createElement(
+  'div',
+  { class: $DCGView.const('dcg-options-menu-content') ____ },
+  $DCGView.createElement(
+    'div',
+    {
+      class: $DCGView.const(
+        'dcg-iconed-mathquill-row dcg-fill-opacity-row'
+      )
+    }
+    ____
+  )
+  ____
+)
+```
+
+*Find* inside `element`
+```js
+createElement(
+  'div',
+  { class: $.const('dcg-options-menu-content') },
+  __rest__
+)
+```
+
+*Find_surrounding_template* `element` => `template`
+
+*Find* inside `template`
+```js
+createElement($ToggleView, {
+  ariaLabel: () => this.controller.s("graphing-calculator-narration-fill-visible")
+```
+
+Just add one more child.
+
+*Replace* `__rest__` with
+```js
+__rest__,
+DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, true))
+```
+
 ## Add a lines menu option for switching an expression to glesmos rendering mode
 
 Warning: this is duplicated above ("Add a fill menu option...").
@@ -83,6 +133,41 @@ Just add one more child.
 ]
 ```
 
+### Alternative
+
+Warning: this is duplicated above ("Add a fill menu option...").
+*Description* `Add toggle in "lines" menu to enable GLesmos`
+
+*Find* => `key`
+```js
+{ class: $DCGView.const('dcg-iconed-mathquill-row dcg-line-opacity-row') }
+```
+
+*Find_surrounding_template* `key` => `template`
+
+*Find* inside `template`
+```js
+createElement(
+  'div',
+  { class: $.const('dcg-options-menu-content') },
+  __rest__
+)
+```
+
+*Find* inside `template`
+```js
+createElement($ToggleView, {
+  ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
+```
+
+Just add one more child.
+
+*Replace* `__rest__` with
+```js
+__rest__,
+DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, false))
+```
+
 ## Add a lines menu option for confirming GLesmos lines
 
 *Description* `Add toggle to confirm GLesmos lines`
@@ -116,6 +201,36 @@ Prefix with a child
   DSM.insertElement(() => DSM.glesmos?.confirmLines(this.model.id, $ToggleView)),
   __options__
 ]
+```
+
+### Alternative
+
+*Description* `Add toggle to confirm GLesmos lines`
+
+*Find* => `options`
+```js
+$DCGView.createElement("div",
+  { class: $DCGView.const("dcg-options-flex-container") },
+  $DCGView.createElement("div",
+    { class: $DCGView.const("dcg-options-left-side") },
+    $DCGView.createElement("div", {
+      class: $DCGView.const("dcg-iconed-mathquill-row dcg-line-opacity-row")
+```
+
+*Find_surrounding_template* `options` => `template`
+
+*Find* inside `template`
+```js
+createElement($ToggleView, {
+  ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
+```
+
+Prefix with a child
+
+*Replace* `options` with
+```js
+DSM.insertElement(() => DSM.glesmos?.confirmLines(this.model.id, $ToggleView)),
+__options__
 ```
 
 ## Replace main renderer with glesmos rendering when necessary

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -9,45 +9,38 @@ adding an extra section to the menu view.
 
 *Description* `Add toggle in "fill" menu to enable GLesmos`
 
-*Find* => `element`
+*Find* => `key`
 ```js
-$createElement(
-  'div',
-  { class: 'dcg-options-menu-content' ____ },
-  $createElement(
-    'div',
-    {
-      class: 'dcg-iconed-mathquill-row dcg-fill-opacity-row'
-    }
-    ____
-  )
-  ____
-)
+{ class: 'dcg-iconed-mathquill-row dcg-fill-opacity-row' ____ }
 ```
 
-*Find* inside `element`
-```js
-$createElement(
-  'div',
-  { class: 'dcg-options-menu-content' },
-  __rest__
-)
-```
-
-*Find_surrounding_template* `element` => `template`
+*Find_surrounding_template* `key` => `template`
 
 *Find* inside `template`
 ```js
-$createElement($ToggleView, {
+$createElement(
+  'div',
+  {
+    class: 'dcg-options-menu-content',
+    children: __children__
+  }
+)
+```
+
+*Find* inside `template`
+```js
+$createElement2($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-fill-visible")
 ```
 
 Just add one more child.
 
-*Replace* `__rest__` with
+*Replace* `children` with
 ```js
-__rest__,
-DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, true))
+[
+  __children__,
+  DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, true))
+]
 ```
 
 ## Add a lines menu option for switching an expression to glesmos rendering mode
@@ -58,7 +51,7 @@ Warning: this is duplicated above ("Add a fill menu option...").
 
 *Find* => `key`
 ```js
-{ class: 'dcg-iconed-mathquill-row dcg-line-opacity-row' }
+{ class: 'dcg-iconed-mathquill-row dcg-line-opacity-row' ____ }
 ```
 
 *Find_surrounding_template* `key` => `template`
@@ -67,44 +60,51 @@ Warning: this is duplicated above ("Add a fill menu option...").
 ```js
 $createElement(
   'div',
-  { class: 'dcg-options-menu-content' },
-  __rest__
+  {
+    class: 'dcg-options-menu-content',
+    children: __children__
+  }
 )
 ```
 
 *Find* inside `template`
 ```js
-$createElement($ToggleView, {
+$createElement2($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
 ```
 
 Just add one more child.
 
-*Replace* `__rest__` with
+*Replace* `children` with
 ```js
-__rest__,
-DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, false))
+[
+  __children__,
+  DSM.insertElement(() => DSM.glesmos?.glesmosToggle(this.model.id, $ToggleView, false))
+]
 ```
 
 ## Add a lines menu option for confirming GLesmos lines
 
 *Description* `Add toggle to confirm GLesmos lines`
 
-*Find* => `options`
+
+*Find* => `key`
 ```js
-$createElement("div",
-  { class: "dcg-options-flex-container" },
-  $createElement("div",
-    { class: "dcg-options-left-side" },
-    $createElement("div", {
-      class: "dcg-iconed-mathquill-row dcg-line-opacity-row"
+{ class: 'dcg-iconed-mathquill-row dcg-line-opacity-row' ____ }
 ```
 
-*Find_surrounding_template* `options` => `template`
+*Find_surrounding_template* `key` => `template`
+
+*Find* inside `template` => `options`
+```js
+$createElement("div",
+  { class: "dcg-options-flex-container" ____}
+)
+```
 
 *Find* inside `template`
 ```js
-$createElement($ToggleView, {
+$createElement2($ToggleView, {
   ariaLabel: () => this.controller.s("graphing-calculator-narration-lines-visible")
 ```
 
@@ -112,8 +112,10 @@ Prefix with a child
 
 *Replace* `options` with
 ```js
-DSM.insertElement(() => DSM.glesmos?.confirmLines(this.model.id, $ToggleView)),
-__options__
+[
+  DSM.insertElement(() => DSM.glesmos?.confirmLines(this.model.id, $ToggleView)),
+  __options__
+]
 ```
 
 ## Replace main renderer with glesmos rendering when necessary

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -46,25 +46,6 @@ undefined: () => $DcgShared.Components.IfElse(
 
 *Find* => `list`
 ```js
-()=>this.getEvaluationType(), {
-list: () => $Dcgview.createElement(__oldList__)
-```
-
-*Replace* `list` with
-```js
-()=>this.getEvaluationType(), {
-list: () => DSM.replaceElement(
-  () => $Dcgview.createElement(__oldList__),
-  () => DSM.betterEvaluationView?.listEvaluation(() => this.props.val())
-)
-```
-
-### Alternative
-
-*Description* `Show list elements (2)`
-
-*Find* => `list`
-```js
 ()=>this.cachedEvaluationRHS)({
 list: $rhs => $createElement(__oldList__)
 ```
@@ -98,23 +79,6 @@ emptyList: () => DSM.replaceElement(
 ## Show color values: JSX consumer
 
 *Description* `Show color values`
-
-*Find* => `color`
-```js
-rgbcolor: () => $Dcgview.createElement(__swatch__)
-```
-
-*Replace* `color` with
-```js
-rgbcolor: () => DSM.replaceElement(
-  () => $Dcgview.createElement(__swatch__),
-  () => DSM.betterEvaluationView?.colorEvaluation(() => this.props.val())
-)
-```
-
-### Alternative
-
-*Description* `Show color values (2)`
 
 *Find* => `color`
 ```js

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -8,7 +8,7 @@
 
 *Find* => `undefined`
 ```js
-undefined: ()=> $Dcgview.createElement(
+undefined: ()=> $DcgShared['n'](
   $ViewClass,
   {
     ...this.props,
@@ -19,17 +19,17 @@ undefined: ()=> $Dcgview.createElement(
 
 *Replace* `undefined` with
 ```js
-undefined: () => $Dcgview.Components.IfElse(
+undefined: () => $DcgShared.Components.IfElse(
     () => DSM.betterEvaluationView,
     {
-      true: () => $Dcgview.createElement(
+      true: () => $DcgShared['n'](
         Desmos.Private.Fragile.StaticMathquillView,
         {
           latex: () => this.getNumberLabelString?.() || "undefined",
-          config: $Dcgview.const({})
+          config: {}
         }
       ),
-      false: () => $Dcgview.createElement(
+      false: () => $DcgShared['n'](
         $ViewClass,
         {
           ...this.props,
@@ -66,14 +66,14 @@ list: () => DSM.replaceElement(
 *Find* => `list`
 ```js
 ()=>this.cachedEvaluationRHS)({
-list: $rhs => $Dcgview.createElement(__oldList__)
+list: $rhs => $DcgShared['n'](__oldList__)
 ```
 
 *Replace* `list` with
 ```js
 ()=>this.cachedEvaluationRHS)({
 list: $rhs => DSM.replaceElement(
-  () => $Dcgview.createElement(__oldList__),
+  () => $DcgShared['n'](__oldList__),
   () => DSM.betterEvaluationView?.listEvaluation(() => {
     const itemModel = this.controller.getItemModel(this.props.id());
     // get untruncated value
@@ -84,13 +84,13 @@ list: $rhs => DSM.replaceElement(
 
 *Find* => `emptyList`
 ```js
-emptyList: () => $emptyListDcgview.createElement(__oldEmptyList__)
+emptyList: () => $emptyListDcgShared['n'](__oldEmptyList__)
 ```
 
 *Replace* `emptyList` with
 ```js
 emptyList: () => DSM.replaceElement(
-  () => $emptyListDcgview.createElement(__oldEmptyList__),
+  () => $emptyListDcgShared['n'](__oldEmptyList__),
   () => DSM.betterEvaluationView?.listEvaluation(() => [])
 )
 ```
@@ -118,13 +118,13 @@ rgbcolor: () => DSM.replaceElement(
 
 *Find* => `color`
 ```js
-rgbcolor: $rhs => $Dcgview.createElement(__swatch__)
+rgbcolor: $rhs => $DcgShared['n'](__swatch__)
 ```
 
 *Replace* `color` with
 ```js
 rgbcolor: $rhs => DSM.replaceElement(
-  () => $Dcgview.createElement(__swatch__),
+  () => $DcgShared['n'](__swatch__),
   () => DSM.betterEvaluationView?.colorEvaluation(() => this.getEvaluationRHS().val)
 )
 ```

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -40,6 +40,44 @@ undefined: () => DSM.replaceElement(
 )
 ```
 
+### Alternative
+
+*Description* `Show NaN, -∞, and +∞`
+
+*Find* => `undefined`
+```js
+undefined: ()=> $Dcgview.createElement(
+  $ViewClass,
+  {
+    ...this.props,
+    content: () => this.controller.s("shared-calculator-label-undefined")
+  }
+)
+```
+
+*Replace* `undefined` with
+```js
+undefined: () => $Dcgview.Components.IfElse(
+    () => DSM.betterEvaluationView,
+    {
+      true: () => $Dcgview.createElement(
+        Desmos.Private.Fragile.StaticMathquillView,
+        {
+          latex: () => this.getNumberLabelString?.() || "undefined",
+          config: $Dcgview.const({})
+        }
+      ),
+      false: () => $Dcgview.createElement(
+        $ViewClass,
+        {
+          ...this.props,
+          content: () => this.controller.s("shared-calculator-label-undefined")
+        }
+      )
+    }
+  )
+```
+
 ## Show list elements: JSX consumer
 
 *Description* `Show list elements`
@@ -76,6 +114,42 @@ emptyList: () => DSM.replaceElement(
 )
 ```
 
+### Alternative
+
+*Description* `Show list elements`
+
+*Find* => `list`
+```js
+()=>this.cachedEvaluationRHS)({
+list: $rhs => $Dcgview.createElement(__oldList__)
+```
+
+*Replace* `list` with
+```js
+()=>this.cachedEvaluationRHS)({
+list: $rhs => DSM.replaceElement(
+  () => $Dcgview.createElement(__oldList__),
+  () => DSM.betterEvaluationView?.listEvaluation(() => {
+    const itemModel = this.controller.getItemModel(this.props.id());
+    // get untruncated value
+    return itemModel.formula.typed_constant_value.value;
+  })
+)
+```
+
+*Find* => `emptyList`
+```js
+emptyList: () => $emptyListDcgview.createElement(__oldEmptyList__)
+```
+
+*Replace* `emptyList` with
+```js
+emptyList: () => DSM.replaceElement(
+  () => $emptyListDcgview.createElement(__oldEmptyList__),
+  () => DSM.betterEvaluationView?.listEvaluation(() => [])
+)
+```
+
 ## Show color values: JSX consumer
 
 *Description* `Show color values`
@@ -89,6 +163,23 @@ rgbcolor: $rhs => $createElement(__swatch__)
 ```js
 rgbcolor: $rhs => DSM.replaceElement(
   () => $createElement(__swatch__),
+  () => DSM.betterEvaluationView?.colorEvaluation(() => this.getEvaluationRHS().val)
+)
+```
+
+### Alternative
+
+*Description* `Show color values`
+
+*Find* => `color`
+```js
+rgbcolor: $rhs => $Dcgview.createElement(__swatch__)
+```
+
+*Replace* `color` with
+```js
+rgbcolor: $rhs => DSM.replaceElement(
+  () => $Dcgview.createElement(__swatch__),
   () => DSM.betterEvaluationView?.colorEvaluation(() => this.getEvaluationRHS().val)
 )
 ```

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -8,7 +8,7 @@
 
 *Find* => `undefined`
 ```js
-undefined: ()=> $DcgShared['n'](
+undefined: ()=> $createElement(
   $ViewClass,
   {
     ...this.props,
@@ -22,14 +22,14 @@ undefined: ()=> $DcgShared['n'](
 undefined: () => $DcgShared.Components.IfElse(
     () => DSM.betterEvaluationView,
     {
-      true: () => $DcgShared['n'](
+      true: () => $createElement(
         Desmos.Private.Fragile.StaticMathquillView,
         {
           latex: () => this.getNumberLabelString?.() || "undefined",
           config: {}
         }
       ),
-      false: () => $DcgShared['n'](
+      false: () => $createElement(
         $ViewClass,
         {
           ...this.props,
@@ -66,14 +66,14 @@ list: () => DSM.replaceElement(
 *Find* => `list`
 ```js
 ()=>this.cachedEvaluationRHS)({
-list: $rhs => $DcgShared['n'](__oldList__)
+list: $rhs => $createElement(__oldList__)
 ```
 
 *Replace* `list` with
 ```js
 ()=>this.cachedEvaluationRHS)({
 list: $rhs => DSM.replaceElement(
-  () => $DcgShared['n'](__oldList__),
+  () => $createElement(__oldList__),
   () => DSM.betterEvaluationView?.listEvaluation(() => {
     const itemModel = this.controller.getItemModel(this.props.id());
     // get untruncated value
@@ -84,13 +84,13 @@ list: $rhs => DSM.replaceElement(
 
 *Find* => `emptyList`
 ```js
-emptyList: () => $emptyListDcgShared['n'](__oldEmptyList__)
+emptyList: () => $createElement(__oldEmptyList__)
 ```
 
 *Replace* `emptyList` with
 ```js
 emptyList: () => DSM.replaceElement(
-  () => $emptyListDcgShared['n'](__oldEmptyList__),
+  () => $createElement(__oldEmptyList__),
   () => DSM.betterEvaluationView?.listEvaluation(() => [])
 )
 ```
@@ -118,13 +118,13 @@ rgbcolor: () => DSM.replaceElement(
 
 *Find* => `color`
 ```js
-rgbcolor: $rhs => $DcgShared['n'](__swatch__)
+rgbcolor: $rhs => $createElement(__swatch__)
 ```
 
 *Replace* `color` with
 ```js
 rgbcolor: $rhs => DSM.replaceElement(
-  () => $DcgShared['n'](__swatch__),
+  () => $createElement(__swatch__),
   () => DSM.betterEvaluationView?.colorEvaluation(() => this.getEvaluationRHS().val)
 )
 ```

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -65,13 +65,13 @@ list: $rhs => DSM.replaceElement(
 
 *Find* => `emptyList`
 ```js
-emptyList: () => $createElement(__oldEmptyList__)
+emptyList: () => $createElement2(__oldEmptyList__)
 ```
 
 *Replace* `emptyList` with
 ```js
 emptyList: () => DSM.replaceElement(
-  () => $createElement(__oldEmptyList__),
+  () => $createElement2(__oldEmptyList__),
   () => DSM.betterEvaluationView?.listEvaluation(() => [])
 )
 ```

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -19,25 +19,25 @@ undefined: ()=> $createElement(
 
 *Replace* `undefined` with
 ```js
-undefined: () => $DcgShared.Components.IfElse(
-    () => DSM.betterEvaluationView,
+undefined: () => DSM.replaceElement(
+  () => $createElement(
+    $ViewClass,
     {
-      true: () => $createElement(
-        Desmos.Private.Fragile.StaticMathquillView,
-        {
-          latex: () => this.getNumberLabelString?.() || "undefined",
-          config: {}
-        }
-      ),
-      false: () => $createElement(
-        $ViewClass,
-        {
-          ...this.props,
-          content: () => this.controller.s("shared-calculator-label-undefined")
-        }
-      )
+      ...this.props,
+      content: () => this.controller.s("shared-calculator-label-undefined")
     }
-  )
+  ),
+  () => 
+    DSM.betterEvaluationView
+      ? $createElement(
+          Desmos.Private.Fragile.StaticMathquillView,
+          {
+            latex: () => this.getNumberLabelString?.() || "undefined",
+            config: {}
+          }
+        )
+      : undefined
+)
 ```
 
 ## Show list elements: JSX consumer

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -6,7 +6,7 @@
 
 *Description* `Show how many characters used by an expression in the exppanel`
 
-*Find* => `math expression item`
+*Find* => `math_item`
 ```js
 $createElement("div", {
     class: ()=>({
@@ -14,19 +14,25 @@ $createElement("div", {
         "dcg-expressionitem": !0,
         "dcg-highlighted-expressionitem": this.controller.isExpressionHighlighted(this.id),
         "dcg-mathitem": !0,
-        __rest0__
-        }),
-        __rest1__
-}, $createElement("div", {
-                class: "dcg-fade-container",
-                onTapStart: this.bindFn(this.onMouseSelect),
-                onTap: this.bindFn(this.onMouseSelect)
-            }, __rest3__), __rest4__)
+        ____
+    })
+    ____
+})
 ```
 
-*Replace* `__rest3__` with
+*Find* inside `math_item`
 ```js
-__rest3__,
+$createElement2("div", {
+    class: "dcg-fade-container",
+    onTapStart: this.bindFn(this.onMouseSelect),
+    onTap: this.bindFn(this.onMouseSelect),
+    children: [__children__]
+})
+```
+
+*Replace* `__children__` with
+```js
+__children__,
 DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this._rootNode)  ))
 ```
 
@@ -34,7 +40,7 @@ DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this
 
 *Description* `Show golfing stats for an entire folder`
 
-*Find* => `folder expression item`
+*Find* => `folder_item`
 ```js
 $createElement("div", {
     class: () => ({
@@ -43,16 +49,23 @@ $createElement("div", {
         "dcg-highlighted-expressionitem": this.controller.isExpressionHighlighted(this.id),
         "dcg-readonly": this.controller.isItemReadonly(this.id),
         "dcg-expressionfolder": !0,
-        __classesAfter__
-    }),
-    __rest1folder__
-}, $createElement("div", {
-    class: "dcg-fade-container"
-}, __rest2folder__), __rest3folder__)
+        ____
+    })
+    ____
+})
 ```
 
-*Replace* `__rest2folder__` with
+
+*Find* inside `folder_item`
 ```js
-__rest2folder__,
+$createElement2("div", {
+    class: "dcg-fade-container",
+    children: [__children__]
+})
+```
+
+*Replace* `children` with
+```js
+__children__,
 DSM.insertElement(() => (DSM.codeGolf?.folderCostPanel(this.model)))
 ```

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -8,7 +8,7 @@
 
 *Find* => `math expression item`
 ```js
-$DCGView.createElement("div", {
+$DCGShared['n']("div", {
     class: ()=>({
         "dcg-do-not-blur": !0,
         "dcg-expressionitem": !0,
@@ -17,8 +17,8 @@ $DCGView.createElement("div", {
         __rest0__
         }),
         __rest1__
-}, $DCGView.createElement("div", {
-                class: $DCGView.const("dcg-fade-container"),
+}, $DCGShared['n']("div", {
+                class: "dcg-fade-container",
                 onTapStart: this.bindFn(this.onMouseSelect),
                 onTap: this.bindFn(this.onMouseSelect)
             }, __rest3__), __rest4__)
@@ -36,7 +36,7 @@ DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this
 
 *Find* => `folder expression item`
 ```js
-$DCGView2.createElement("div", {
+$DCGShared['n']("div", {
     class: () => ({
         "dcg-do-not-blur": !0,
         "dcg-expressionitem": !0,
@@ -46,8 +46,8 @@ $DCGView2.createElement("div", {
         __classesAfter__
     }),
     __rest1folder__
-}, $DCGView2.createElement("div", {
-    class: $DCGView2.const("dcg-fade-container")
+}, $DCGShared['n']("div", {
+    class: "dcg-fade-container"
 }, __rest2folder__), __rest3folder__)
 ```
 

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -8,7 +8,7 @@
 
 *Find* => `math expression item`
 ```js
-$DCGShared['n']("div", {
+$createElement("div", {
     class: ()=>({
         "dcg-do-not-blur": !0,
         "dcg-expressionitem": !0,
@@ -17,7 +17,7 @@ $DCGShared['n']("div", {
         __rest0__
         }),
         __rest1__
-}, $DCGShared['n']("div", {
+}, $createElement("div", {
                 class: "dcg-fade-container",
                 onTapStart: this.bindFn(this.onMouseSelect),
                 onTap: this.bindFn(this.onMouseSelect)
@@ -36,7 +36,7 @@ DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this
 
 *Find* => `folder expression item`
 ```js
-$DCGShared['n']("div", {
+$createElement("div", {
     class: () => ({
         "dcg-do-not-blur": !0,
         "dcg-expressionitem": !0,
@@ -46,7 +46,7 @@ $DCGShared['n']("div", {
         __classesAfter__
     }),
     __rest1folder__
-}, $DCGShared['n']("div", {
+}, $createElement("div", {
     class: "dcg-fade-container"
 }, __rest2folder__), __rest3folder__)
 ```

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -36,6 +36,34 @@ __children__,
 DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this._rootNode)  ))
 ```
 
+### Alternative
+
+*Description* `Show how many characters used by an expression in the exppanel`
+
+*Find* => `math expression item`
+```js
+$DCGView.createElement("div", {
+    class: ()=>({
+        "dcg-do-not-blur": !0,
+        "dcg-expressionitem": !0,
+        "dcg-highlighted-expressionitem": this.controller.isExpressionHighlighted(this.id),
+        "dcg-mathitem": !0,
+        __rest0__
+        }),
+        __rest1__
+}, $DCGView.createElement("div", {
+                class: $DCGView.const("dcg-fade-container"),
+                onTapStart: this.bindFn(this.onMouseSelect),
+                onTap: this.bindFn(this.onMouseSelect)
+            }, __rest3__), __rest4__)
+```
+
+*Replace* `__rest3__` with
+```js
+__rest3__,
+DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this._rootNode)  ))
+```
+
 ## Add total counts to folders in exppanel
 
 *Description* `Show golfing stats for an entire folder`
@@ -67,5 +95,32 @@ $createElement2("div", {
 *Replace* `children` with
 ```js
 __children__,
+DSM.insertElement(() => (DSM.codeGolf?.folderCostPanel(this.model)))
+```
+
+### Alternative
+
+*Description* `Show golfing stats for an entire folder`
+
+*Find* => `folder expression item`
+```js
+$DCGView2.createElement("div", {
+    class: () => ({
+        "dcg-do-not-blur": !0,
+        "dcg-expressionitem": !0,
+        "dcg-highlighted-expressionitem": this.controller.isExpressionHighlighted(this.id),
+        "dcg-readonly": this.controller.isItemReadonly(this.id),
+        "dcg-expressionfolder": !0,
+        __classesAfter__
+    }),
+    __rest1folder__
+}, $DCGView2.createElement("div", {
+    class: $DCGView2.const("dcg-fade-container")
+}, __rest2folder__), __rest3folder__)
+```
+
+*Replace* `__rest2folder__` with
+```js
+__rest2folder__,
 DSM.insertElement(() => (DSM.codeGolf?.folderCostPanel(this.model)))
 ```

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -48,6 +48,34 @@ error: () => $createElement($TooltippedError, {
   })
 ```
 
+### Alternative
+
+*Description* `Wrap error triangle to control its style`
+
+*Find* => `from`
+```js
+error: () => $DCGView.createElement($TooltippedError, {
+    error: $e.bindFn($e.getErrorMsg),
+    __opts__
+  })
+```
+
+*Find_surrounding_template* `from` => `template`
+
+*Find* inside `template`
+```js
+$this.bindFn($this.getIconMode)
+```
+
+*Replace* `from` with
+```js
+error: () => $DCGView.createElement($TooltippedError, {
+    error: $e.bindFn($e.getErrorMsg),
+    exprId: () => $this.model.id,
+    __opts__
+  })
+```
+
 ## Wrap error triangle with div for onTap and opacity control
 
 *Description* `Wrap error triangle to control its style (2)`
@@ -58,6 +86,31 @@ Wrap the error message tooltipped-error with a div, using `onTap` to trigger hid
 ```js
 additionalClass: this.const("dcg-tooltipped-error-container"),
 children: __errorTriangle__
+```
+
+*Replace* `errorTriangle` with
+```js
+DSM.replaceElement(
+  () => __errorTriangle__,
+  () => DSM.hideErrors?.errorTriangle(this.props.exprId?.() ?? "")
+)
+```
+
+### Alternative
+
+*Description* `Wrap error triangle to control its style`
+
+Wrap the error message tooltipped-error with a div, using `onTap` to trigger hiding/showing the error (but only when shift is held).
+
+*Find* => `from`
+```js
+$DCGView.createElement($Tooltip,
+  {
+    tooltip: this.props.error,
+    __opts__
+  },
+  __errorTriangle__
+)
 ```
 
 *Replace* `errorTriangle` with
@@ -82,6 +135,26 @@ $createElement(
 
 Add one more child for the hide button
 
+*Replace* `children` with
+```js
+__children__,
+DSM.insertElement(() => DSM.hideErrors?.hideButton(() => this.model))
+```
+
+### Alternative
+
+*Description* `Add a "hide" button to the slider prompts`
+
+*Find* => `element`
+```js
+createElement(
+  'span',
+  { class: $DCGView.const('btns') },
+  __children__
+)
+```
+
+Add one more child for the hide button
 *Replace* `children` with
 ```js
 __children__,

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -22,11 +22,11 @@
 
 ## Pass in ID to error triangle
 
-*Description* `Wrap error triangle to control its style`
+*Description* `Wrap error triangle to control its style (1)`
 
 *Find* => `from`
 ```js
-error: () => $DCGView.createElement($TooltippedError, {
+error: () => $DCGShared['n']($TooltippedError, {
     error: $e.bindFn($e.getErrorMsg),
     __opts__
   })
@@ -41,7 +41,7 @@ $this.bindFn($this.getIconMode)
 
 *Replace* `from` with
 ```js
-error: () => $DCGView.createElement($TooltippedError, {
+error: () => $DCGShared['n']($TooltippedError, {
     error: $e.bindFn($e.getErrorMsg),
     exprId: () => $this.model.id,
     __opts__
@@ -50,13 +50,13 @@ error: () => $DCGView.createElement($TooltippedError, {
 
 ## Wrap error triangle with div for onTap and opacity control
 
-*Description* `Wrap error triangle to control its style`
+*Description* `Wrap error triangle to control its style (2)`
 
 Wrap the error message tooltipped-error with a div, using `onTap` to trigger hiding/showing the error (but only when shift is held).
 
 *Find* => `from`
 ```js
-$DCGView.createElement($Tooltip,
+$DCGShared['n']($Tooltip,
   {
     tooltip: this.props.error,
     __opts__
@@ -79,9 +79,9 @@ DSM.replaceElement(
 
 *Find* => `element`
 ```js
-createElement(
+$['n'](
   'span',
-  { class: $DCGView.const('btns') },
+  { class: 'btns' },
   __children__
 )
 ```

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -26,7 +26,7 @@
 
 *Find* => `from`
 ```js
-error: () => $DCGShared['n']($TooltippedError, {
+error: () => $createElement($TooltippedError, {
     error: $e.bindFn($e.getErrorMsg),
     __opts__
   })
@@ -41,7 +41,7 @@ $this.bindFn($this.getIconMode)
 
 *Replace* `from` with
 ```js
-error: () => $DCGShared['n']($TooltippedError, {
+error: () => $createElement($TooltippedError, {
     error: $e.bindFn($e.getErrorMsg),
     exprId: () => $this.model.id,
     __opts__
@@ -56,7 +56,7 @@ Wrap the error message tooltipped-error with a div, using `onTap` to trigger hid
 
 *Find* => `from`
 ```js
-$DCGShared['n']($Tooltip,
+$createElement($Tooltip,
   {
     tooltip: this.props.error,
     __opts__
@@ -79,7 +79,7 @@ DSM.replaceElement(
 
 *Find* => `element`
 ```js
-$['n'](
+$createElement(
   'span',
   { class: 'btns' },
   __children__

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -56,13 +56,8 @@ Wrap the error message tooltipped-error with a div, using `onTap` to trigger hid
 
 *Find* => `from`
 ```js
-$createElement($Tooltip,
-  {
-    tooltip: this.props.error,
-    __opts__
-  },
-  __errorTriangle__
-)
+additionalClass: this.const("dcg-tooltipped-error-container"),
+children: __errorTriangle__
 ```
 
 *Replace* `errorTriangle` with
@@ -81,8 +76,7 @@ DSM.replaceElement(
 ```js
 $createElement(
   'span',
-  { class: 'btns' },
-  __children__
+  { class: 'btns', children: [__children__] }
 )
 ```
 

--- a/src/plugins/show-tips/index.ts
+++ b/src/plugins/show-tips/index.ts
@@ -1,4 +1,4 @@
-import { DCGView } from "../../DCGView";
+import { createElementWrapped } from "../../preload/replaceElement";
 import { Inserter, PluginController } from "../PluginController";
 import Tip from "./Tip";
 
@@ -19,6 +19,6 @@ export default class ShowTips extends PluginController {
   }
 
   tipView(): Inserter {
-    return () => DCGView.createElement(Tip, { st: () => this });
+    return () => createElementWrapped(Tip, { st: () => this });
   }
 }

--- a/src/plugins/show-tips/show-tips.replacements
+++ b/src/plugins/show-tips/show-tips.replacements
@@ -8,7 +8,7 @@
 
 *Find*
 ```js
-$DCGShared['n'](
+$createElement(
   "div",
   {
     class: "dcg-expressions-branding"

--- a/src/plugins/show-tips/show-tips.replacements
+++ b/src/plugins/show-tips/show-tips.replacements
@@ -8,10 +8,10 @@
 
 *Find*
 ```js
-$DCGView.createElement(
+$DCGShared['n'](
   "div",
   {
-    class: $DCGView.const("dcg-expressions-branding")
+    class: "dcg-expressions-branding"
     __args__
   },
   __children__

--- a/src/plugins/show-tips/show-tips.replacements
+++ b/src/plugins/show-tips/show-tips.replacements
@@ -24,3 +24,25 @@ $createElement(
   DSM.insertElement(() => DSM.showTips?.tipView())
 ]
 ```
+
+### Alternative
+
+*Description* `Replace "powered by desmos" with tips`
+
+*Find*
+```js
+$DCGView.createElement(
+  "div",
+  {
+    class: $DCGView.const("dcg-expressions-branding")
+    __args__
+  },
+  __children__
+)
+```
+
+*Replace* `children` with
+```js
+__children__,
+DSM.insertElement(() => DSM.showTips?.tipView())
+```

--- a/src/plugins/show-tips/show-tips.replacements
+++ b/src/plugins/show-tips/show-tips.replacements
@@ -11,15 +11,16 @@
 $createElement(
   "div",
   {
-    class: "dcg-expressions-branding"
-    __args__
-  },
-  __children__
+    class: "dcg-expressions-branding",
+    children: __children__
+  }
 )
 ```
 
 *Replace* `children` with
 ```js
-__children__,
-DSM.insertElement(() => DSM.showTips?.tipView())
+[
+  __children__,
+  DSM.insertElement(() => DSM.showTips?.tipView())
+]
 ```

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -26,21 +26,14 @@ isShowKeypadButtonVisible () {
 
 *Find* => `center`
 ```js
-.createElement(
+$DGCShared['n'](
   'div',
-  { class: $DCGView.const('dcg-center-buttons') },
+  { class: 'dcg-center-buttons' },
   ____
 )
 ```
 
-*Find_surrounding_template* `center` => `template`
-
-*Find* inside `template`
-
-```js
-.createElement($Tooltip, {
-  tooltip: () => this.controller.s("graphing-calculator-label-edit-list-tooltip")
-```
+*Description* Removed template here as it does not seem to be needed anymore?
 
 *Replace* `center` with
 ```js
@@ -99,11 +92,11 @@ $ExpressionView = (window.DesModderFragile ??= {}).ExpressionView
 *Find*
 
 ```js
-$ImageIconView = class extends $.Class {
+$ImageIconView = class extends $.View {
   init() { ____ }
   template() {
-      return $.createElement("div", {
-          class: $.const("dcg-expression-icon-container dcg-image-icon-container")
+      return $['n']("div", {
+          class: "dcg-expression-icon-container dcg-image-icon-container"
       }
 ```
 

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -45,6 +45,32 @@ DSM.insertElement(
 )
 ```
 
+### Alternative
+
+*Description* `Add toggle button to enable Text Mode`
+
+*Find* => `center`
+```js
+.createElement(
+  'div',
+  { class: $DCGView.const('dcg-center-buttons') },
+  ____
+)
+```
+
+*Replace* `center` with
+```js
+__center__,
+DSM.insertElement(() => DSM.textMode?.textModeToggle()),
+// This is for pillbox-menus, not text-mode
+DSM.insertElement(
+  () => (
+    !this.controller.getGraphSettings().config.graphpaper
+      && DSM.pillboxMenus?.pillboxButtonsView(true)
+  )
+)
+```
+
 ## Add Text Mode class for styling
 
 *Description* `Style expressions list differently in Text Mode`
@@ -95,6 +121,25 @@ $ImageIconView = class extends $.View {
       return $createElement("div", {
           class: "dcg-expression-icon-container dcg-image-icon-container"
           ____
+      }
+```
+
+*Replace* `ImageIconView` with
+```js
+$ImageIconView = (window.DesModderFragile ??= {}).ImageIconView
+```
+
+### Alternative
+
+*Description* `Show style circles for Text Mode images`
+
+*Find*
+```js
+$ImageIconView = class extends $.View {
+  init() { ____ }
+  template() {
+      return $.createElement("div", {
+          class: $.const("dcg-expression-icon-container dcg-image-icon-container")
       }
 ```
 

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -26,14 +26,11 @@ isShowKeypadButtonVisible () {
 
 *Find* => `center`
 ```js
-$DGCShared$createElement(
+$createElement(
   'div',
-  { class: 'dcg-center-buttons' },
-  ____
+  { class: 'dcg-center-buttons' ____ }
 )
 ```
-
-*Description* Removed template here as it does not seem to be needed anymore?
 
 *Replace* `center` with
 ```js
@@ -97,6 +94,7 @@ $ImageIconView = class extends $.View {
   template() {
       return $createElement("div", {
           class: "dcg-expression-icon-container dcg-image-icon-container"
+          ____
       }
 ```
 

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -26,7 +26,7 @@ isShowKeypadButtonVisible () {
 
 *Find* => `center`
 ```js
-$DGCShared['n'](
+$DGCShared$createElement(
   'div',
   { class: 'dcg-center-buttons' },
   ____
@@ -95,7 +95,7 @@ $ExpressionView = (window.DesModderFragile ??= {}).ExpressionView
 $ImageIconView = class extends $.View {
   init() { ____ }
   template() {
-      return $['n']("div", {
+      return $createElement("div", {
           class: "dcg-expression-icon-container dcg-image-icon-container"
       }
 ```

--- a/src/preload/moduleOverrides/insert-panels.replacements
+++ b/src/preload/moduleOverrides/insert-panels.replacements
@@ -30,3 +30,31 @@ __children__,
 DSM.insertElement(() => DSM.pinExpressions?.pinnedPanel(this)),
 DSM.insertElement(() => DSM.textMode?.editorPanel(this)),
 ```
+
+### Alternative
+
+*Description* `Insert panels to show Text Mode and pinned expressions`
+
+*Find* => `element`
+```js
+$DCGView.createElement(
+  "div",
+  {
+    class: () => {
+      var $;
+      return {
+        "dcg-exppanel-container": ____
+      }
+    },
+    ____
+  },
+  __children__
+)
+```
+
+*Replace* `children` with
+```js
+__children__,
+DSM.insertElement(() => DSM.pinExpressions?.pinnedPanel(this)),
+DSM.insertElement(() => DSM.textMode?.editorPanel(this)),
+```

--- a/src/preload/moduleOverrides/insert-panels.replacements
+++ b/src/preload/moduleOverrides/insert-panels.replacements
@@ -17,9 +17,10 @@ $createElement(
       return {
         "dcg-exppanel-container": ____
       }
-    }, ____
-  },
-  __children__
+    },
+    style: () => (____),
+    children: [__children__]
+  }
 )
 ```
 

--- a/src/preload/moduleOverrides/insert-panels.replacements
+++ b/src/preload/moduleOverrides/insert-panels.replacements
@@ -9,7 +9,7 @@
 
 *Find* => `element`
 ```js
-$DCGShared['n'](
+$createElement(
   "div",
   {
     class: () => {

--- a/src/preload/moduleOverrides/insert-panels.replacements
+++ b/src/preload/moduleOverrides/insert-panels.replacements
@@ -9,7 +9,7 @@
 
 *Find* => `element`
 ```js
-$DCGView.createElement(
+$DCGShared['n'](
   "div",
   {
     class: () => {
@@ -17,8 +17,7 @@ $DCGView.createElement(
       return {
         "dcg-exppanel-container": ____
       }
-    },
-    ____
+    }, ____
   },
   __children__
 )

--- a/src/preload/replaceElement.ts
+++ b/src/preload/replaceElement.ts
@@ -1,12 +1,34 @@
 /** This file runs before Desmos is loaded */
+import type { ComponentChild, ComponentConstructor, OrConst } from "../DCGView";
 import { Replacer } from "../plugins/PluginController";
+
+export function createElementWrapped<Props>(
+  el: ComponentConstructor<Props>,
+  props: OrConst<Props> & { children?: ComponentChild[] }
+) {
+  const { DCGView } = (Desmos as any).Private.Fragile;
+  const isChildrenOutsideProps =
+    DCGView.createElement({}, {}, "third-arg").children === "third-arg";
+  if (isChildrenOutsideProps) {
+    const { children } = props;
+    const childrenArr = !children
+      ? []
+      : Array.isArray(children)
+        ? children
+        : [children];
+    // Old interface
+    // TODO-remove-children-props
+    return DCGView.createElement(el, props, ...childrenArr);
+  }
+  return DCGView.createElement(el, props as any);
+}
 
 export function insertElement(creator: () => undefined | (() => any)) {
   const { DCGView } = (Desmos as any).Private.Fragile;
-  return DCGView.createElement(DCGView.Components.If, {
+  return createElementWrapped(DCGView.Components.If, {
     predicate: () => !!creator(),
     children: () => creator()!(),
-  });
+  } as any);
 }
 
 export function replaceElement<T>(old: () => T, replacer: () => Replacer<T>) {

--- a/src/preload/replaceElement.ts
+++ b/src/preload/replaceElement.ts
@@ -3,11 +3,10 @@ import { Replacer } from "../plugins/PluginController";
 
 export function insertElement(creator: () => undefined | (() => any)) {
   const { DCGView } = (Desmos as any).Private.Fragile;
-  return DCGView.createElement(
-    DCGView.Components.If,
-    { predicate: () => !!creator() },
-    () => creator()!()
-  );
+  return DCGView.createElement(DCGView.Components.If, {
+    predicate: () => !!creator(),
+    children: () => creator()!(),
+  });
 }
 
 export function replaceElement<T>(old: () => T, replacer: () => Replacer<T>) {


### PR DESCRIPTION
Gracefully handle the following changes:
- `$DCGView.createElement` becomes a single minified ident `$createElement`.
- `children` is passed as a prop to `createElement` instead of a third parameter.
- `$DCGView.const()` removed (heading towards no getters).

After Desmos updates to use these changes, the Alternatives in the replacement files can be removed, as well as some code marked as `TODO-remove-children-props`.