### PR TITLE
Fix broken replacements for Right Click Tray

### DIFF
--- a/src/plugins/right-click-tray/right-click-tray.replacements
+++ b/src/plugins/right-click-tray/right-click-tray.replacements
@@ -8,7 +8,7 @@
 
 *Find*
 ```js
-$DCGView.addCustomAttribute("onLongHold", $callback => ({
+$addCustomAttribute("onLongHold", $callback => ({
   bindings: {
     onMount($el) {
       __body__


### PR DESCRIPTION
Replaced `$DCGView.addCustomAttribute` with a single identifier `$addCustomAttribute`