### PR TITLE
Better-nav-hide-scroll-bar

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -354,6 +354,8 @@ better-navigation-opt-ctrlArrow-name = Ctrl+Arrow Support
 better-navigation-opt-ctrlArrow-desc = Use Ctrl+ArrowKeys or Ctrl+Shift+ArrowKeys to skip over large blocks of text quickly. Use Ctrl+Backspace to delete large blocks of text.
 better-navigation-opt-scrollableExpressions-name = Scrollable Expressions
 better-navigation-opt-scrollableExpressions-desc = Adds horizontal scrollbars to expressions. This is primarily intended to make scrolling easier on mobile.
+better-navigation-opt-showScrollbar-name = Show Scrollbar
+better-navigation-opt-showScrollbar-desc = Shows or hides scrollbar. It is convenient to turn this off for touch devices.
 
 ## Paste Image
 paste-image-name = Paste Image

--- a/localization/es.ftl
+++ b/localization/es.ftl
@@ -362,3 +362,5 @@ better-navigation-opt-ctrlArrow-name = Atajo Ctrl+Flecha.
 better-navigation-opt-ctrlArrow-desc = Te permite utilizar Ctrl+Flecha y Ctrl+Shift+Flecha para avanzar bloques de texto más rápidamente. De manera similar puedes usar Ctrl+Retroceso para borrar bloques.
 better-navigation-opt-scrollableExpressions-name = Expresiones Desplazables
 better-navigation-opt-scrollableExpressions-desc = Añade una barra de desplazamiento horizontal. Mayormente destinado para facilitar la navegación en móvil.
+better-navigation-opt-showScrollbar-name = Mostrar Barra de Desplazamiento
+better-navigation-opt-showScrollbar-desc = Mostrar o esconder barra de desplazamiento. Coveniente para dispositivos de pantalla táctil.

--- a/localization/es.ftl
+++ b/localization/es.ftl
@@ -25,6 +25,7 @@ GLesmos-label-toggle-glesmos = Usar GLesmos
 GLesmos-confirm-lines = Confirmar líneas
 GLesmos-confirm-lines-body = Generar líneas con GLesmos puede ser lento. Sé especialmente cuidadoso cuando utilices listas.
 GLesmos-no-support = Desafortunadamente tu navegador no soporta GLesmos porque no provee soporte para WebGL2.
+GLesmos-not-enabled = Habilita GLesmos para mejorar el rendimiento de algunas expresiones implícitas.
 # Missing: error messages
 
 ## Tips
@@ -137,6 +138,9 @@ builtin-settings-opt-zoomButtons-desc = {""}
 builtin-settings-opt-keypad-name = Mostrar el teclado numérico
 # Unchanged
 builtin-settings-opt-keypad-desc = {""}
+builtin-settings-opt-showPerformanceMeter-name = Mostrar Monitor de Rendimiento 
+# Unchanged
+builtin-settings-opt-showPerformanceMeter-desc = {""}
 builtin-settings-opt-showIDs-name = Mostrar IDs
 # Unchanged
 builtin-settings-opt-showIDs-desc = {""}
@@ -184,6 +188,7 @@ video-creator-orientation-mode-current-speed = actual
 video-creator-orientation-mode-current-delta = recorrer
 video-creator-orientation-mode-from-to = rango
 video-creator-size = Tamaño:
+video-creator-mosaic = Mosaico:
 video-creator-angle-current = Ángulo:
 video-creator-angle-from = Desde:
 video-creator-angle-to = Hasta:
@@ -364,3 +369,9 @@ better-navigation-opt-scrollableExpressions-name = Expresiones Desplazables
 better-navigation-opt-scrollableExpressions-desc = Añade una barra de desplazamiento horizontal. Mayormente destinado para facilitar la navegación en móvil.
 better-navigation-opt-showScrollbar-name = Mostrar Barra de Desplazamiento
 better-navigation-opt-showScrollbar-desc = Mostrar o esconder barra de desplazamiento. Coveniente para dispositivos de pantalla táctil.
+
+## Paste Image
+paste-image-name = Pegar Imagen
+paste-image-desc = Te permite pegar imagenes directamente en las expressiones para importar.
+paste-image-error-images-not-enabled = Inserción de imagen no está disponible para este gráfico.
+paste-image-error-another-upload-in-progress = Vuelve a intentar cuando la imagen previa termine de procesarse.

--- a/src/plugins/better-navigation/index.less
+++ b/src/plugins/better-navigation/index.less
@@ -4,3 +4,10 @@ body.dsm-better-nav-scrollable-expressions {
     overflow-x: auto;
   }
 }
+
+body.dsm-better-nave-hide-scroll-bar {
+  .dcg-mq-editable-field
+    .dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block {
+    scrollbar-width: none;
+  }
+}

--- a/src/plugins/better-navigation/index.less
+++ b/src/plugins/better-navigation/index.less
@@ -5,7 +5,7 @@ body.dsm-better-nav-scrollable-expressions {
   }
 }
 
-body.dsm-better-nave-hide-scroll-bar {
+body.dsm-better-nav-hide-scroll-bar {
   .dcg-mq-editable-field
     .dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block.dcg-mq-root-block {
     scrollbar-width: none;

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -77,7 +77,7 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
     },
     {
       type: "boolean",
-      default: false,
+      default: true,
       key: "showScrollbar",
       shouldShow: (config) => config.scrollableExpressions,
     },
@@ -90,7 +90,7 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
     );
     document.body.classList.toggle(
       "dsm-better-nave-hide-scroll-bar",
-      this.settings.showScrollbar
+      !this.settings.showScrollbar
     );
   }
 

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -2,6 +2,7 @@
 import { PluginController } from "../PluginController";
 import { MathQuillField, MathQuillView } from "src/components";
 import { getController } from "../intellisense/latex-parsing";
+import { ConfigItem } from "#plugins/index.ts";
 
 import "./index.less";
 
@@ -45,6 +46,7 @@ function isAtStartOrEndOfASubscriptOrSuperscript(mq: MathQuillField, dir: Dir) {
 interface BetterNavSettings {
   ctrlArrow: boolean;
   scrollableExpressions: boolean;
+  showScrollbar: boolean;
 }
 
 const NavigationTable: Record<
@@ -73,12 +75,22 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
       default: false,
       key: "scrollableExpressions",
     },
-  ] as const;
+    {
+      type: "boolean",
+      default: false,
+      key: "showScrollbar",
+      shouldShow: (config) => config.scrollableExpressions,
+    },
+  ] satisfies readonly ConfigItem[];
 
   afterConfigChange(): void {
     document.body.classList.toggle(
       "dsm-better-nav-scrollable-expressions",
       this.settings.scrollableExpressions
+    );
+    document.body.classList.toggle(
+      "dsm-better-nave-hide-scroll-bar",
+      this.settings.showScrollbar
     );
   }
 

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -89,7 +89,7 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
       this.settings.scrollableExpressions
     );
     document.body.classList.toggle(
-      "dsm-better-nave-hide-scroll-bar",
+      "dsm-better-nav-hide-scroll-bar",
       !this.settings.showScrollbar
     );
   }


### PR DESCRIPTION
Add setting to show or hide scrollbar for long expressions when better navigation is enabled.

As [discussed here](https://discord.com/channels/1095245998747557978/1095245999473176709/1356759569283551404), it may be convenient to hide it in devices with trackpads and/or touch screen.