### PR TITLE
Add support for exporting frames as WebP

### DIFF
--- a/src/core-plugins/pillbox-menus/components/PillboxMenu.tsx
+++ b/src/core-plugins/pillbox-menus/components/PillboxMenu.tsx
@@ -38,6 +38,7 @@ export default class PillboxMenu extends Component<{
             didUnmount={() => this.didUnmountContainer()}
             style={() => ({
               position: "absolute",
+              "min-width": "min-content",
               ...this.getPopoverPosition(),
             })}
           >

--- a/src/plugins/video-creator/backend/export.ts
+++ b/src/plugins/video-creator/backend/export.ts
@@ -4,7 +4,7 @@ import { downloadZip } from "client-zip";
 import { Console } from "#globals";
 
 type FFmpeg = ReturnType<typeof createFFmpeg>;
-type FFmpegFileType = "gif" | "mp4" | "webm" | "apng";
+type FFmpegFileType = "gif" | "mp4" | "webm" | "apng" | "webp";
 export type OutFileType = FFmpegFileType | "zip";
 
 let ffmpeg: null | FFmpeg = null;
@@ -26,6 +26,7 @@ async function exportAll(
     // https://superuser.com/a/1239082
     gif: ["-lavfi", "palettegen=stats_mode=diff[pal],[0:v][pal]paletteuse"],
     apng: ["-plays", "0", "-f", "apng"],
+    webp: ["-vcodec", "libwebp", "-lossless", "1", "-loop", "0"],
   }[fileType];
 
   await ffmpeg.run(
@@ -101,7 +102,7 @@ async function* files(frames: string[]) {
 async function exportFFmpeg(
   vc: VideoCreator,
   fileType: FFmpegFileType,
-  ext: "png" | "gif" | "mp4" | "webm"
+  ext: "png" | "gif" | "mp4" | "webm" | "webp"
 ) {
   const ffmpeg = await initFFmpeg(vc);
 
@@ -125,9 +126,13 @@ async function exportFFmpeg(
     ffmpeg.FS("unlink", filename);
   }
   ffmpeg.FS("unlink", outFilename);
-  const metaExt = { png: "image", gif: "image", mp4: "video", webm: "video" }[
-    ext
-  ];
+  const metaExt = {
+    png: "image",
+    gif: "image",
+    webp: "image",
+    mp4: "video",
+    webm: "video",
+  }[ext];
 
   return new Blob([data.buffer as ArrayBuffer], { type: `${metaExt}/${ext}` });
 }

--- a/src/plugins/video-creator/components/MainPopup.tsx
+++ b/src/plugins/video-creator/components/MainPopup.tsx
@@ -10,7 +10,14 @@ import { format } from "#i18n";
 import ManagedNumberInput from "./ManagedNumberInput";
 import { OrientationView } from "./OrientationView";
 
-const fileTypeNames: OutFileType[] = ["gif", "mp4", "webm", "apng", "zip"];
+const fileTypeNames: OutFileType[] = [
+  "gif",
+  "mp4",
+  "webm",
+  "apng",
+  "webp",
+  "zip",
+];
 
 export function MainPopupFunc(vc: VideoCreator) {
   return <MainPopup vc={vc} />;


### PR DESCRIPTION
With webp selected, ffmpeg will now be run with `-vcodec libwebp -lossless 1 -loop 0` and generate an animated WebP file.

Tweaked PillboxMenu styles to prevent the "Select export type" control from overflowing.