### PR TITLE
Support Dot replacements

### DIFF
--- a/apply-replacements/replacements.md
+++ b/apply-replacements/replacements.md
@@ -67,6 +67,8 @@ Some special pattern tokens match something other than their exact value:
 
 - `$id` matches any identifier name, and lets the variable `id` represent that identifier name.
 - `$` matches any identifier name but ignores the value
+- `$$id` matches any identifier name or a member access consisting of two identifiers joined by a `.`, such as `p.const`.
+  - `$$` does the same but ignores the value.
 - `__range__` matches a balanced sequence of tokens, and lets `range` represent that range of tokens
   - Greedy, matches up to the next close brace
   - Must be followed by a close brace in the pattern

--- a/apply-replacements/tokenize.ts
+++ b/apply-replacements/tokenize.ts
@@ -8,6 +8,10 @@ export type PatternToken =
       value: string;
     }
   | {
+      type: "PatternIdentifierDot";
+      value: string;
+    }
+  | {
       type: "PatternIdentifier";
       value: string;
     };
@@ -135,13 +139,22 @@ function* _patternTokens(str: string, msg: string): Generator<PatternToken> {
 
 function* _patternTokensRaw(str: string): Generator<PatternToken> {
   for (const token of jsTokens(str.trim())) {
-    yield token.type !== "IdentifierName"
-      ? token
-      : /^__\w*__$/.test(token.value)
-        ? { type: "PatternBalanced", value: token.value }
-        : token.value.startsWith("$")
-          ? { type: "PatternIdentifier", value: token.value }
-          : token;
+    yield parseToken(token);
+  }
+}
+
+function parseToken(token: jsTokens.Token): PatternToken {
+  switch (true) {
+    case token.type !== "IdentifierName":
+      return token;
+    case /^__\w*__$/.test(token.value):
+      return { type: "PatternBalanced", value: token.value };
+    case token.value.startsWith("$$"):
+      return { type: "PatternIdentifierDot", value: token.value };
+    case token.value.startsWith("$"):
+      return { type: "PatternIdentifier", value: token.value };
+    default:
+      return token;
   }
 }
 

--- a/apply-replacements/tokenize.ts
+++ b/apply-replacements/tokenize.ts
@@ -143,7 +143,7 @@ function* _patternTokensRaw(str: string): Generator<PatternToken> {
   }
 }
 
-function parseToken(token: jsTokens.Token): PatternToken {
+function parseToken(token: Token): PatternToken {
   switch (true) {
     case token.type !== "IdentifierName":
       return token;

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -67,8 +67,8 @@ $createElement("div", {
   didMount: this.bindFn(this.didMountContainer),
   didUnmount: this.bindFn(this.didUnmountContainer),
   children: $createElement2("div", {
-    class: $createElement3.const("dcg-popover-interior"),
-    role: $createElement3.const("region"),
+    class: $$const("dcg-popover-interior"),
+    role: $$const("region"),
     "aria-label": () => this.controller.s("graphing-calculator-label-tooltip-geometry-settings"),
     children: [__children__]
   })
@@ -79,7 +79,7 @@ $createElement("div", {
 ```js
 __children__,
 $createElement("div", {
-    class: $createElement3.const("dcg-arrow")
+    class: $$const("dcg-arrow")
 }),
 ```
 

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -11,7 +11,7 @@ adding an extra section to the menu view.
 
 *Find* => `key`
 ```js
-{ class: $.const('dcg-iconed-mathquill-row dcg-fill-opacity-row') ____ }
+{ class: $$const('dcg-iconed-mathquill-row dcg-fill-opacity-row') ____ }
 ```
 
 *Find_surrounding_template* `key` => `template`
@@ -21,7 +21,7 @@ adding an extra section to the menu view.
 $createElement(
   'div',
   {
-    class: $.const('dcg-options-menu-content'),
+    class: $$const('dcg-options-menu-content'),
     children: __children__
   }
 )
@@ -51,7 +51,7 @@ Warning: this is partially duplicated above ("Add a fill menu option...").
 
 *Find* => `key`
 ```js
-{ class: $.const('dcg-iconed-mathquill-row dcg-line-opacity-row') ____ }
+{ class: $$const('dcg-iconed-mathquill-row dcg-line-opacity-row') ____ }
 ```
 
 *Find_surrounding_template* `key` => `template`
@@ -61,7 +61,7 @@ Warning: this is partially duplicated above ("Add a fill menu option...").
 $createElement(
   'div',
   {
-    class: $.const('dcg-options-menu-content'),
+    class: $$const('dcg-options-menu-content'),
     children: __children__
   }
 )

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -23,7 +23,7 @@ $createElement("div", {
 *Find* inside `math_item`
 ```js
 $createElement2("div", {
-    class: $.const("dcg-fade-container"),
+    class: $$const("dcg-fade-container"),
     onTapStart: this.bindFn(this.onMouseSelect),
     onTap: this.bindFn(this.onMouseSelect),
     children: [__children__]
@@ -59,7 +59,7 @@ $createElement("div", {
 *Find* inside `folder_item`
 ```js
 $createElement2("div", {
-    class: $.const("dcg-fade-container"),
+    class: $$const("dcg-fade-container"),
     children: [__children__]
 })
 ```

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -56,7 +56,7 @@ Wrap the error message tooltipped-error with a div, using `onTap` to trigger hid
 
 *Find* => `from`
 ```js
-additionalClass: this.const("dcg-tooltipped-error-container"),
+additionalClass: $$const("dcg-tooltipped-error-container"),
 children: __errorTriangle__
 ```
 
@@ -76,7 +76,7 @@ DSM.replaceElement(
 ```js
 $createElement(
   'span',
-  { class: $.const('btns'), children: [__children__] }
+  { class: $$const('btns'), children: [__children__] }
 )
 ```
 

--- a/src/plugins/show-tips/show-tips.replacements
+++ b/src/plugins/show-tips/show-tips.replacements
@@ -11,7 +11,7 @@
 $createElement(
   "div",
   {
-    class: $.const("dcg-expressions-branding"),
+    class: $$const("dcg-expressions-branding"),
     children: __children__
   }
 )

--- a/src/plugins/text-mode/text-mode.replacements
+++ b/src/plugins/text-mode/text-mode.replacements
@@ -28,7 +28,7 @@ isShowKeypadButtonVisible () {
 ```js
 $createElement(
   'div',
-  { class: $.const('dcg-center-buttons') ____ }
+  { class: $$const('dcg-center-buttons') ____ }
 )
 ```
 
@@ -93,7 +93,7 @@ $ImageIconView = class extends $.View {
   init() { ____ }
   template() {
       return $createElement("div", {
-          class: $.const("dcg-expression-icon-container dcg-image-icon-container")
+          class: $$const("dcg-expression-icon-container dcg-image-icon-container")
           ____
       }
 ```


### PR DESCRIPTION
Use two dollar signs like `$$const` to do a match that handles either an identifier like `const` or chained member accesses like `p.const` or `a.b.c.d.e.f`.

Short term purpose is to match both `DCGView.const("abc")` and `const("abc")`, but long-term it provides an easy way to handle any future such minifications that Desmos does.