### PR TITLE
Create pillbox buttons in the same way as desmos

### DIFF
--- a/src/core-plugins/pillbox-menus/components/PillboxButton.tsx
+++ b/src/core-plugins/pillbox-menus/components/PillboxButton.tsx
@@ -1,0 +1,62 @@
+import PillboxMenus from "..";
+import { Component, jsx } from "#DCGView";
+import { Tooltip } from "#components";
+import { format } from "#i18n";
+import PillboxMenu from "./PillboxMenu";
+
+export class PillboxButton extends Component<{
+  pm: PillboxMenus;
+  buttonId: string;
+  horizontal: boolean;
+}> {
+  pm!: PillboxMenus;
+  horizontal!: boolean;
+
+  init() {
+    this.pm = this.props.pm();
+    this.horizontal = this.props.horizontal();
+  }
+
+  template() {
+    const id = this.props.buttonId();
+    return (
+      <div
+        // TODO-jared: mess of classes.
+        class={{
+          "dsm-pillbox-buttons": true,
+          "dsm-pillbox-and-popover": true,
+        }}
+      >
+        <Tooltip
+          tooltip={() => format(this.pm.pillboxButtons[id].tooltip)}
+          gravity={() => (this.horizontal ? "s" : "w")}
+        >
+          <div
+            class={() =>
+              this.horizontal
+                ? "dcg-icon-btn"
+                : "dcg-btn-flat-gray dcg-settings-pillbox dcg-action-settings dcg-pillbox-btn-interior dsm-action-menu"
+            }
+            data-buttonId={id}
+            role="button"
+            onTap={() => this.onTapMenuButton(id)}
+            // TODO: manageFocus?
+          >
+            <i class={() => this.pm.pillboxButtons[id].iconClass ?? ""} />
+          </div>
+        </Tooltip>
+        {
+          <PillboxMenu
+            pm={this.pm}
+            horizontal={this.horizontal}
+            buttonId={this.props.buttonId()}
+          />
+        }
+      </div>
+    );
+  }
+
+  onTapMenuButton(id: string) {
+    this.pm.toggleMenu(id);
+  }
+}

--- a/src/core-plugins/pillbox-menus/components/PillboxContainer.less
+++ b/src/core-plugins/pillbox-menus/components/PillboxContainer.less
@@ -11,11 +11,6 @@
   .dcg-left-pillbox-elements {
     display: none;
   }
-
-  .dsm-pillbox-buttons > *,
-  .dsm-text-mode-toggle {
-    margin-right: 6px;
-  }
 }
 
 .dcg-geometry-toolbar-view .dcg-header-right {
@@ -26,6 +21,6 @@
   display: flex;
 }
 
