### PR TITLE
Use Keyed for

### DIFF
--- a/src/DCGView.ts
+++ b/src/DCGView.ts
@@ -67,7 +67,7 @@ abstract class SwitchComponent extends ClassComponent<{
 
 export interface DCGViewModule {
   Components: {
-    For: typeof ForComponent;
+    For: typeof ForComponent | { Keyed: typeof ForComponent };
     If: typeof IfComponent;
     Input: typeof InputComponent;
     Switch: typeof SwitchComponent;

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -133,8 +133,11 @@ export abstract class InlineMathInputViewComponent extends ClassComponent<{
 /** General InlineMathInputView, without any defaults filled in */
 export const InlineMathInputViewGeneral = Fragile.InlineMathInputView;
 
-export const { If, For, IfElse, Input, Switch, SwitchUnion } =
-  DCGView.Components;
+export const { If, IfElse, Input, Switch, SwitchUnion } = DCGView.Components;
+export const For =
+  "Keyed" in DCGView.Components.For
+    ? DCGView.Components.For.Keyed
+    : DCGView.Components.For;
 export function Match<Disc extends { type: string }>(
   discriminant: () => Disc,
   branches: {

--- a/src/core-plugins/expr-action-buttons/components/ActionButtons.tsx
+++ b/src/core-plugins/expr-action-buttons/components/ActionButtons.tsx
@@ -9,9 +9,9 @@ export function ActionButtons(eab: ExprActionButtons, m: ItemModel) {
   return (
     <div class="dsm-action-buttons">
       <For each={() => eab.order()} key={(b) => b.key}>
-        {(b: ActionButton) => (
-          <If predicate={() => b.predicate(m)}>
-            {() => ActionButtonView(b, m)}
+        {(getButton: () => ActionButton) => (
+          <If predicate={() => getButton().predicate(m)}>
+            {() => ActionButtonView(getButton(), m)}
           </If>
         )}
       </For>

--- a/src/core-plugins/pillbox-menus/components/Menu.tsx
+++ b/src/core-plugins/pillbox-menus/components/Menu.tsx
@@ -107,8 +107,8 @@ export default class Menu extends Component<{
               {() => (
                 <div class="dsm-category-container">
                   <For each={() => categoryPlugins[category]} key={(id) => id}>
-                    {(pluginID: PluginID) =>
-                      this.plugin(plugins.get(pluginID)!)
+                    {(getPluginID: () => PluginID) =>
+                      this.plugin(plugins.get(getPluginID())!)
                     }
                   </For>
                 </div>
@@ -258,16 +258,16 @@ function colorListOption(
                   }
                   key={([e, i]) => `${e}:${i}`}
                 >
-                  {([v, i]: [string, number]) => (
+                  {(getPair: () => [value: string, index: number]) => (
                     <div class="dsm-settings-color-list-item-container">
                       <input
                         type="color"
-                        value={v}
+                        value={getPair()[0]}
                         onChange={(e: InputEvent) => {
                           const newValue = (e.target as HTMLInputElement).value;
                           setValue(
                             (settings[item.key] as string[]).map((e, j) =>
-                              j === i ? newValue : e
+                              j === getPair()[1] ? newValue : e
                             )
                           );
                         }}
@@ -276,16 +276,18 @@ function colorListOption(
                         <IconButton
                           onTap={() => {
                             setValue([
-                              ...value().slice(0, i + 1),
+                              ...value().slice(0, getPair()[1] + 1),
                               "#FF0000",
-                              ...value().slice(i + 1),
+                              ...value().slice(getPair()[1] + 1),
                             ]);
                           }}
                           iconClass={"dcg-icon-plus"}
                         ></IconButton>
                         <IconButton
                           onTap={() => {
-                            setValue(value().filter((_, j) => j !== i));
+                            setValue(
+                              value().filter((_, j) => j !== getPair()[1])
+                            );
                           }}
                           iconClass={"dcg-icon-remove"}
                         ></IconButton>

--- a/src/core-plugins/pillbox-menus/components/PillboxContainer.tsx
+++ b/src/core-plugins/pillbox-menus/components/PillboxContainer.tsx
@@ -38,9 +38,9 @@ export class PillboxContainer extends Component<{
         }}
       >
         <For each={() => this.pm.pillboxButtonsOrder} key={(id) => id}>
-          {(id: string) => (
+          {(getId: () => string) => (
             <PillboxButton
-              buttonId={id}
+              buttonId={getId()}
               pm={this.pm}
               horizontal={this.horizontal}
             />

--- a/src/plugins/intellisense/view.tsx
+++ b/src/plugins/intellisense/view.tsx
@@ -74,20 +74,26 @@ export class JumpToDefinitionMenu extends Component<{
                   }
                   key={(e) => e[0].sourceExprIndex}
                 >
-                  {([e, i]: [
-                    JumpToDefinitionMenuInfo["idents"][number],
-                    number,
-                  ]) => (
+                  {(
+                    getPair: () => [
+                      e: JumpToDefinitionMenuInfo["idents"][number],
+                      index: number,
+                    ]
+                  ) => (
                     <li
                       onClick={() => {
-                        this.props.jumpToDefinitionById(e.sourceExprId);
+                        this.props.jumpToDefinitionById(
+                          getPair()[0].sourceExprId
+                        );
                       }}
                       class={() =>
-                        i === this.props.jumpToDefIndex() ? "selected" : ""
+                        getPair()[1] === this.props.jumpToDefIndex()
+                          ? "selected"
+                          : ""
                       }
                     >
                       <DStaticMathquillView
-                        latex={() => e.sourceExprLatex}
+                        latex={() => getPair()[0].sourceExprLatex}
                         config={{}}
                       ></DStaticMathquillView>
                     </li>
@@ -174,8 +180,8 @@ export class FormattedDocstring extends Component<{
           each={() => this.props.docstring().map((e, i) => [e, i] as const)}
           key={() => counter++}
         >
-          {([r, _]: [DocStringRenderable, number]) =>
-            Match(() => r, {
+          {(getPair: () => [DocStringRenderable, number]) =>
+            Match(() => getPair()[0], {
               param: (r) => {
                 const ltx = () =>
                   textModeExprToLatex(this.props.cfg(), r.latex) ?? r.latex;
@@ -269,10 +275,11 @@ export class PartialFunctionCallView extends Component<{
                     }
                     key={(e) => e[0]}
                   >
-                    {(p: [string, number]) => (
+                    {(getPair: () => [string, number]) => (
                       <div
                         class={() =>
-                          this.props.partialFunctionCall()?.paramIndex === p[1]
+                          this.props.partialFunctionCall()?.paramIndex ===
+                          getPair()[1]
                             ? "pfc-param-selected"
                             : "pfc-param"
                         }
@@ -282,9 +289,9 @@ export class PartialFunctionCallView extends Component<{
                           latex={() =>
                             identifierStringToLatexString(
                               this.props.cfg(),
-                              p[0]
+                              getPair()[0]
                             ) +
-                            (p[1] ===
+                            (getPair()[1] ===
                             (this.props.partialFunctionCallIdent()?.params
                               ?.length ?? 0) -
                               1

--- a/src/plugins/pin-expressions/components/PinnedPanel.tsx
+++ b/src/plugins/pin-expressions/components/PinnedPanel.tsx
@@ -19,13 +19,13 @@ export function PinnedPanel(pe: PinExpressions, listView: ListView) {
         }
         key={(model) => (model as any).guid}
       >
-        {(model: any) => (
-          <If predicate={() => pe?.isExpressionPinned(model.id)}>
+        {(model: () => any) => (
+          <If predicate={() => pe?.isExpressionPinned(model().id)}>
             {/** marking as a drag copy causes it not to affect the render shells
              * calculations (all the logic is present already because if the top
              * expression is dragged to the bottom, it shouldn't cause all
              * expressions to render from the top) */}
-            {() => listView.makeDragCopyViewForModel(model)}
+            {() => listView.makeDragCopyViewForModel(model())}
           </If>
         )}
       </For>

--- a/src/utils/utilComponents.tsx
+++ b/src/utils/utilComponents.tsx
@@ -20,7 +20,10 @@ export class IndexFor<T> extends Component<{
         }}
         key={([e]) => this.props.key(e)}
       >
-        {([e, index]: [T, () => number]) => this.props?.children(e, index)}
+        {(getPair: () => [T, () => number]) => {
+          const [elem, index] = getPair();
+          return this.props?.children(elem, index);
+        }}
       </For>
     );
   }


### PR DESCRIPTION
Use `For.Keyed` instead of `For`. The main difference here is that the parameter is a getter instead of the list entry itself. Desmos will be migrating to this being the only way to use `For` and removing `For.Keyed`, so fallback to `For` if `For.Keyed` is not available.

Not the prettiest migrations.