### PR TITLE
Don't insert pasted images into special folders

### DIFF
--- a/metadata/manage.ts
+++ b/metadata/manage.ts
@@ -1,5 +1,8 @@
 import Metadata, { Expression } from "./interface";
 
+export const ID_METADATA = "dsm-metadata";
+export const ID_METADATA_FOLDER = "dsm-metadata-folder";
+
 export function getBlankMetadata(): Metadata {
   return {
     version: 2,

--- a/src/core-plugins/manage-metadata/sync.ts
+++ b/src/core-plugins/manage-metadata/sync.ts
@@ -2,6 +2,8 @@ import Metadata from "#metadata/interface.ts";
 import { migrateToLatestMaybe } from "#metadata/migrate.ts";
 import {
   getBlankMetadata,
+  ID_METADATA,
+  ID_METADATA_FOLDER,
   isBlankMetadata,
   mergeMetadata,
   metadataWithIdsMapped,
@@ -26,9 +28,6 @@ The text content of dsm-metadata is in JSON format
 There used to be a folder with ID "dsm-metadata-folder". We no longer use it
 and instead remove the folder from existing graphs.
 */
-
-const ID_METADATA = "dsm-metadata";
-const ID_METADATA_FOLDER = "dsm-metadata-folder";
 
 function getMetadataExpr(cc: CalcController) {
   return cc.getItemModel(ID_METADATA);

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -1,4 +1,4 @@
-import { ItemModel } from "./models";
+import { FolderModel, ItemModel } from "./models";
 import { GraphState, ItemState, Product } from "../../graph-state";
 import { MathQuillField } from "#components";
 import { Matrix3 } from "./matrix3";
@@ -35,7 +35,8 @@ export type VanillaDispatchedEvent =
         | "update-expression-search-str"
         | "ui/container-resized"
         | "toggle-complex-mode"
-        | "new-expression";
+        | "new-expression"
+        | "new-expression-at-end";
     }
   | {
       type: "commit-user-requested-viewport";
@@ -364,6 +365,7 @@ interface CalcPrivate {
     getDefaultViewport: () => {
       constructor: { fromObject: (vp: Viewport) => ViewportClass };
     };
+    getGeometryFolder: () => FolderModel | undefined;
   };
   _calc: {
     globalHotkeys: TopLevelComponents;

--- a/text-mode-core/aug/augToRaw.ts
+++ b/text-mode-core/aug/augToRaw.ts
@@ -1,7 +1,10 @@
-// eslint-disable-next-line @desmodder/eslint-rules/no-reach-past-exports
-import type Metadata from "../../metadata/interface";
-// eslint-disable-next-line @desmodder/eslint-rules/no-reach-past-exports
-import { changeExprInMetadata, isBlankMetadata } from "../../metadata/manage";
+import type Metadata from "#metadata/interface";
+import {
+  changeExprInMetadata,
+  ID_METADATA,
+  ID_METADATA_FOLDER,
+  isBlankMetadata,
+} from "#metadata/manage";
 import { Config } from "../TextModeConfig";
 import { isConstant } from "./AugLatex";
 import Aug from "./AugState";
@@ -36,14 +39,14 @@ export default function augToRaw(
     list.push(
       {
         type: "folder",
-        id: "dsm-metadata-folder",
+        id: ID_METADATA_FOLDER,
         secret: true,
         title: "DesModder Metadata",
       } as const,
       {
         type: "text",
-        id: "dsm-metadata",
-        folderId: "dsm-metadata-folder",
+        id: ID_METADATA,
+        folderId: ID_METADATA_FOLDER,
         text: JSON.stringify(dsmMetadata),
       } as const
     );

--- a/text-mode-core/aug/rawToAug.ts
+++ b/text-mode-core/aug/rawToAug.ts
@@ -1,7 +1,6 @@
-// eslint-disable-next-line @desmodder/eslint-rules/no-reach-past-exports
-import Metadata from "../../metadata/interface";
-// eslint-disable-next-line @desmodder/eslint-rules/no-reach-past-exports
-import migrateToLatest from "../../metadata/migrate";
+import Metadata from "#metadata/interface";
+import migrateToLatest from "#metadata/migrate";
+import { ID_METADATA, ID_METADATA_FOLDER } from "#metadata/manage";
 import {
   ChildExprNode,
   evalMaybeRational,
@@ -45,7 +44,7 @@ export function rawToAugSettings(raw: Graph.GraphState): Aug.GraphSettings {
 
 export function rawToDsmMetadata(raw: Graph.GraphState) {
   const dsmMetadataExpr = raw.expressions.list.find(
-    (e) => e.id === "dsm-metadata"
+    (e) => e.id === ID_METADATA
   );
   return migrateToLatest(
     dsmMetadataExpr?.type === "text"
@@ -62,7 +61,7 @@ function rawListToAug(
   const res: Aug.ItemAug[] = [];
   let currentFolder: null | Aug.FolderAug = null;
   for (const item of list) {
-    if (item.id === "dsm-metadata-folder" || item.id === "dsm-metadata") {
+    if (item.id === ID_METADATA_FOLDER || item.id === ID_METADATA) {
       continue;
     }
     if (item.type === "folder") {

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -13,7 +13,7 @@
 
     "target": "es2020",
     "module": "ESNext",
-    "lib": ["ES2024.Object"],
+    "lib": ["ES2024.Object", "ES2023.Array"],
     "baseUrl": ".",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This PR fixes the behavior of Paste Image so that pasted images won't be inserted into special (and secret) folders such as the previous metadata and the geometry folder.