-.dsm-pillbox-buttons .dsm-action-menu {
+.dsm-action-menu {
   background: var(--dcg-custom-background-color-shaded, #ededed);
 }

--- a/src/core-plugins/pillbox-menus/components/PillboxContainer.tsx
+++ b/src/core-plugins/pillbox-menus/components/PillboxContainer.tsx
@@ -1,10 +1,10 @@
 import PillboxMenus from "..";
 import "./PillboxContainer.less";
 import { Component, jsx } from "#DCGView";
-import { If, Tooltip, For } from "#components";
-import { format } from "#i18n";
+import { If, For } from "#components";
+import { PillboxButton } from "./PillboxButton";
 
-export default class PillboxContainer extends Component<{
+export class PillboxContainer extends Component<{
   pm: PillboxMenus;
   horizontal: boolean;
 }> {
@@ -30,36 +30,22 @@ export default class PillboxContainer extends Component<{
 
   templateTrue() {
     return (
-      <div class="dsm-pillbox-and-popover">
-        <div
-          class={{
-            "dsm-pillbox-buttons": true,
-            "dsm-horizontal-pillbox": this.horizontal,
-          }}
-        >
-          <For each={() => this.pm.pillboxButtonsOrder} key={(id) => id}>
-            {(id: string) => (
-              <Tooltip
-                tooltip={() => format(this.pm.pillboxButtons[id].tooltip)}
-                gravity={() => (this.horizontal ? "s" : "w")}
-              >
-                <div
-                  class={() =>
-                    this.horizontal
-                      ? "dcg-icon-btn"
-                      : "dcg-btn-flat-gray dcg-settings-pillbox dcg-action-settings dcg-pillbox-btn-interior dsm-action-menu"
-                  }
-                  role="button"
-                  onTap={() => this.onTapMenuButton(id)}
-                  // TODO: manageFocus?
-                >
-                  <i class={() => this.pm.pillboxButtons[id].iconClass ?? ""} />
-                </div>
-              </Tooltip>
-            )}
-          </For>
-        </div>
-        {this.pm.dsm.insertElement(() => this.pm.pillboxMenuView(false))}
+      <div
+        class={{
+          "dsm-pillbox-and-popover": true,
+          "dsm-pillbox-buttons": true,
+          "dsm-horizontal-pillbox": this.horizontal,
+        }}
+      >
+        <For each={() => this.pm.pillboxButtonsOrder} key={(id) => id}>
+          {(id: string) => (
+            <PillboxButton
+              buttonId={id}
+              pm={this.pm}
+              horizontal={this.horizontal}
+            />
+          )}
+        </For>
       </div>
     );
   }

--- a/src/core-plugins/pillbox-menus/components/PillboxMenu.less
+++ b/src/core-plugins/pillbox-menus/components/PillboxMenu.less
@@ -1,3 +1,7 @@
+.dsm-menu-container {
+  line-height: normal;
+}
+
 .dcg-container
   .dsm-menu-container.dcg-constrained-height-popover
   .dcg-popover-interior {

--- a/src/core-plugins/pillbox-menus/components/PillboxMenu.tsx
+++ b/src/core-plugins/pillbox-menus/components/PillboxMenu.tsx
@@ -7,6 +7,7 @@ import { keys } from "#utils/depUtils.ts";
 export default class PillboxMenu extends Component<{
   pm: PillboxMenus;
   horizontal: boolean;
+  buttonId: string;
 }> {
   pm!: PillboxMenus;
   horizontal!: boolean;
@@ -20,7 +21,7 @@ export default class PillboxMenu extends Component<{
     return (
       <If
         predicate={() =>
-          this.pm.pillboxMenuOpen !== null &&
+          this.pm.pillboxMenuOpen === this.props.buttonId() &&
           this.pm.showHorizontalPillboxMenu() === this.horizontal
         }
       >

--- a/src/core-plugins/pillbox-menus/index.ts
+++ b/src/core-plugins/pillbox-menus/index.ts
@@ -1,10 +1,10 @@
 import { Inserter, PluginController } from "../../plugins/PluginController";
 import { MenuFunc } from "./components/Menu";
-import PillboxContainer from "./components/PillboxContainer";
-import PillboxMenu from "./components/PillboxMenu";
 import { DCGView } from "#DCGView";
 import { plugins, PluginID, ConfigItem } from "#plugins/index.ts";
 import { createElementWrapped } from "../../preload/replaceElement";
+import { PillboxButton } from "./components/PillboxButton";
+import { PillboxContainer } from "./components/PillboxContainer";
 
 export default class PillboxMenus extends PluginController<undefined> {
   static id = "pillbox-menus" as const;
@@ -25,7 +25,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   // array of IDs
   pillboxButtonsOrder: string[] = ["main-menu"];
   // map button ID to setup
-  pillboxButtons: Record<string, PillboxButton> = {
+  pillboxButtons: Record<string, PillboxButtonSpec> = {
     "main-menu": {
       id: "main-menu",
       tooltip: "menu-desmodder-tooltip",
@@ -44,7 +44,13 @@ export default class PillboxMenus extends PluginController<undefined> {
     );
   }
 
-  pillboxButtonsView(horizontal: boolean): Inserter {
+  pushToPillboxList(list: { push: (buttonId: string) => void }) {
+    for (const buttonId of this.pillboxButtonsOrder) {
+      list.push("dsm-" + buttonId);
+    }
+  }
+
+  pillboxContainerView(horizontal: boolean): Inserter {
     return () =>
       createElementWrapped(PillboxContainer, {
         pm: () => this,
@@ -52,11 +58,11 @@ export default class PillboxMenus extends PluginController<undefined> {
       });
   }
 
-  pillboxMenuView(horizontal: boolean): Inserter {
-    if (this.pillboxMenuOpen === null) return undefined;
+  pillboxButtonView(buttonId: string, horizontal: boolean): Inserter {
     return () =>
-      createElementWrapped(PillboxMenu, {
+      createElementWrapped(PillboxButton, {
         pm: () => this,
+        buttonId: DCGView.const(buttonId),
         horizontal: DCGView.const(horizontal),
       });
   }
@@ -65,7 +71,7 @@ export default class PillboxMenus extends PluginController<undefined> {
     this.cc.dispatch({ type: "tick" });
   }
 
-  addPillboxButton(info: PillboxButton) {
+  addPillboxButton(info: PillboxButtonSpec) {
     this.pillboxButtons[info.id] = info;
     this.pillboxButtonsOrder.push(info.id);
     this.updateMenuView();
@@ -164,7 +170,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   }
 }
 
-interface PillboxButton {
+interface PillboxButtonSpec {
   id: string;
   tooltip: string;
   iconClass: string;

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -14,20 +14,24 @@ this.shouldShowGeometrySettings() && $right.push("settings-geo"),
 *Replace* `pushkey` with
 ```js
 __pushkey__
-DSM.pillboxMenus && $right.push("dsm-pillbox-menus"),
+DSM.pillboxMenus?.pushToPillboxList($right),
 ```
 
 *Find* => `case`
 ```js
-case "settings2d":
-  return $createElement($, ____);
+switch ($buttonId) {
+  case "settings2d":
+    return $createElement($, ____);
 ```
 
 *Replace* `case` with
 ```js
 __case__
-case "dsm-pillbox-menus":
-  return DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonsView(false));
+  default:
+    if ($buttonId.startsWith("dsm-"))
+      return DSM.insertElement(() => DSM.pillboxMenus?.pillboxButtonView($buttonId.slice(4), false));
+    console.warn("Unhandled pillbox button type");
+    return $createElement("span", {});
 ```
 
 ## Bottom zero for our pillbox menus
@@ -43,27 +47,6 @@ this.controller.isGraphSettingsOpen() ? `bottom: ${$e}px;` : "bottom: auto"
 ```js
 this.controller.isGraphSettingsOpen() || DSM.pillboxMenus?.isSomePillboxMenuOpen()
   ? `bottom: ${$e}px;` : "bottom: auto;"
-```
-
-## Add popover view for geometry
-
-*Description* `Allow showing pillbox menus (like the video creator menu) in the geometry calculator`
-
-*Find* => `from`
-```js
-$createElement($If, {
-  predicate: () =>
-    this.controller.isGeoUIActive() &&
-    this.controller.getGraphSettings().config.settingsMenu &&
-    this.controller.isGraphSettingsOpen(),
-  ____
-} ____)
-```
-
-*Replace* `from` with
-```js
-__from__,
-DSM.insertElement(() => DSM.pillboxMenus?.pillboxMenuView(true))
 ```
 
 ## Tweak placement of existing settings menu in geometry

--- a/src/plugins/performance-info/performance-info.int.test.ts
+++ b/src/plugins/performance-info/performance-info.int.test.ts
@@ -1,7 +1,7 @@
 import { clean, testWithPage } from "#tests";
 
 const POPUP = ".dcg-popover-interior.dsm-performance-info-menu";
-const BUTTON = ".dsm-pillbox-buttons :nth-child(3)";
+const BUTTON = "[data-buttonid='dsm-pi-menu']";
 const PIN_BUTTON = ".dsm-pi-pin-menu-button";
 
 describe("Performance info", () => {

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -40,7 +40,7 @@ DSM.insertElement(() => DSM.textMode?.textModeToggle()),
 DSM.insertElement(
   () => (
     !this.controller.getGraphSettings().config.graphpaper
-      && DSM.pillboxMenus?.pillboxButtonsView(true)
+      && DSM.pillboxMenus?.pillboxContainerView(true)
   )
 )
 ```

--- a/src/plugins/video-creator/video-creator.int.test.ts
+++ b/src/plugins/video-creator/video-creator.int.test.ts
@@ -8,7 +8,7 @@ const EXPANDED = ".dsm-vc-preview-expanded";
 describe("Video Creator", () => {
   testWithPage("Menuing", async (driver) => {
     // Open menu. It should be FFmpeg loading
-    await driver.click(".dsm-pillbox-buttons :nth-child(2)");
+    await driver.click("[data-buttonid='dsm-vc-menu']");
     await driver.assertSelector(".dsm-menu-container .dsm-delayed-reveal");
 
     // Eventually, FFmpeg loads. Capture menu but no preview/export


### PR DESCRIPTION
This gets the correct height when dragging the expressions list vertically to cover them.