### PR TITLE
Automatically suggest using the Prettier extension for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
   "files.associations": {
     "*.replacements": "markdown"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,7 +25,8 @@ If you're looking for in-depth development documentation, see:
 First follow the instructions above in "Setup Environment".
 
 1. You will want the Prettier and Typescript packages installed for your editor.
-   - VS Code comes bundled with Typescript support. Its Prettier extension is called "Prettier - Code Formatter," and I suggest the settings
+   - VS Code comes bundled with Typescript support.
+   - VS Code should automatically suggest installing the Prettier extension. If not, its Prettier extension is called [`Prettier - Code Formatter`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), and I suggest the settings
      ```json
      "editor.formatOnSave": true,
      "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
- Set the default formatter to Prettier in the workspace settings
- Suggest installing Prettier if it isn't installed already
- Update the docs to match