### PR TITLE
Fix issue with list of points in Better Evaluation View

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: npm install and build
         run: |
           npm ci

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -11,8 +11,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: "npm"
@@ -23,8 +23,8 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: "npm"
@@ -35,8 +35,8 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: "npm"

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -33,7 +33,9 @@ export type VanillaDispatchedEvent =
         | "upward-delete-selected-expression"
         | "downward-delete-selected-expression"
         | "update-expression-search-str"
-        | "ui/container-resized";
+        | "ui/container-resized"
+        | "toggle-complex-mode"
+        | "new-expression";
     }
   | {
       type: "commit-user-requested-viewport";

--- a/src/globals/index.ts
+++ b/src/globals/index.ts
@@ -1,5 +1,5 @@
 import window from "./window";
 export default window;
 export type * from "./Calc";
-export type * from "./models";
+export * from "./models";
 export * from "./window";

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -36,40 +36,45 @@ interface ItemModelBase {
   dsmEnableGolfDespiteLength?: boolean;
 }
 
+interface FormulaBase {
+  exported_variables?: string[];
+  is_graphable: boolean;
+  action_value?: Record<string, string>;
+}
+
 interface NonfolderItemModelBase extends ItemModelBase {
   folderId?: string;
   secret?: boolean;
   error?: any;
-  formula?: {
-    exported_variables?: string[];
-    expression_type:
-      | "X_OR_Y"
-      // Soon, X_OR_Y will be removed in favor of the following two:
-      | "X_OR_Y_EQUATION"
-      | "X_OR_Y_INEQUALITY"
-      | "SINGLE_POINT"
-      | "POINT_LIST"
-      | "PARAMETRIC"
-      | "POLAR"
-      | "IMPLICIT"
-      // Soon, IMPLICIT will be removed in favor of the following two:
-      | "IMPLICIT_EQUATION"
-      | "IMPLICIT_INEQUALITY"
-      | "POLYGON"
-      | "HISTOGRAM"
-      | "DOTPLOT"
-      | "BOXPLOT"
-      | "TTEST"
-      | "STATS"
-      | "CUBE"
-      | "SPHERE"
-      // There are many possible expression types due to 3d. No point writing them all out.
-      | string;
-    is_graphable: boolean;
-    is_inequality: boolean;
-    action_value?: Record<string, string>;
-  };
+  formula?: FormulaBase;
   dcgView?: ClassComponent;
+}
+
+export interface ExpressionFormula extends FormulaBase {
+  is_inequality?: boolean;
+  expression_type:
+    | "X_OR_Y"
+    // Soon, X_OR_Y will be removed in favor of the following two:
+    | "X_OR_Y_EQUATION"
+    | "X_OR_Y_INEQUALITY"
+    | "SINGLE_POINT"
+    | "POINT_LIST"
+    | "PARAMETRIC"
+    | "POLAR"
+    | "IMPLICIT"
+    // Soon, IMPLICIT will be removed in favor of the following two:
+    | "IMPLICIT_EQUATION"
+    | "IMPLICIT_INEQUALITY"
+    | "POLYGON"
+    | "HISTOGRAM"
+    | "DOTPLOT"
+    | "BOXPLOT"
+    | "TTEST"
+    | "STATS"
+    | "CUBE"
+    | "SPHERE"
+    // There are many possible expression types due to 3d. No point writing them all out.
+    | (string & {});
 }
 
 interface BaseClickable {
@@ -120,6 +125,7 @@ export interface ExpressionModel
     | "auto_right";
   clickableInfo?: BaseClickable;
   shouldGraph?: boolean;
+  formula?: ExpressionFormula;
 }
 
 interface TableColumn extends BasicSetExpression {

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -36,6 +36,28 @@ interface ItemModelBase {
   dsmEnableGolfDespiteLength?: boolean;
 }
 
+export enum ValueType {
+  Any = 0,
+  Number = 1,
+  Bool = 2,
+  Complex = 38,
+  ListOfComplex = 39,
+  Point = 3,
+  Point3D = 100,
+  Distribution = 4,
+  Action = 5,
+  ListOfAny = 6,
+  ListOfNumber = 7,
+  ListOfBool = 8,
+  ListOfPoint = 9,
+  ListOfPoint3D = 101,
+  ListOfDistribution = 10,
+  EmptyList = 11,
+  RGBColor = 14,
+  ListOfColor = 15,
+  // omitted
+}
+
 interface FormulaBase {
   exported_variables?: string[];
   is_graphable: boolean;
@@ -49,6 +71,28 @@ interface NonfolderItemModelBase extends ItemModelBase {
   formula?: FormulaBase;
   dcgView?: ClassComponent;
 }
+
+interface ValueTypeMap {
+  [ValueType.EmptyList]: [];
+  [ValueType.Number]: number;
+  [ValueType.ListOfNumber]: number[];
+  [ValueType.Point]: [number, number];
+  [ValueType.ListOfPoint]: [number, number][];
+  [ValueType.Point3D]: [number, number, number];
+  [ValueType.ListOfPoint3D]: [number, number, number][];
+  [ValueType.Complex]: [number, number];
+  [ValueType.ListOfComplex]: [number, number][];
+  [ValueType.RGBColor]: [number, number, number];
+  [ValueType.ListOfColor]: [number, number, number][];
+  [key: number]: unknown;
+}
+
+export type TypedConstantValue<T extends ValueType = ValueType> = T extends T
+  ? {
+      valueType: T;
+      value: ValueTypeMap[T];
+    }
+  : never;
 
 export interface ExpressionFormula extends FormulaBase {
   is_inequality?: boolean;
@@ -75,6 +119,7 @@ export interface ExpressionFormula extends FormulaBase {
     | "SPHERE"
     // There are many possible expression types due to 3d. No point writing them all out.
     | (string & {});
+  typed_constant_value?: TypedConstantValue | undefined;
 }
 
 interface BaseClickable {

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -34,6 +34,7 @@ interface ItemModelBase {
   readonly?: boolean;
   dsmGolfStats?: GolfStats;
   dsmEnableGolfDespiteLength?: boolean;
+  rootViewNode: HTMLElement;
 }
 
 export enum ValueType {

--- a/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
@@ -1,35 +1,19 @@
-import { Driver, clean, testWithPage } from "#tests";
-
-async function expectEval(driver: Driver, latexExpected: string) {
-  const latexFound = await driver.$eval(
-    ".dcg-evaluation-container .dcg-mq-root-block",
-    (el) => (el as any).mqBlockNode.latex()
-  );
-  expect(latexFound).toBe(latexExpected);
-}
-
-async function expectEvalPlain(driver: Driver, textExpected: string) {
-  const textFound = await driver.$eval(
-    ".dcg-evaluation-container",
-    (el) => (el as HTMLElement).innerText
-  );
-  expect(textFound).toBe(textExpected);
-}
+import { clean, testWithPage } from "#tests";
 
 const COLOR_SWATCH = ".dcg-color-swatch";
 
 testWithPage("List", async (driver) => {
   await driver.focusIndex(0);
   await driver.setLatexAndSync("[1,2,3]+0");
-  await expectEval(driver, "\\left[1,2,3\\right]");
+  await driver.expectEval("\\left[1,2,3\\right]");
 
   // It updates when you edit the latex
   await driver.setLatexAndSync("[1,2,3,4]+0");
-  await expectEval(driver, "\\left[1,2,3,4\\right]");
+  await driver.expectEval("\\left[1,2,3,4\\right]");
 
   // It gets reset on disabling lists, and shows the native list view instead.
   await driver.setPluginSetting("better-evaluation-view", "lists", false);
-  await expectEvalPlain(driver, "equals\n=\n1\n1\n2\n2\n3\n3\n4\n4");
+  await driver.expectEvalPlain("equals\n=\n1\n1\n2\n2\n3\n3\n4\n4");
 
   // Clean up
   await driver.clean();
@@ -40,12 +24,12 @@ testWithPage("Color", async (driver) => {
   await driver.focusIndex(0);
   await driver.setLatexAndSync("C=\\operatorname{rgb}\\left(1,2,3\\right)");
   const exp = "\\operatorname{rgb}\\left(1,2,3\\right)";
-  await expectEval(driver, exp);
+  await driver.expectEval(exp);
 
   // It doesn't get reset on disabling color lists
   await driver.setPluginSetting("better-evaluation-view", "colorLists", false);
   await driver.assertSelector(COLOR_SWATCH);
-  await expectEval(driver, exp);
+  await driver.expectEval(exp);
 
   // It gets reset on disabling colors
   await driver.setPluginSetting("better-evaluation-view", "colors", false);
@@ -61,7 +45,7 @@ testWithPage("Color List", async (driver) => {
   await driver.setLatexAndSync("C=\\operatorname{rgb}\\left(1,2,[3,4]\\right)");
   const exp =
     "\\operatorname{rgb}\\left(\\left[\\left(1,2,3\\right),\\left(1,2,4\\right)\\right]\\right)";
-  await expectEval(driver, exp);
+  await driver.expectEval(exp);
   await driver.assertSelector(COLOR_SWATCH);
 
   // It gets reset on disabling color lists

--- a/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
@@ -2,8 +2,10 @@ import { clean, testWithPage } from "#tests";
 
 const COLOR_SWATCH = ".dcg-color-swatch";
 
-testWithPage("List", async (driver) => {
-  await driver.focusIndex(0);
+testWithPage("EmptyList and ListOfNumber", async (driver) => {
+  const listOfNumberIndex = 0;
+  const emptyListIndex = 1;
+  await driver.focusIndex(listOfNumberIndex);
   await driver.setLatexAndSync("[1,2,3]+0");
   await driver.expectEval("\\left[1,2,3\\right]");
 
@@ -11,11 +13,69 @@ testWithPage("List", async (driver) => {
   await driver.setLatexAndSync("[1,2,3,4]+0");
   await driver.expectEval("\\left[1,2,3,4\\right]");
 
+  await driver.dispatch({
+    type: "new-expression",
+  });
+  await driver.focusIndex(emptyListIndex);
+  await driver.setLatexAndSync("[]+0");
+  await driver.expectEval("\\left[\\right]");
+
   // It gets reset on disabling lists, and shows the native list view instead.
   await driver.setPluginSetting("better-evaluation-view", "lists", false);
+  await driver.focusIndex(listOfNumberIndex);
   await driver.expectEvalPlain("equals\n=\n1\n1\n2\n2\n3\n3\n4\n4");
+  await driver.focusIndex(emptyListIndex);
+  await driver.expectEvalPlain("empty list");
 
   // Clean up
+  await driver.clean();
+  return clean;
+});
+
+testWithPage("ListOfComplex", async (driver) => {
+  await driver.dispatch({
+    type: "toggle-complex-mode",
+  });
+  await driver.focusIndex(0);
+  await driver.setLatexAndSync("[1,2,3,4]+i");
+  await driver.expectEval("\\left[1+i,2+i,3+i,4+i\\right]");
+
+  await driver.setPluginSetting("better-evaluation-view", "lists", false);
+  await driver.expectEvalPlain(
+    'equals\n=\n1 plus "i"\n1+i\n2 plus "i"\n2+i\n3 plus "i"\n3+i\n4 plus "i"\n4+i'
+  );
+
+  await driver.clean();
+  return clean;
+});
+
+testWithPage("ListOfPoint and ListOfPoint3D", async (driver) => {
+  const listOfPointIndex = 0;
+  const listOfPoint3DIndex = 1;
+  await driver.focusIndex(listOfPointIndex);
+  await driver.setLatexAndSync("([1...3],2)");
+  await driver.expectEval(
+    "\\left[\\left(1,2\\right),\\left(2,2\\right),\\left(3,2\\right)\\right]"
+  );
+  await driver.dispatch({
+    type: "new-expression",
+  });
+  await driver.focusIndex(listOfPoint3DIndex);
+  await driver.setLatexAndSync("([1...3],2,3)");
+  await driver.expectEval(
+    "\\left[\\left(1,2,3\\right),\\left(2,2,3\\right),\\left(3,2,3\\right)\\right]"
+  );
+
+  await driver.setPluginSetting("better-evaluation-view", "lists", false);
+  await driver.focusIndex(listOfPointIndex);
+  await driver.expectEvalPlain(
+    "equals\n=\nleft parenthesis, 1 , 2 , right parenthesis\n1,2\nleft parenthesis, 2 , 2 , right parenthesis\n2,2\nleft parenthesis, 3 , 2 , right parenthesis\n3,2"
+  );
+  await driver.focusIndex(listOfPoint3DIndex);
+  await driver.expectEvalPlain(
+    "equals\n=\nleft parenthesis, 1 , 2 , 3 , right parenthesis\n1,2,3\nleft parenthesis, 2 , 2 , 3 , right parenthesis\n2,2,3\nleft parenthesis, 3 , 2 , 3 , right parenthesis\n3,2,3"
+  );
+
   await driver.clean();
   return clean;
 });

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -27,7 +27,7 @@ undefined: () => DSM.replaceElement(
       content: () => this.controller.s("shared-calculator-label-undefined")
     }
   ),
-  () => 
+  () =>
     DSM.betterEvaluationView
       ? $createElement(
           Desmos.Private.Fragile.StaticMathquillView,
@@ -59,7 +59,7 @@ list: $rhs => $createElement(__oldList__)
   () => DSM.betterEvaluationView?.listEvaluation(() => {
     const itemModel = this.controller.getItemModel(this.props.id());
     // get untruncated value
-    return itemModel.formula.typed_constant_value.value;
+    return itemModel.formula.typed_constant_value;
   })
 ),
 list: $rhs => DSM.replaceElement(
@@ -67,7 +67,7 @@ list: $rhs => DSM.replaceElement(
   () => DSM.betterEvaluationView?.listEvaluation(() => {
     const itemModel = this.controller.getItemModel(this.props.id());
     // get untruncated value
-    return itemModel.formula.typed_constant_value.value;
+    return itemModel.formula.typed_constant_value;
   })
 )
 ```
@@ -81,7 +81,10 @@ emptyList: () => $emptyListCreateElement(__oldEmptyList__)
 ```js
 emptyList: () => DSM.replaceElement(
   () => $emptyListCreateElement(__oldEmptyList__),
-  () => DSM.betterEvaluationView?.listEvaluation(() => [])
+  () => DSM.betterEvaluationView?.listEvaluation(() => {
+    const itemModel = this.controller.getItemModel(this.props.id());
+    return itemModel.formula.typed_constant_value;
+  })
 )
 ```
 

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -1,29 +1,50 @@
-import { truncatedLatexLabel } from "../../../utils/depUtils";
 import { jsx } from "#DCGView";
 import { StaticMathQuillView } from "#components";
+import { Private, TypedConstantValue, ValueType } from "#globals";
 
-export function ListEvaluation(val: () => string[]) {
+export function ListEvaluation(
+  val: () => TypedConstantValue<
+    | ValueType.EmptyList
+    | ValueType.ListOfNumber
+    | ValueType.ListOfComplex
+    | ValueType.ListOfPoint
+    | ValueType.ListOfPoint3D
+  >
+) {
   return (
     <div class="dcg-evaluation-view__wrapped-value">
       <StaticMathQuillView
         latex={() => {
-          const values = val();
+          const typedConstantValue = val();
           const labelOptions = {
             smallCutoff: 0.00001,
             bigCutoff: 1000000,
             digits: 5,
             displayAsFraction: false,
           };
-          const length = 20;
-          const labels = values
-            .slice(0, length)
-            .map((label) => truncatedLatexLabel(label, labelOptions));
+          const formatLabel = (() => {
+            switch (typedConstantValue.valueType) {
+              case ValueType.ListOfComplex:
+                return Private.Mathtools.Label.complexNumberLabel;
+              case ValueType.ListOfPoint:
+                return Private.Mathtools.Label.pointLabel;
+              case ValueType.ListOfPoint3D:
+                return Private.Mathtools.Label.point3dLabel;
+              default:
+                return Private.Mathtools.Label.truncatedLatexLabel;
+            }
+          })();
+          const listLength = typedConstantValue.value.length;
+          const truncationLength = 20;
+          const labels = typedConstantValue.value
+            .slice(0, truncationLength)
+            .map((label) => formatLabel(label, labelOptions));
           return (
             "\\left[" +
             labels.join(",") +
-            (values.length > length
+            (listLength > truncationLength
               ? `\\textcolor{gray}{...\\mathit{${
-                  values.length - length
+                  listLength - truncationLength
                 }\\ more}}`
               : "") +
             "\\right]"

--- a/src/plugins/better-evaluation-view/index.ts
+++ b/src/plugins/better-evaluation-view/index.ts
@@ -9,7 +9,7 @@ export default class BetterEvaluationView extends PluginController<Config> {
   static enabledByDefault = true;
   static config = configList;
 
-  listEvaluation(val: () => string[]): Inserter {
+  listEvaluation(val: Parameters<typeof ListEvaluation>[0]): Inserter {
     if (!this.settings.lists) return undefined;
     return () => ListEvaluation(val);
   }

--- a/src/tests/puppeteer-utils.ts
+++ b/src/tests/puppeteer-utils.ts
@@ -195,6 +195,35 @@ export class Driver {
     await this.click(EXIT_ELM);
   }
 
+  async expectEval(latexExpected: string) {
+    const latexFound = await this.evaluate(() => {
+      const { rootViewNode } = Calc.controller.getSelectedItem()!;
+      interface MqRoot extends Element {
+        mqBlockNode: {
+          latex: () => string;
+        };
+      }
+      // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- false positive
+      const evaluationMqRoot = rootViewNode.querySelector(
+        ".dcg-evaluation-container .dcg-mq-root-block"
+      ) as MqRoot;
+      return evaluationMqRoot.mqBlockNode.latex();
+    });
+    expect(latexFound).toBe(latexExpected);
+  }
+
+  async expectEvalPlain(textExpected: string) {
+    const textFound = await this.evaluate(() => {
+      const { rootViewNode } = Calc.controller.getSelectedItem()!;
+      // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- false positive
+      const evaluationMqRoot = rootViewNode.querySelector(
+        ".dcg-evaluation-container"
+      ) as HTMLElement;
+      return evaluationMqRoot.innerText;
+    });
+    expect(textFound).toBe(textExpected);
+  }
+
   async clean() {
     await this.setBlank();
     await this.evaluate(

--- a/src/tests/puppeteer-utils.ts
+++ b/src/tests/puppeteer-utils.ts
@@ -3,7 +3,7 @@ import { PluginID } from "../plugins";
 import { GraphState } from "../../graph-state";
 import Intellisense from "#plugins/intellisense/index.tsx";
 import { Browser, Page } from "puppeteer";
-import { Calc as CalcType } from "../globals/Calc";
+import { Calc as CalcType, DispatchedEvent } from "../globals/Calc";
 
 /** Calc is only available inside evaluate() callbacks and friends, since those
  * stringify the function and evaluate it inside the browser */
@@ -193,6 +193,13 @@ export class Driver {
 
   async exitEditListMode() {
     await this.click(EXIT_ELM);
+  }
+
+  async dispatch(e: DispatchedEvent) {
+    await this.evaluate((_e) => {
+      Calc.controller.dispatch(_e);
+    }, e);
+    await this.waitForSync();
   }
 
   async expectEval(latexExpected: string) {

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -36,10 +36,6 @@ export const autoCommandNames: string =
 export const autoOperatorNames: string =
   Private.MathquillConfig?.getAutoOperators?.();
 
-export function truncatedLatexLabel(label: any, labelOptions: any) {
-  return Private.Mathtools.Label.truncatedLatexLabel(label, labelOptions);
-}
-
 export function getCurrentGraphTitle(calc: Calc): string | undefined {
   return calc._calc.globalHotkeys?.mygraphsController?.graphsController?.getCurrentGraphTitle?.();
 }


### PR DESCRIPTION
Fix #1015
- Extracted `NonfolderItemModelBase["formula"]` types to interface
  - Made property `expression_type` and `is_inequality` present only in `ExpressionFormula`
  - Made property `is_inequality` optional since it exists only in inequalities as far as I could find
- Added typings for `typed_constant_value`
- Return `itemModel.formula.typed_constant_value` instead of `itemModel.formula.typed_constant_value.value` in `listEvaluation` callbacks so that we can access to the `valueType` property
- Added tests for `EmptyList`, `ListOfComplex`, `ListOfPoint`, and `ListOfPoint3D`
- Made `expectEval` and `expectEvalPlain` into methods of `Driver` to deal with multiple expressions in one test case

to-do:
- Add more detailed typings for `Private`