### PR TITLE
Added "Quake Pro" Feature

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -368,3 +368,4 @@ paste-image-error-another-upload-in-progress = Retry after another upload in pro
 ## Quake Pro
 quake-pro-name = Quake Pro
 quake-pro-desc = Allows you to increase the FOV beyond the regular limit.
+quake-opt-multiplier-name = Multiplier

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -364,3 +364,7 @@ paste-image-name = Paste Image
 paste-image-desc = Lets you paste image files to import them at once.
 paste-image-error-images-not-enabled = Image insertion is not enabled for this graph.
 paste-image-error-another-upload-in-progress = Retry after another upload in progress is completed.
+
+## Quake Pro
+quake-pro-name = Quake Pro
+quake-pro-desc = Allows you to increase the FOV beyond the regular limit.

--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -367,5 +367,6 @@ paste-image-error-another-upload-in-progress = Retry after another upload in pro
 
 ## Quake Pro
 quake-pro-name = Quake Pro
-quake-pro-desc = Allows you to increase the FOV beyond the regular limit.
-quake-opt-multiplier-name = Multiplier
+quake-pro-desc = Allows you to increase the Field of View beyond the 3D calculator's regular limit.
+quake-pro-opt-magnification-name = Zoom Multiplier
+quake-pro-opt-magnification-desc = Increase the viewport's zoom limit by using this as the multiplier.

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
     "eslint-rules": {
       "name": "@desmodder/eslint-rules",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^8.26.0",

--- a/src/core-plugins/pillbox-menus/components/Menu.tsx
+++ b/src/core-plugins/pillbox-menus/components/Menu.tsx
@@ -57,6 +57,7 @@ const categoryPlugins: Record<string, PluginID[]> = {
     "compact-view",
     "multiline",
     "syntax-highlighting",
+    "quake-pro",
   ],
   integrations: ["wakatime"],
 };

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -234,6 +234,7 @@ export interface Grapher3d {
   transition: {
     duration: number;
   };
+  redrawAllLayers: () => void;
 }
 
 export type Scale = "linear" | "logarithmic";

--- a/src/plugins/index-replacements.ts
+++ b/src/plugins/index-replacements.ts
@@ -13,6 +13,7 @@ import showTips from "#plugins/show-tips/show-tips.replacements";
 import syntaxHighlighting from "#plugins/syntax-highlighting/syntax-highlighting.replacements";
 import textMode from "#plugins/text-mode/text-mode.replacements";
 import insertPanels from "../preload/moduleOverrides/insert-panels.replacements";
