### PR TITLE
Support additional value types in BEV list-count

### DIFF
--- a/src/components/StaticMathQuillView.tsx
+++ b/src/components/StaticMathQuillView.tsx
@@ -1,12 +1,16 @@
-import { DStaticMathquillView } from "./desmosComponents";
+import { DStaticMathquillView, MathQuillConfig } from "./desmosComponents";
 import { Component, jsx } from "#DCGView";
 
 export default class StaticMathquillView extends Component<{
   latex: string;
+  config?: MathQuillConfig;
 }> {
   template() {
     return (
-      <DStaticMathquillView latex={() => this.props.latex()} config={{}} />
+      <DStaticMathquillView
+        latex={() => this.props.latex()}
+        config={() => this.props.config?.() ?? {}}
+      />
     );
   }
 }

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -154,7 +154,7 @@ export function Match<Disc extends { type: string }>(
 
 export abstract class DStaticMathquillViewComponent extends ClassComponent<{
   latex: string;
-  config: any;
+  config: MathQuillConfig;
 }> {}
 
 export const DStaticMathquillView = Fragile.StaticMathquillView;

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -54,9 +54,76 @@ export enum ValueType {
   ListOfPoint3D = 101,
   ListOfDistribution = 10,
   EmptyList = 11,
+  ErrorType = 12,
+  SeedType = 13,
   RGBColor = 14,
   ListOfColor = 15,
-  // omitted
+  Polygon = 16,
+  ListOfPolygon = 17,
+  Segment = 18,
+  ListOfSegment = 19,
+  Circle = 20,
+  ListOfCircle = 21,
+  Arc = 22,
+  ListOfArc = 23,
+  Line = 24,
+  ListOfLine = 25,
+  Ray = 26,
+  ListOfRay = 27,
+  Vector = 34,
+  ListOfVector = 35,
+  Restriction = 36,
+  ListOfRestriction = 37,
+  AngleMarker = 28,
+  ListOfAngleMarker = 29,
+  DirectedAngleMarker = 30,
+  ListOfDirectedAngleMarker = 31,
+  Transformation = 32,
+  ListOfTransformation = 33,
+  Segment3D = 102,
+  ListOfSegment3D = 103,
+  Triangle3D = 104,
+  ListOfTriangle3D = 105,
+  Sphere3D = 106,
+  ListOfSphere3D = 107,
+  Vector3D = 108,
+  ListOfVector3D = 109,
+  Tone = 50,
+  ListOfTone = 51,
+  ConfidenceInterval = 60,
+  ListOfConfidenceInterval = 61,
+  OneSampleTInference = 62,
+  ListOfOneSampleTInference = 63,
+  TwoSampleTInference = 64,
+  ListOfTwoSampleTInference = 65,
+  RegressionTInference = 76,
+  ListOfRegressionTInference = 77,
+  OneSampleZInference = 66,
+  ListOfOneSampleZInference = 67,
+  TwoSampleZInference = 68,
+  ListOfTwoSampleZInference = 69,
+  OneProportionZInference = 70,
+  ListOfOneProportionZInference = 71,
+  TwoProportionZInference = 72,
+  ListOfTwoProportionZInference = 73,
+  HypothesisTest = 74,
+  ListOfHypothesisTest = 75,
+  ChiSquareGoodnessOfFit = 78,
+  ListOfChiSquareGoodnessOfFit = 79,
+  ChiSquareIndependence = 80,
+  ListOfChiSquareIndependence = 81,
+  MapIntervalPoint = 200,
+  MapIntervalComplex = 208,
+  MapIntervalPoint3D = 201,
+  MapInterval2DPoint = 202,
+  MapInterval2DComplex = 209,
+  MapInterval2DPoint3D = 203,
+  ListOfMapIntervalPoint = 204,
+  ListOfMapIntervalComplex = 210,
+  ListOfMapIntervalPoint3D = 205,
+  ListOfMapInterval2DPoint = 206,
+  ListOfMapInterval2DComplex = 211,
+  ListOfMapInterval2DPoint3D = 207,
 }
 
 interface FormulaBase {
@@ -74,17 +141,180 @@ interface NonfolderItemModelBase extends ItemModelBase {
 }
 
 interface ValueTypeMap {
-  [ValueType.EmptyList]: [];
+  [ValueType.Any]: unknown;
   [ValueType.Number]: number;
-  [ValueType.ListOfNumber]: number[];
-  [ValueType.Point]: [number, number];
-  [ValueType.ListOfPoint]: [number, number][];
-  [ValueType.Point3D]: [number, number, number];
-  [ValueType.ListOfPoint3D]: [number, number, number][];
-  [ValueType.Complex]: [number, number];
-  [ValueType.ListOfComplex]: [number, number][];
-  [ValueType.RGBColor]: [number, number, number];
-  [ValueType.ListOfColor]: [number, number, number][];
+  [ValueType.Bool]: boolean;
+  [ValueType.Complex]: [re: number, im: number];
+  [ValueType.ListOfComplex]: Array<ValueTypeMap[ValueType.Complex]>;
+  [ValueType.Point]: [x: number, y: number];
+  [ValueType.Point3D]: [x: number, y: number, z: number];
+  // [ValueType.Distribution]: unknown;
+  [ValueType.Action]: {
+    type: "Action";
+    updateRules: Record<
+      string,
+      TypedConstantValue<Exclude<ValueType, ValueType.Action>>
+    >;
+  };
+  [ValueType.ListOfAny]: Array<ValueTypeMap[ValueType.Any]>;
+  [ValueType.ListOfNumber]: Array<ValueTypeMap[ValueType.Number]>;
+  [ValueType.ListOfBool]: Array<ValueTypeMap[ValueType.Bool]>;
+  [ValueType.ListOfPoint]: Array<ValueTypeMap[ValueType.Point]>;
+  [ValueType.ListOfPoint3D]: Array<ValueTypeMap[ValueType.Point3D]>;
+  // [ValueType.ListOfDistribution]: Array<ValueTypeMap[ValueType.Distribution]>;
+  [ValueType.EmptyList]: [];
+  // couldn't be deduced; may not appear in typed_constant_value.
+  // [ValueType.ErrorType]: unknown;
+  // [ValueType.SeedType]: unknown;
+  [ValueType.RGBColor]: [r: number, g: number, b: number];
+  [ValueType.ListOfColor]: Array<ValueTypeMap[ValueType.RGBColor]>;
+  [ValueType.Polygon]: Array<ValueTypeMap[ValueType.Point]>;
+  [ValueType.ListOfPolygon]: Array<ValueTypeMap[ValueType.Polygon]>;
+  [ValueType.Segment]: [
+    start: ValueTypeMap[ValueType.Point],
+    end: ValueTypeMap[ValueType.Point],
+  ];
+  [ValueType.ListOfSegment]: Array<ValueTypeMap[ValueType.Segment]>;
+  [ValueType.Circle]: [center: ValueTypeMap[ValueType.Point], radius: number];
+  [ValueType.ListOfCircle]: Array<ValueTypeMap[ValueType.Circle]>;
+  [ValueType.Arc]: [
+    p0: ValueTypeMap[ValueType.Point],
+    p1: ValueTypeMap[ValueType.Point],
+    p2: ValueTypeMap[ValueType.Point],
+  ];
+  [ValueType.ListOfArc]: Array<ValueTypeMap[ValueType.Arc]>;
+  [ValueType.Line]: [
+    p0: ValueTypeMap[ValueType.Point],
+    p1: ValueTypeMap[ValueType.Point],
+  ];
+  [ValueType.ListOfLine]: Array<ValueTypeMap[ValueType.Line]>;
+  [ValueType.Ray]: [
+    origin: ValueTypeMap[ValueType.Point],
+    direction: ValueTypeMap[ValueType.Point],
+  ];
+  [ValueType.ListOfRay]: Array<ValueTypeMap[ValueType.Ray]>;
+  [ValueType.Vector]: [
+    start: ValueTypeMap[ValueType.Point],
+    end: ValueTypeMap[ValueType.Point],
+  ];
+  [ValueType.ListOfVector]: Array<ValueTypeMap[ValueType.Vector]>;
+  // [ValueType.Restriction]: unknown;
+  // [ValueType.ListOfRestriction]: Array<ValueTypeMap[ValueType.Restriction]>;
+  [ValueType.AngleMarker]: [
+    vertex: ValueTypeMap[ValueType.Point],
+    startRad: number,
+    sweepRad: number,
+    trigAngleMultiplier: number,
+  ];
+  [ValueType.ListOfAngleMarker]: Array<ValueTypeMap[ValueType.AngleMarker]>;
+  [ValueType.DirectedAngleMarker]: [
+    vertex: ValueTypeMap[ValueType.Point],
+    startRad: number,
+    sweepRad: number,
+    trigAngleMultiplier: number,
+  ];
+  [ValueType.ListOfDirectedAngleMarker]: Array<
+    ValueTypeMap[ValueType.DirectedAngleMarker]
+  >;
+  [ValueType.Transformation]: [
+    linear: ValueTypeMap[ValueType.Complex],
+    translate: ValueTypeMap[ValueType.Complex],
+    conjugate: boolean,
+  ];
+  [ValueType.ListOfTransformation]: Array<
+    ValueTypeMap[ValueType.Transformation]
+  >;
+  [ValueType.Segment3D]: [
+    start: ValueTypeMap[ValueType.Point3D],
+    end: ValueTypeMap[ValueType.Point3D],
+  ];
+  [ValueType.ListOfSegment3D]: Array<ValueTypeMap[ValueType.Segment3D]>;
+  [ValueType.Triangle3D]: [
+    p0: ValueTypeMap[ValueType.Point3D],
+    p1: ValueTypeMap[ValueType.Point3D],
+    p2: ValueTypeMap[ValueType.Point3D],
+  ];
+  [ValueType.ListOfTriangle3D]: Array<ValueTypeMap[ValueType.Triangle3D]>;
+  [ValueType.Sphere3D]: [
+    center: ValueTypeMap[ValueType.Point3D],
+    radius: number,
+  ];
+  [ValueType.ListOfSphere3D]: Array<ValueTypeMap[ValueType.Sphere3D]>;
+  [ValueType.Vector3D]: [
+    start: ValueTypeMap[ValueType.Point3D],
+    end: ValueTypeMap[ValueType.Point3D],
+  ];
+  [ValueType.ListOfVector3D]: Array<ValueTypeMap[ValueType.Vector3D]>;
+  [ValueType.Tone]: [frequency: number, gain: number];
+  [ValueType.ListOfTone]: Array<ValueTypeMap[ValueType.Tone]>;
+  // [ValueType.ConfidenceInterval]: unknown;
+  // [ValueType.ListOfConfidenceInterval]: Array<
+  //   ValueTypeMap[ValueType.ConfidenceInterval]
+  // >;
+  // [ValueType.OneSampleTInference]: unknown;
+  // [ValueType.ListOfOneSampleTInference]: Array<
+  //   ValueTypeMap[ValueType.OneSampleTInference]
+  // >;
+  // [ValueType.TwoSampleTInference]: unknown;
+  // [ValueType.ListOfTwoSampleTInference]: Array<
+  //   ValueTypeMap[ValueType.TwoSampleTInference]
+  // >;
+  // [ValueType.RegressionTInference]: unknown;
+  // [ValueType.ListOfRegressionTInference]: Array<
+  //   ValueTypeMap[ValueType.RegressionTInference]
+  // >;
+  // [ValueType.OneSampleZInference]: unknown;
+  // [ValueType.ListOfOneSampleZInference]: Array<
+  //   ValueTypeMap[ValueType.OneSampleZInference]
+  // >;
+  // [ValueType.TwoSampleZInference]: unknown;
+  // [ValueType.ListOfTwoSampleZInference]: Array<
+  //   ValueTypeMap[ValueType.TwoSampleZInference]
+  // >;
+  // [ValueType.OneProportionZInference]: unknown;
+  // [ValueType.ListOfOneProportionZInference]: Array<
+  //   ValueTypeMap[ValueType.OneProportionZInference]
+  // >;
+  // [ValueType.TwoProportionZInference]: unknown;
+  // [ValueType.ListOfTwoProportionZInference]: Array<
+  //   ValueTypeMap[ValueType.TwoProportionZInference]
+  // >;
+  // [ValueType.HypothesisTest]: unknown;
+  // [ValueType.ListOfHypothesisTest]: Array<
+  //   ValueTypeMap[ValueType.HypothesisTest]
+  // >;
+  // [ValueType.ChiSquareGoodnessOfFit]: unknown;
+  // [ValueType.ListOfChiSquareGoodnessOfFit]: Array<
+  //   ValueTypeMap[ValueType.ChiSquareGoodnessOfFit]
+  // >;
+  // [ValueType.ChiSquareIndependence]: unknown;
+  // [ValueType.ListOfChiSquareIndependence]: Array<
+  //   ValueTypeMap[ValueType.ChiSquareIndependence]
+  // >;
+  // [ValueType.MapIntervalPoint]: unknown;
+  // [ValueType.MapIntervalComplex]: unknown;
+  // [ValueType.MapIntervalPoint3D]: unknown;
+  // [ValueType.MapInterval2DPoint]: unknown;
+  // [ValueType.MapInterval2DComplex]: unknown;
+  // [ValueType.MapInterval2DPoint3D]: unknown;
+  // [ValueType.ListOfMapIntervalPoint]: Array<
+  //   ValueTypeMap[ValueType.MapIntervalPoint]
+  // >;
+  // [ValueType.ListOfMapIntervalComplex]: Array<
+  //   ValueTypeMap[ValueType.MapIntervalComplex]
+  // >;
+  // [ValueType.ListOfMapIntervalPoint3D]: Array<
+  //   ValueTypeMap[ValueType.MapIntervalPoint3D]
+  // >;
+  // [ValueType.ListOfMapInterval2DPoint]: Array<
+  //   ValueTypeMap[ValueType.MapInterval2DPoint]
+  // >;
+  // [ValueType.ListOfMapInterval2DComplex]: Array<
+  //   ValueTypeMap[ValueType.MapInterval2DComplex]
+  // >;
+  // [ValueType.ListOfMapInterval2DPoint3D]: Array<
+  //   ValueTypeMap[ValueType.MapInterval2DPoint3D]
+  // >;
   [key: number]: unknown;
 }
 

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -140,7 +140,7 @@ interface NonfolderItemModelBase extends ItemModelBase {
   dcgView?: ClassComponent;
 }
 
-interface ValueTypeMap {
+export interface ValueTypeMap {
   [ValueType.Any]: unknown;
   [ValueType.Number]: number;
   [ValueType.Bool]: boolean;

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -45,16 +45,41 @@ interface Desmos extends DesmosPublic {
   };
 }
 
+export interface LabelOptionsBase {
+  zeroCutoff?: number;
+  smallCutoff?: number;
+  bigCutoff?: number;
+  digits?: number;
+  displayAsFraction?: boolean;
+  addEllipses?: boolean;
+  spaceConstrained?: boolean;
+  scientificNotationDigits?: number;
+}
+
+type ComponentEmitType = "decimalString" | "latex" | (string & {});
+
 interface Mathtools {
   Label: {
     truncatedLatexLabel: (
-      label: string,
-      labelOptions: {
-        smallCutoff: 0.00001;
-        bigCutoff: 1000000;
-        digits: 5;
-        displayAsFraction: false;
-      }
+      label: number,
+      labelOptions?: LabelOptionsBase
+    ) => string;
+    pointLabel: (
+      label: [number, number],
+      labelOptions?: LabelOptionsBase,
+      emitComponentsAs?: ComponentEmitType
+    ) => string;
+    point3dLabel: (
+      label: [number, number, number],
+      labelOptions?: LabelOptionsBase,
+      emitComponentsAs?: ComponentEmitType
+    ) => string;
+    complexNumberLabel: (
+      label: [number, number],
+      labelOptions?: LabelOptionsBase & {
+        alwaysEmitImaginary?: boolean;
+      },
+      emitComponentsAs?: ComponentEmitType
     ) => string;
   };
   migrateToLatest: (s: GraphState) => GraphState;

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -1,4 +1,5 @@
 import { DCGViewModule } from "../DCGView";
+import Node from "#parsing/parsenode.ts";
 import DSM from "#DSM";
 import {
   CheckboxComponent,
@@ -28,14 +29,19 @@ export interface DWindow extends Window {
     ExpressionView: ExpressionViewComponent;
     ImageIconView: typeof IconViewComponent;
   };
-  Desmos: {
-    Private: {
-      Fragile: typeof Fragile;
-      Mathtools: Mathtools;
-    };
-    MathQuill: {
-      config: (config: MathQuillConfig) => DWindow["Desmos"]["MathQuill"];
-    };
+  Desmos: Desmos;
+}
+
+type DesmosPublic = typeof Desmos;
+interface Desmos extends DesmosPublic {
+  Private: {
+    Fragile: Fragile;
+    Mathtools: Mathtools;
+    Parser: Parser;
+    MathquillConfig: MathquillConfig;
+  };
+  MathQuill: {
+    config: (config: MathQuillConfig) => Desmos["MathQuill"];
   };
 }
 
@@ -54,21 +60,41 @@ interface Mathtools {
   migrateToLatest: (s: GraphState) => GraphState;
 }
 
+export interface Parser {
+  parse: (
+    s: string,
+    config?: {
+      allowDt?: boolean;
+      allowIndex?: boolean;
+      disallowFrac?: boolean;
+      trailingComma?: boolean;
+      seedPrefix?: string;
+      allowIntervalComprehensions?: boolean;
+      disableParentheses?: boolean;
+      disabledFeatures?: string[];
+    }
+  ) => Node;
+}
+
+interface MathquillConfig {
+  getAutoCommands: (options?: {
+    disallowAns?: boolean;
+    disallowFrac?: boolean;
+    additionalCommands?: string[];
+  }) => string;
+  getAutoOperators: (options?: {
+    additionalOperators?: string[];
+    includeGeometryFunctions?: boolean;
+    include3DFunctions?: boolean;
+    newStats?: boolean;
+  }) => string;
+}
+
 declare let window: DWindow;
 
 export default window;
 
-export const Fragile = new Proxy(
-  {},
-  {
-    get(_target, prop) {
-      if ((window as any).Desmos === undefined) return undefined;
-      const fragile = (window as any).Desmos?.Private?.Fragile;
-      if (fragile === undefined) return undefined;
-      return fragile[prop];
-    },
-  }
-) as {
+interface Fragile {
   DCGView: DCGViewModule;
   PromptSliderView: any;
   Checkbox: typeof CheckboxComponent;
@@ -99,21 +125,30 @@ export const Fragile = new Proxy(
     moveItemsTo: (listModel: any, from: number, to: number, n: number) => void;
   };
   currentLanguage: () => string;
-};
+}
+
+export const Fragile = new Proxy(
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  {} as Fragile,
+  {
+    get(_target, prop: keyof Fragile) {
+      return window.Desmos?.Private?.Fragile?.[prop];
+    },
+  }
+);
 
 type Section = "colors-only" | "lines" | "points" | "fill" | "label" | "drag";
 
+type Private = Desmos["Private"];
 export const Private = new Proxy(
-  {},
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  {} as Private,
   {
-    get(_target, prop) {
-      if ((window as any).Desmos === undefined) return undefined;
-      const priv = (window as any).Desmos.Private;
-      if (priv === undefined) return undefined;
-      return priv[prop];
+    get(_target, prop: keyof Private) {
+      return window.Desmos?.Private?.[prop];
     },
   }
-) as any;
+);
 
 /* Object.fromEntries based on https://dev.to/svehla/typescript-object-fromentries-389c */
 type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> };

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -14,7 +14,7 @@ import {
   MathQuillConfig,
 } from "../components/desmosComponents";
 import { GenericSettings, PluginID } from "../plugins";
-import { ItemModel } from "./models";
+import { ItemModel, ValueType, ValueTypeMap } from "./models";
 import { GraphState } from "../../graph-state";
 
 export interface DWindow extends Window {
@@ -61,21 +61,21 @@ type ComponentEmitType = "decimalString" | "latex" | (string & {});
 interface Mathtools {
   Label: {
     truncatedLatexLabel: (
-      label: number,
+      label: ValueTypeMap[ValueType.Number],
       labelOptions?: LabelOptionsBase
     ) => string;
     pointLabel: (
-      label: [number, number],
+      label: ValueTypeMap[ValueType.Point],
       labelOptions?: LabelOptionsBase,
       emitComponentsAs?: ComponentEmitType
     ) => string;
     point3dLabel: (
-      label: [number, number, number],
+      label: ValueTypeMap[ValueType.Point3D],
       labelOptions?: LabelOptionsBase,
       emitComponentsAs?: ComponentEmitType
     ) => string;
     complexNumberLabel: (
-      label: [number, number],
+      label: ValueTypeMap[ValueType.Complex],
       labelOptions?: LabelOptionsBase & {
         alwaysEmitImaginary?: boolean;
       },

--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -118,21 +118,12 @@ Add a value field to "undefined" labels
 if (isNaN($val) || !isFinite($val)) return { type: "undefined" }
 ```
 
-Format complex numbers nicely
-
-*Find*
-```js
-complexNumberLabel: () => $complexNumberLabel,
-```
-
 *Replace* `undefined` with
 ```js
 if (isNaN($val) || !isFinite($val))
   return {
     type: "decimal",
-    value: Array.isArray($val) && $val.length == 2
-      ? $complexNumberLabel($val, {digits: 5})
-      : isNaN($val)
+    value: isNaN($val)
       ? "\\mathrm{NaN}"
       : $val === Infinity
       ? "\\infty"

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -1,54 +1,85 @@
 import { jsx } from "#DCGView";
 import { StaticMathQuillView } from "#components";
-import { Private, TypedConstantValue, ValueType } from "#globals";
+import {
+  LabelOptionsBase,
+  Private,
+  TypedConstantValue,
+  ValueType,
+  ValueTypeMap,
+} from "#globals";
 
-export function ListEvaluation(
-  val: () => TypedConstantValue<
-    | ValueType.EmptyList
-    | ValueType.ListOfNumber
-    | ValueType.ListOfComplex
-    | ValueType.ListOfPoint
-    | ValueType.ListOfPoint3D
-  >
+const labelOptions = {
+  smallCutoff: 0.00001,
+  bigCutoff: 1000000,
+  digits: 5,
+  displayAsFraction: false,
+} satisfies LabelOptionsBase;
+
+const { complexNumberLabel, pointLabel, point3dLabel, truncatedLatexLabel } =
+  Private.Mathtools.Label;
+
+type ListValueType =
+  | ValueType.EmptyList
+  | ValueType.ListOfNumber
+  | ValueType.ListOfComplex
+  | ValueType.ListOfPoint
+  | ValueType.ListOfPoint3D;
+
+type TypedConstantIteratorValue<T extends ListValueType> = T extends T
+  ? {
+      valueType: T;
+      iterator: ArrayIterator<ValueTypeMap[T][number]>;
+    }
+  : never;
+
+function formatLabels<T extends ListValueType>(
+  typedConstantValue: TypedConstantValue<T>
 ) {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const { valueType, iterator } = {
+    valueType: typedConstantValue.valueType,
+    iterator: typedConstantValue.value.values(),
+  } as TypedConstantIteratorValue<T>;
+  switch (valueType) {
+    case ValueType.ListOfComplex:
+      return iterator.map((label) => complexNumberLabel(label, labelOptions));
+    case ValueType.ListOfPoint:
+      return iterator.map((label) => pointLabel(label, labelOptions));
+    case ValueType.ListOfPoint3D:
+      return iterator.map((label) => point3dLabel(label, labelOptions));
+    default:
+      return iterator.map((label) => truncatedLatexLabel(label, labelOptions));
+  }
+}
+
+// https://github.com/tc39/proposal-iterator-helpers/issues/296
+// The result of the iterator helpers is an object with prototype %IteratorHelperPrototype%, which is a closable iterator.
+// So take(n) implicitly calls the 'return' method and closes the iterator. This is unexpected when intending to access to the rest of the iterator.
+function* reusableTake<T>(iterable: Iterator<T>, limit: number) {
+  let i = 0;
+  while (i++ < limit) {
+    const result = iterable.next();
+    if (result.done) break;
+    yield result.value;
+  }
+}
+
+export function ListEvaluation(val: () => TypedConstantValue<ListValueType>) {
   return (
     <div class="dcg-evaluation-view__wrapped-value">
       <StaticMathQuillView
         latex={() => {
           const typedConstantValue = val();
-          const labelOptions = {
-            smallCutoff: 0.00001,
-            bigCutoff: 1000000,
-            digits: 5,
-            displayAsFraction: false,
-          };
-          const formatLabel = (() => {
-            switch (typedConstantValue.valueType) {
-              case ValueType.ListOfComplex:
-                return Private.Mathtools.Label.complexNumberLabel;
-              case ValueType.ListOfPoint:
-                return Private.Mathtools.Label.pointLabel;
-              case ValueType.ListOfPoint3D:
-                return Private.Mathtools.Label.point3dLabel;
-              default:
-                return Private.Mathtools.Label.truncatedLatexLabel;
-            }
-          })();
           const listLength = typedConstantValue.value.length;
           const truncationLength = 20;
-          const labels = typedConstantValue.value
-            .slice(0, truncationLength)
-            .map((label) => formatLabel(label, labelOptions));
-          return (
-            "\\left[" +
-            labels.join(",") +
-            (listLength > truncationLength
-              ? `\\textcolor{gray}{...\\mathit{${
-                  listLength - truncationLength
-                }\\ more}}`
-              : "") +
-            "\\right]"
-          );
+          const labels = formatLabels(typedConstantValue);
+          const labelsToShow = [...reusableTake(labels, truncationLength)];
+
+          return `\\left[${labelsToShow.join(",")}${
+            listLength > truncationLength
+              ? `\\textcolor{gray}{...\\mathit{${listLength - truncationLength}\\ more}}`
+              : ""
+          }\\right]`;
         }}
       />
     </div>

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -18,7 +18,7 @@ export function EvaluateSingleExpression(calc: Calc, s: string): number {
   return evaluateLatex(s, calc.controller.getDegreeMode());
 }
 
-export const autoCommandNames = Private?.MathquillConfig?.getAutoCommands?.();
+export const autoCommands = Private?.MathquillConfig?.getAutoCommands?.();
 export const autoOperatorNames = Private?.MathquillConfig?.getAutoOperators?.();
 
 export function getCurrentGraphTitle(calc: Calc): string | undefined {

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,24 +1,11 @@
-import Node from "#parsing/parsenode.ts";
 import { type Calc, Fragile, Private } from "#globals";
 
 const { evaluateLatex } = Fragile;
 
 export const keys = Fragile.Keys;
 
-export type Parse = (
-  s: string,
-  config?: {
-    allowDt?: boolean;
-    allowIndex?: boolean;
-    disallowFrac?: boolean;
-    trailingComma?: boolean;
-    seedPrefix?: string;
-    allowIntervalComprehensions?: boolean;
-  }
-) => Node;
-
 export function parseDesmosLatex(s: string) {
-  const parseDesmosLatexRaw = Private.Parser.parse as Parse;
+  const parseDesmosLatexRaw = Private.Parser.parse;
   return parseDesmosLatexRaw(s, {
     allowDt: true,
     allowIndex: true,
@@ -31,10 +18,8 @@ export function EvaluateSingleExpression(calc: Calc, s: string): number {
   return evaluateLatex(s, calc.controller.getDegreeMode());
 }
 
-export const autoCommandNames: string =
-  Private.MathquillConfig?.getAutoCommands?.();
-export const autoOperatorNames: string =
-  Private.MathquillConfig?.getAutoOperators?.();
+export const autoCommandNames = Private?.MathquillConfig?.getAutoCommands?.();
+export const autoOperatorNames = Private?.MathquillConfig?.getAutoOperators?.();
 
 export function getCurrentGraphTitle(calc: Calc): string | undefined {
   return calc._calc.globalHotkeys?.mygraphsController?.graphsController?.getCurrentGraphTitle?.();

--- a/text-mode-core/TextModeConfig.ts
+++ b/text-mode-core/TextModeConfig.ts
@@ -1,4 +1,6 @@
-import type { Parse } from "#utils/depUtils";
+import type { Parser } from "src/globals";
+
+type Parse = Parser["parse"];
 
 export interface PublicConfig {
   /** operatorNames affects subscripting */

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -13,7 +13,7 @@
 
     "target": "es2020",
     "module": "ESNext",
-    "lib": ["ES2024.Object"],
+    "lib": ["ES2024.Object", "ESNext.Iterator"],
     "baseUrl": ".",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Fixes crashes when typing lists of polygons, segments, vectors, and such.

- Added detailed types for `Desmos.Private `(a2863e9209459a5b94c1eef61418ed9072bac447) and refactored the label formatting process in a type-safe way and use iterators when mapping formatter functions (e75339c91ddf6eccfd454b9166b26e816406cc30). 
  This change would be useful in the event of a future need to expand the list of values, since iterator mappings are evaluated lazily. These two commits were cherry-picked from branch no-explicit-any (which is still a work in progress).
- Removed the old replacements (7caf5e2d348baab72137806237a0612c144ed0c3).
- Added extra types for `ValueType` and `ValueTypeMap`. Not all types could be deduced, so I need to look into this more.
- Support for displaying list values of additional types. Still wondering what method would be best as for `AngleMarker`, `DirectedAngleMarker` and `Transformation`.