### PR TITLE
Add 'floats' config to better-evaluation-view

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -233,6 +233,8 @@ performance-info-other = Other
 ## Better Evaluation View
 better-evaluation-view-name = Better Evaluation View
 better-evaluation-view-desc = Displays list elements, colors, and undefined values
+better-evaluation-view-opt-floats-name = Advanced floating point
+better-evaluation-view-opt-floats-desc = Show NaN/∞/-∞ instead of undefined, and '-0' for negative 0.
 better-evaluation-view-opt-lists-name = Show list elements
 better-evaluation-view-opt-lists-desc = Show list elements instead of list length
 better-evaluation-view-opt-colors-name = Show colors

--- a/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
@@ -1,10 +1,16 @@
-import { clean, testWithPage } from "#tests";
+import { clean, Driver, testWithPage } from "#tests";
 
 const COLOR_SWATCH = ".dcg-color-swatch";
+
+async function enableBevLists(driver: Driver) {
+  // This used to be the defaults, so all the tests currently start with this.
+  await driver.setPluginSetting("better-evaluation-view", "lists", true);
+}
 
 testWithPage("EmptyList and ListOfNumber", async (driver) => {
   const listOfNumberIndex = 0;
   const emptyListIndex = 1;
+  await enableBevLists(driver);
   await driver.focusIndex(listOfNumberIndex);
   await driver.setLatexAndSync("[1,2,3]+0");
   await driver.expectEval("\\left[1,2,3\\right]");
@@ -33,6 +39,7 @@ testWithPage("EmptyList and ListOfNumber", async (driver) => {
 });
 
 testWithPage("ListOfComplex", async (driver) => {
+  await enableBevLists(driver);
   await driver.dispatch({
     type: "toggle-complex-mode",
   });
@@ -50,6 +57,7 @@ testWithPage("ListOfComplex", async (driver) => {
 });
 
 testWithPage("ListOfPoint and ListOfPoint3D", async (driver) => {
+  await enableBevLists(driver);
   const listOfPointIndex = 0;
   const listOfPoint3DIndex = 1;
   await driver.focusIndex(listOfPointIndex);
@@ -81,6 +89,7 @@ testWithPage("ListOfPoint and ListOfPoint3D", async (driver) => {
 });
 
 testWithPage("Color", async (driver) => {
+  await enableBevLists(driver);
   await driver.focusIndex(0);
   await driver.setLatexAndSync("C=\\operatorname{rgb}\\left(1,2,3\\right)");
   const exp = "\\operatorname{rgb}\\left(1,2,3\\right)";
@@ -101,6 +110,7 @@ testWithPage("Color", async (driver) => {
 });
 
 testWithPage("Color List", async (driver) => {
+  await enableBevLists(driver);
   await driver.focusIndex(0);
   await driver.setLatexAndSync("C=\\operatorname{rgb}\\left(1,2,[3,4]\\right)");
   const exp =

--- a/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.int.test.ts
@@ -131,3 +131,52 @@ testWithPage("Color List", async (driver) => {
   await driver.clean();
   return clean;
 });
+
+testWithPage(
+  "Floats",
+  async (driver) => {
+    await enableBevLists(driver);
+    await driver.focusIndex(0);
+
+    // List is untouched with floats=false (default)
+    await driver.setLatexAndSync("L=[0/0,1/0,-1/0,4]+0");
+    await driver.expectEval(
+      "\\left[\\mathrm{undefined},\\mathrm{undefined},\\mathrm{undefined},4\\right]"
+    );
+
+    // Scalar is untouched with floats=false.
+    await driver.setLatexAndSync("L=0/0");
+    await driver.expectEvalPlain("undefined");
+    await driver.setLatexAndSync("L=1/0");
+    await driver.expectEvalPlain("undefined");
+    await driver.setLatexAndSync("L=-1/0");
+    await driver.expectEvalPlain("undefined");
+
+    // Set floats=true
+    await driver.setPluginSetting("better-evaluation-view", "floats", true);
+
+    // List uses advanced floats with floats=true.
+    await driver.setLatexAndSync("L=[0/0,1/0,-1/0,4]+0");
+    await driver.expectEval(
+      "\\left[\\mathrm{NaN},\\infty ,-\\infty ,4\\right]"
+    );
+
+    // Scalar uses advanced floats with floats=true.
+    await driver.setLatexAndSync("L=0/0");
+    await driver.expectEval("\\mathrm{NaN}");
+    await driver.setLatexAndSync("L=1/0");
+    await driver.expectEval("\\infty");
+    await driver.setLatexAndSync("L=-1/0");
+    await driver.expectEval("-\\infty");
+
+    // Lists use advanced floats with floats=true even if lists=false.
+    await driver.setPluginSetting("better-evaluation-view", "lists", false);
+    await driver.setLatexAndSync("L=[0/0,1/0,-1/0,4]+0");
+    await driver.expectEval(["\\mathrm{NaN}", "\\infty", "-\\infty", "4"]);
+
+    // Clean up
+    await driver.clean();
+    return clean;
+  },
+  150000
+);

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -28,7 +28,7 @@ undefined: () => DSM.replaceElement(
     }
   ),
   () =>
-    DSM.betterEvaluationView
+    DSM.betterEvaluationView?.settings.floats
       ? $createElement(
           Desmos.Private.Fragile.StaticMathquillView,
           {
@@ -136,7 +136,7 @@ if (isNaN($val) || !isFinite($val)) {
       value: $complexNumberLabel($val, {digits: 5})
     };
   }
-  if (!DSM.betterEvaluationView) {
+  if (!DSM.betterEvaluationView?.settings.floats) {
     return { type: "undefined" };
   }
   return {
@@ -171,7 +171,7 @@ if ($val === 0 || Math.abs($val) < $zeroCutoff)
 *Replace* `zero` with
 ```js
 if ($val === 0) {
-  if (!DSM.betterEvaluationView || Object.is($val, 0)) {
+  if (!DSM.betterEvaluationView.settings.floats || Object.is($val, 0)) {
     return {
       type: "decimal",
       value: "0"
@@ -183,7 +183,7 @@ if ($val === 0) {
     }
   }
 } else if ($zeroCutoff && Math.abs($val) < $zeroCutoff) {
-  if (!DSM.betterEvaluationView || Math.sign($val) === 1) {
+  if (!DSM.betterEvaluationView.settings.floats || Math.sign($val) === 1) {
     return {
       type: "decimal",
       value: "0"
@@ -224,7 +224,7 @@ function $truncatedLatexLabel($e, $t) {
     let $r = $numericLabel($e, $t);
     switch ($r.type) {
     case "undefined":
-        return DSM.betterEvaluationView ? $r.value : 'undefined';
+        return DSM.betterEvaluationView?.settings.floats ? $r.value : 'undefined';
     case "decimal":
         return $r.value;
     case "scientific":

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -109,6 +109,8 @@ rgbcolor: $rhs => DSM.replaceElement(
 
 *Description* `Distinguish NaN vs -∞ vs +∞ vs complex`
 
+Needs 'worker_only' because this goes into the `shared_module_source`
+
 *worker_only*
 
 Add a value field to "undefined" labels
@@ -127,19 +129,28 @@ complexNumberLabel: () => $complexNumberLabel,
 
 *Replace* `undefined` with
 ```js
-if (isNaN($val) || !isFinite($val))
+if (isNaN($val) || !isFinite($val)) {
+  if (Array.isArray($val) && $val.length == 2) {
+    return {
+      type: "decimal",
+      value: $complexNumberLabel($val, {digits: 5})
+    };
+  }
+  if (!DSM.betterEvaluationView) {
+    return { type: "undefined" };
+  }
   return {
     type: "decimal",
-    value: Array.isArray($val) && $val.length == 2
-      ? $complexNumberLabel($val, {digits: 5})
-      : isNaN($val)
+    value: 
+      isNaN($val)
       ? "\\mathrm{NaN}"
       : $val === Infinity
       ? "\\infty"
       : $val === -Infinity
       ? "-\\infty"
-      : "undefined",
+      : "undefined"
   };
+}
 ```
 
 ## Distinguish between 0 and -0 in numericLabels
@@ -190,8 +201,7 @@ if ($val === 0) {
 
 *Description* `Distinguish NaN, +∞, -∞ in lists.`
 
-I'm really confused. The match doesn't work without *worker_only*, but the code
-runs on the main page, not the worker.
+Needs 'worker_only' because this goes into the `shared_module_source`
 
 *worker_only*
 

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -38,7 +38,11 @@ export function ListEvaluation(
           const truncationLength = 20;
           const labels = typedConstantValue.value
             .slice(0, truncationLength)
-            .map((label) => formatLabel(label, labelOptions));
+            .map((label) => {
+              const latex = formatLabel(label, labelOptions);
+              if (latex === "undefined") return "\\mathrm{undefined}";
+              return latex;
+            });
           return (
             "\\left[" +
             labels.join(",") +

--- a/src/plugins/better-evaluation-view/config.ts
+++ b/src/plugins/better-evaluation-view/config.ts
@@ -2,6 +2,11 @@ import { ConfigItem } from "#plugins/index.ts";
 
 export const configList: ConfigItem[] = [
   {
+    key: "floats",
+    type: "boolean",
+    default: false,
+  },
+  {
     key: "lists",
     type: "boolean",
     default: true,
@@ -20,6 +25,7 @@ export const configList: ConfigItem[] = [
 ];
 
 export interface Config {
+  floats: boolean;
   lists: boolean;
   colors: boolean;
   colorLists: boolean;

--- a/src/plugins/better-evaluation-view/config.ts
+++ b/src/plugins/better-evaluation-view/config.ts
@@ -9,7 +9,7 @@ export const configList: ConfigItem[] = [
   {
     key: "lists",
     type: "boolean",
-    default: true,
+    default: false,
   },
   {
     key: "colors",

--- a/src/tests/puppeteer-utils.ts
+++ b/src/tests/puppeteer-utils.ts
@@ -202,21 +202,38 @@ export class Driver {
     await this.waitForSync();
   }
 
-  async expectEval(latexExpected: string) {
-    const latexFound = await this.evaluate(() => {
+  async expectEval(latexExpected: string | string[]) {
+    const latexFoundList = await this.evaluate(() => {
       const { rootViewNode } = Calc.controller.getSelectedItem()!;
       interface MqRoot extends Element {
         mqBlockNode: {
           latex: () => string;
         };
       }
-      // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- false positive
-      const evaluationMqRoot = rootViewNode.querySelector(
+      const evaluationMqRoots = rootViewNode.querySelectorAll(
         ".dcg-evaluation-container .dcg-mq-root-block"
-      ) as MqRoot;
-      return evaluationMqRoot.mqBlockNode.latex();
+      );
+      // Do a list in case of vanilla list output.
+      const latexes = [...evaluationMqRoots].map((x) =>
+        (x as MqRoot).mqBlockNode.latex().trim()
+      );
+      if (latexes[0] === "=") {
+        latexes.shift();
+      }
+      if (latexes.length === 0) {
+        throw new Error(
+          "Evaluation is not latex. Use `expectEvalPlain` instead to expect plaintext like 'undefined'."
+        );
+      }
+      return latexes;
     });
-    expect(latexFound).toBe(latexExpected);
+    let latexFound;
+    if (latexFoundList.length === 1 && !Array.isArray(latexExpected)) {
+      [latexFound] = latexFoundList;
+    } else {
+      latexFound = latexFoundList;
+    }
+    expect(latexFound).toStrictEqual(latexExpected);
   }
 
   async expectEvalPlain(textExpected: string) {


### PR DESCRIPTION
Adds a new option "Advanced floating point" (default false) to show NaN/∞/-∞ instead of undefined, and '-0' for negative 0.

Fixes #1020

Also fixes the bug where NaN/∞/-∞ was shown even if BEV was disabled.

Also disables "Show list elements" by default since Desmos has its builtin list display.