+import quakePro from "#plugins/quake-pro/quake-pro.replacements";
 
 export default [
   insertPanels,
@@ -30,4 +31,5 @@ export default [
   rightClickTray,
   codeGolf,
   syntaxHighlighting,
+  quakePro,
 ];

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -30,6 +30,7 @@ import Wakatime from "./wakatime";
 import WolframToDesmos from "./wolfram2desmos";
 import BetterNavigation from "./better-navigation";
 import OverrideKeystroke from "../core-plugins/override-keystroke";
+import quakePro from "./quake-pro";
 import { DispatchedEvent } from "src/globals/extra-actions";
 
 interface ConfigItemGeneric {
@@ -149,6 +150,7 @@ export const keyToPlugin = {
   syntaxHighlighting: SyntaxHighlighting,
   betterNavigation: BetterNavigation,
   pasteImage: PasteImage,
+  quakePro: quakePro,
 } satisfies Record<string, Plugin<any>>;
 
 export const pluginList = Object.values(keyToPlugin);
@@ -204,6 +206,7 @@ export class TransparentPlugins implements KeyToPluginInstance {
   get syntaxHighlighting () { return this.ep["syntax-highlighting"]}
   get betterNavigation () { return this.ep["better-navigation"]} 
   get pasteImage () { return this.ep["paste-image"]; }
+  get quakePro () { return this.ep["quake-pro"]; }
 }
 
 export type IDToPluginSettings = {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -150,7 +150,7 @@ export const keyToPlugin = {
   syntaxHighlighting: SyntaxHighlighting,
   betterNavigation: BetterNavigation,
   pasteImage: PasteImage,
-  quakePro: quakePro,
+  quakePro,
 } satisfies Record<string, Plugin<any>>;
 
 export const pluginList = Object.values(keyToPlugin);

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -29,8 +29,8 @@ import VideoCreator from "./video-creator";
 import Wakatime from "./wakatime";
 import WolframToDesmos from "./wolfram2desmos";
 import BetterNavigation from "./better-navigation";
+import QuakePro from "./quake-pro";
 import OverrideKeystroke from "../core-plugins/override-keystroke";
-import quakePro from "./quake-pro";
 import { DispatchedEvent } from "src/globals/extra-actions";
 
 interface ConfigItemGeneric {
@@ -150,7 +150,7 @@ export const keyToPlugin = {
   syntaxHighlighting: SyntaxHighlighting,
   betterNavigation: BetterNavigation,
   pasteImage: PasteImage,
-  quakePro,
+  quakePro: QuakePro,
 } satisfies Record<string, Plugin<any>>;
 
 export const pluginList = Object.values(keyToPlugin);

--- a/src/plugins/quake-pro/config.ts
+++ b/src/plugins/quake-pro/config.ts
@@ -1,9 +1,9 @@
 export const configList = [
   {
-    key: "multiplier",
+    key: "magnification",
     type: "number",
-    default: 1.0,
-    min: 0.1,
+    default: 1,
+    min: 1,
     max: 10,
     step: 0.1,
   },
@@ -12,5 +12,5 @@ export const configList = [
 ] as const;
 
 export interface Config {
-  multiplier: number;
+  magnification: number;
 }

--- a/src/plugins/quake-pro/config.ts
+++ b/src/plugins/quake-pro/config.ts
@@ -1,0 +1,16 @@
+export const configList = [
+  {
+    key: "multiplier",
+    type: "number",
+    default: 1.0,
+    min: 0.1,
+    max: 10,
+    step: 0.1,
+  },
+  // `as const` ensures that the key values can be used as types
+  // instead of the type 'string'
+] as const;
+
+export interface Config {
+  multiplier: number;
+}

--- a/src/plugins/quake-pro/config.ts
+++ b/src/plugins/quake-pro/config.ts
@@ -2,7 +2,7 @@ export const configList = [
   {
     key: "magnification",
     type: "number",
-    default: 1,
+    default: 3,
     min: 1,
     max: 30,
     step: 0.1,

--- a/src/plugins/quake-pro/config.ts
+++ b/src/plugins/quake-pro/config.ts
@@ -4,11 +4,9 @@ export const configList = [
     type: "number",
     default: 1,
     min: 1,
-    max: 10,
+    max: 30,
     step: 0.1,
   },
-  // `as const` ensures that the key values can be used as types
-  // instead of the type 'string'
 ] as const;
 
 export interface Config {

--- a/src/plugins/quake-pro/index.ts
+++ b/src/plugins/quake-pro/index.ts
@@ -1,0 +1,26 @@
+import { PluginController } from "../PluginController";
+
+export default class quakePro extends PluginController {
+  static id = "quake-pro" as const;
+  static enabledByDefault = true;
+
+  oldName = "";
+
+  afterEnable() {
+    const headerElement = getHeaderElement();
+    if (headerElement === null) return;
+    const text = headerElement.innerText;
+    if (text !== undefined) this.oldName = text;
+    headerElement.innerText = "DesModder ♥";
+  }
+
+  afterDisable() {
+    const headerElement = getHeaderElement();
+    if (headerElement === null) return;
+    headerElement.innerText = this.oldName;
+  }
+}
+
+function getHeaderElement(): HTMLElement | null {
+  return document.querySelector(".header-account-name");
+}

--- a/src/plugins/quake-pro/index.ts
+++ b/src/plugins/quake-pro/index.ts
@@ -6,6 +6,7 @@ export default class quakePro extends PluginController<Config> {
   static enabledByDefault = true;
   static config = configList;
 
+  magnification = 1;
   oldName = "";
 
   afterEnable() {

--- a/src/plugins/quake-pro/index.ts
+++ b/src/plugins/quake-pro/index.ts
@@ -7,23 +7,25 @@ export default class quakePro extends PluginController<Config> {
   static config = configList;
 
   magnification = 1;
-  oldName = "";
 
   afterEnable() {
-    const headerElement = getHeaderElement();
-    if (headerElement === null) return;
-    const text = headerElement.innerText;
-    if (text !== undefined) this.oldName = text;
-    headerElement.innerText = "DesModder ♥";
+    this.magnification = this.settings.magnification;
+    this.redrawAllLayers();
+  }
+
+  afterConfigChange() {
+    this.magnification = this.settings.magnification;
+    this.redrawAllLayers();
   }
 
   afterDisable() {
-    const headerElement = getHeaderElement();
-    if (headerElement === null) return;
-    headerElement.innerText = this.oldName;
+    this.magnification = 1;
+    this.redrawAllLayers();
   }
-}
 
-function getHeaderElement(): HTMLElement | null {
-  return document.querySelector(".header-account-name");
+  redrawAllLayers() {
+    const { grapher3d } = this.cc;
+    if (!grapher3d) return;
+    grapher3d.redrawAllLayers();
+  }
 }

--- a/src/plugins/quake-pro/index.ts
+++ b/src/plugins/quake-pro/index.ts
@@ -1,8 +1,10 @@
 import { PluginController } from "../PluginController";
+import { Config, configList } from "./config";
 
-export default class quakePro extends PluginController {
+export default class quakePro extends PluginController<Config> {
   static id = "quake-pro" as const;
   static enabledByDefault = true;
+  static config = configList;
 
   oldName = "";
 

--- a/src/plugins/quake-pro/index.ts
+++ b/src/plugins/quake-pro/index.ts
@@ -3,7 +3,7 @@ import { Config, configList } from "./config";
 
 export default class quakePro extends PluginController<Config> {
   static id = "quake-pro" as const;
-  static enabledByDefault = true;
+  static enabledByDefault = false;
   static config = configList;
 
   magnification = 1;

--- a/src/plugins/quake-pro/quake-pro.replacements
+++ b/src/plugins/quake-pro/quake-pro.replacements
@@ -2,55 +2,44 @@
 
 *plugin* `quake-pro`
 
-## Adjust the FOV slider
 
-*Description* `Divide getPerspectiveValue() to normalize the FOV slider.`
-
-
-*Find* => `from`
-```js
-return this.controller.getPerspectiveDistortion() - 1
-```
-
-
-*Replace* `from` with
-```js
-let multiplier = DSM.pluginSettings["quake-pro"].multiplier;
-return this.controller.getPerspectiveDistortion() / multiplier - 1
-```
-
-
-
-## Increase the camera FOV
+## Increase the FOV of the camera
 
 *Description* `Multiply getPerspectiveDistortion() to increase the viewport FOV.`
 
 *Find* => `from`
 ```js
-let $e = this.graphSettings.config.perspectiveDistortion;
-return isNaN($e) ? 1 : $e < 1e-4 ? 0 : $__dcg_shared_module_exports__['bc']($e, 0, $yk)
+{
+  let $e = this.graphSettings.config.perspectiveDistortion;
+  return __return__
+}
 ```
 
 *Replace* `from` with
 ```js
-let multiplier = DSM.pluginSettings["quake-pro"].multiplier;
-
-let $e = this.graphSettings.config.perspectiveDistortion;
-return isNaN($e) ? 1 : $e < 1e-4 ? 0 : $__dcg_shared_module_exports__['bc']($e, 0, $yk) * multiplier
+{
+  let $e = this.graphSettings.config.perspectiveDistortion;
+  // Multiply result to magnify.
+  return __return__ * DSM.pluginSettings["quake-pro"].magnification;
+  
+}
 ```
 
 
-*Find* => `potential`
+## Adjust the FOV of the slider
+
+*Description* `Divide getPerspectiveValue() to normalize the FOV slider in the settings menu.`
+
+*Find* => `from`
 ```js
-this.cameraDistance = $OP / $perspectiveDistortion,
-this.camera.position.set(-this.cameraDistance, 0, 0),
-this.camera.fov = $mathAtan($perspectiveDistortion * $mathTan($convertToRadian * $aspectRatio)) / $convertToRadian
+{
+  return this.controller.getPerspectiveDistortion() - 1
+}
 ```
 
-*Replace* `potential` with
+*Replace* `from` with
 ```js
-
-__potential__
-
+{
+  return this.controller.getPerspectiveDistortion() / DSM.pluginSettings["quake-pro"].magnification - 1
+}
 ```
-

--- a/src/plugins/quake-pro/quake-pro.replacements
+++ b/src/plugins/quake-pro/quake-pro.replacements
@@ -1,0 +1,29 @@
+# Replacements for Quake Pro
+
+*plugin* `quake-pro`
+
+## Add a character count to each expression in the exppanel
+
+*Description* `Show how many characters used by an expression in the exppanel`
+
+*Find* => `thingy`
+```js
+case "set-perspective-distortion":
+{
+    this.getGraphSettings().config.setProperty("perspectiveDistortion", $e.value),
+    ($I = this.grapher3d) == null || $I.redrawAllLayers();
+    break
+}
+```
+
+
+*Replace* `thingy` with
+```js
+case "set-perspective-distortion":
+{
+    console.log("howdy mister!")
+    this.getGraphSettings().config.setProperty("perspectiveDistortion", $e.value),
+    ($I = this.grapher3d) == null || $I.redrawAllLayers();
+    break
+}
+```

--- a/src/plugins/quake-pro/quake-pro.replacements
+++ b/src/plugins/quake-pro/quake-pro.replacements
@@ -2,40 +2,55 @@
 
 *plugin* `quake-pro`
 
-## Add a character count to each expression in the exppanel
+## Adjust the FOV slider
 
-*Description* `Show how many characters used by an expression in the exppanel`
+*Description* `Divide getPerspectiveValue() to normalize the FOV slider.`
 
-*Find* => `thingy`
+
+*Find* => `from`
 ```js
-case "set-perspective-distortion":
-{
-    this.getGraphSettings().config.setProperty("perspectiveDistortion", $e.value),
-    ($I = this.grapher3d) == null || $I.redrawAllLayers();
-    break
-}
+return this.controller.getPerspectiveDistortion() - 1
 ```
 
 
-*Replace* `thingy` with
+*Replace* `from` with
 ```js
-case "set-perspective-distortion":
-{
-    this.getGraphSettings().config.setProperty("perspectiveDistortion", $e.value *3 ),
-    ($I = this.grapher3d) == null || $I.redrawAllLayers();
-
-    console.log($I);
-    break
-}
+let multiplier = DSM.pluginSettings["quake-pro"].multiplier;
+return this.controller.getPerspectiveDistortion() / multiplier - 1
 ```
+
+
+
+## Increase the camera FOV
+
+*Description* `Multiply getPerspectiveDistortion() to increase the viewport FOV.`
+
+*Find* => `from`
+```js
+let $e = this.graphSettings.config.perspectiveDistortion;
+return isNaN($e) ? 1 : $e < 1e-4 ? 0 : $__dcg_shared_module_exports__['bc']($e, 0, $yk)
+```
+
+*Replace* `from` with
+```js
+let multiplier = DSM.pluginSettings["quake-pro"].multiplier;
+
+let $e = this.graphSettings.config.perspectiveDistortion;
+return isNaN($e) ? 1 : $e < 1e-4 ? 0 : $__dcg_shared_module_exports__['bc']($e, 0, $yk) * multiplier
+```
+
 
 *Find* => `potential`
 ```js
-this.camera.fov = $Oae($t * $Nz($o * $i)) / $o
+this.cameraDistance = $OP / $perspectiveDistortion,
+this.camera.position.set(-this.cameraDistance, 0, 0),
+this.camera.fov = $mathAtan($perspectiveDistortion * $mathTan($convertToRadian * $aspectRatio)) / $convertToRadian
 ```
 
 *Replace* `potential` with
 ```js
-console.log("BEING TRIGGERED")
-this.camera.fov = 3*$Oae($t * $Nz($o * $i)) / $o
+
+__potential__
+
 ```
+

--- a/src/plugins/quake-pro/quake-pro.replacements
+++ b/src/plugins/quake-pro/quake-pro.replacements
@@ -19,7 +19,7 @@
 ```js
 {
   let $e = this.graphSettings.config.perspectiveDistortion;
-  return __return__ * (DSM.quakePro?.magnification ?? 1);
+  return (__return__) * (DSM.quakePro?.magnification ?? 1);
 }
 ```
 

--- a/src/plugins/quake-pro/quake-pro.replacements
+++ b/src/plugins/quake-pro/quake-pro.replacements
@@ -21,9 +21,21 @@ case "set-perspective-distortion":
 ```js
 case "set-perspective-distortion":
 {
-    console.log("howdy mister!")
-    this.getGraphSettings().config.setProperty("perspectiveDistortion", $e.value),
+    this.getGraphSettings().config.setProperty("perspectiveDistortion", $e.value *3 ),
     ($I = this.grapher3d) == null || $I.redrawAllLayers();
+
+    console.log($I);
     break
 }
+```
+
+*Find* => `potential`
+```js
+this.camera.fov = $Oae($t * $Nz($o * $i)) / $o
+```
+
+*Replace* `potential` with
+```js
+console.log("BEING TRIGGERED")
+this.camera.fov = 3*$Oae($t * $Nz($o * $i)) / $o
 ```

--- a/src/plugins/quake-pro/quake-pro.replacements
+++ b/src/plugins/quake-pro/quake-pro.replacements
@@ -19,9 +19,7 @@
 ```js
 {
   let $e = this.graphSettings.config.perspectiveDistortion;
-  // Multiply result to magnify.
-  return __return__ * DSM.pluginSettings["quake-pro"].magnification;
-  
+  return __return__ * (DSM.quakePro?.magnification ?? 1);
 }
 ```
 
@@ -40,6 +38,6 @@
 *Replace* `from` with
 ```js
 {
-  return this.controller.getPerspectiveDistortion() / DSM.pluginSettings["quake-pro"].magnification - 1
+  return this.controller.getPerspectiveDistortion() / (DSM.quakePro?.magnification ?? 1) - 1
 }
 ```

--- a/src/preload/moduleReplacements.ts
+++ b/src/preload/moduleReplacements.ts
@@ -36,6 +36,7 @@ const pluginNames = [
   "multiline",
   "intellisense",
   "override-keystroke",
+  "quake-pro",
 ];
 
 replacements.forEach((r) => {


### PR DESCRIPTION
This feature introduces an ability to increase the Field of View of the 3D calculator beyond the regular limit.

The name comes from FOV setting in Minecraft, where if you maximize the viewport, its named as "Quake Pro". Can rename it to anything you like, i found this catchy.

The method is to multiply anything related to `perspectiveDistortion` when it comes to rendering. This will retain vanilla behavior, albeit with a higher magnification limit.

(Thanks to @SlimRunner for teaching me how to do replacements!!!)

<img width="1392" alt="feature screenshot" src="https://github.com/user-attachments/assets/67e4fff8-d219-45cf-b106-49b474a2af45" />