### PR TITLE
Robustify replacements

### DIFF
--- a/apply-replacements/applyReplacement.ts
+++ b/apply-replacements/applyReplacement.ts
@@ -427,18 +427,20 @@ function findPattern(
   if (found === null) {
     const s = inside.start;
     const len = inside.length;
-    throw new Error(
+    const msg =
       `Pattern not found: ${fullPattern.map((v) => v.value).join("")} ` +
-        `in {start: ${s}, length: ${len}}\n` +
-        str
-          .slice(s, s + 20)
-          .concat({ value: " … " } as any)
-          .concat(str.slice(s + len - 20, s + len))
-          .filter((v) => v.type !== "MultiLineComment")
-          .map((v) => (v.value.length < 100 ? v.value : "[long token]"))
-          .join("")
-          .replace(/\n{2,}/g, "\n")
-    );
+      `in {start: ${s}, length: ${len}}\n` +
+      str
+        .slice(s, s + 20)
+        .concat({ value: " … " } as any)
+        .concat(str.slice(s + len - 20, s + len))
+        .filter((v) => v.type !== "MultiLineComment")
+        .map((v) => (v.value.length < 100 ? v.value : "[long token]"))
+        .join("")
+        .replace(/\n{2,}/g, "\n");
+    (window as any).DSM_panics ??= [];
+    (window as any).DSM_panics.push(msg);
+    throw new Error(msg);
   }
   return found;
 }

--- a/apply-replacements/replacements.md
+++ b/apply-replacements/replacements.md
@@ -73,6 +73,8 @@ Some special pattern tokens match something other than their exact value:
   - Greedy, matches up to the next close brace
   - Must be followed by a close brace in the pattern
 - `____` matches a balanced sequence of code but ignores the value
+- `____$` matches a balanced sequence of tokens but is non-greedy.
+  - Note for simplicity of implementation, there is no back-tracking. Make sure the token after this is sufficiently unique.
 
 The patterns bind names (`id` and `range`) in these bulleted examples. They get placed into the scope of the block in which the pattern appears; they do not get returned as return values. What this means is these carry over to later patterns in the same block.
 

--- a/apply-replacements/tokenize.ts
+++ b/apply-replacements/tokenize.ts
@@ -8,6 +8,10 @@ export type PatternToken =
       value: string;
     }
   | {
+      type: "PatternBalancedNonGreedy";
+      value: string;
+    }
+  | {
       type: "PatternIdentifierDot";
       value: string;
     }
@@ -149,6 +153,8 @@ function parseToken(token: Token): PatternToken {
       return token;
     case /^__\w*__$/.test(token.value):
       return { type: "PatternBalanced", value: token.value };
+    case /^__\w*__\$$/.test(token.value):
+      return { type: "PatternBalancedNonGreedy", value: token.value };
     case token.value.startsWith("$$"):
       return { type: "PatternIdentifierDot", value: token.value };
     case token.value.startsWith("$"):

--- a/src/core-plugins/pillbox-menus/pillbox-menus.replacements
+++ b/src/core-plugins/pillbox-menus/pillbox-menus.replacements
@@ -60,16 +60,11 @@ It should be on the left to avoid covering up all the DesModder config stuff.
 $createElement("div", {
   class: () => ({
       "dcg-geometry-settings-container": !0,
-      "dcg-popover": !0,
       __classes__
   }),
-  style: this.bindFn(this.getContainerStyle),
-  didMount: this.bindFn(this.didMountContainer),
-  didUnmount: this.bindFn(this.didUnmountContainer),
+  ____$
   children: $createElement2("div", {
-    class: $$const("dcg-popover-interior"),
-    role: $$const("region"),
-    "aria-label": () => this.controller.s("graphing-calculator-label-tooltip-geometry-settings"),
+    ____$
     children: [__children__]
   })
 })
@@ -79,7 +74,7 @@ $createElement("div", {
 ```js
 __children__,
 $createElement("div", {
-    class: $$const("dcg-arrow")
+    class: () => "dcg-arrow"
 }),
 ```
 

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -151,63 +151,39 @@ addStatement($stmt) {
 
 *worker_only*
 
-*Find*
+*Find* => `branchesReplacement`
 ```js
-.shader = $emitGLSL($t, 0)
-```
-
-*Find*
-
-```js
-function $_graphFuncSubroutine(
-  $graphMode,
-  {
-    viewState: $,
-    node: $node,
-    concrete: $,
-    graphInfo: $,
-    policy: $,
-    styleBroadcastStrategy: $
-  }
-){
-  let $ = $.valueType === $;
-  __graph__
+branchesReplacement: function (____) {
+  ____
 }
 ```
 
-The code loops over the different IR objects `$ir`.
+*Replace* `branchesReplacement` with
 
-*Find* inside `graph` => `compute2d`
 ```js
-let $branch = $c({
-  viewState: $viewState,
-  graphInfo: $graphInfo,
-  compiled: $compiled,
-  derivative: $derivative
-})
-```
-
-*Find* inside `graph`
-```js
-$ = $concrete.toImplicitBool()
-```
-
-*Replace* `compute2d` with
-```js
-if ($node.userData.glesmos) {
+branchesReplacement: function (
+  graphProps,
+  concrete,
+  graphInfo,
+  emitGLSL
+) {
+  const { userData } = graphProps;
+  if (!userData.glesmos)
+    return undefined;
+  const isEquality = graphInfo.operator === '=';
   const lines =
-    $node.userData.lines !== false &&
-    (!$node.isInequality() || $node.userData.glesmosLinesConfirmed);
+    userData.lines !== false &&
+    (isEquality || userData.glesmosLinesConfirmed);
   let derivativeX, derivativeY;
   if (lines) {
     try {
-      derivativeX = $concrete.takeDerivative('x');
-      derivativeY = $concrete.takeDerivative('y');
+      derivativeX = concrete.takeDerivative('x');
+      derivativeY = concrete.takeDerivative('y');
     } catch {}
   }
   const newCompiled = self.dsm_compileGLesmos(
-    $concrete, $graphInfo.color, $graphInfo.fillOpacity ?? 0, $graphInfo.lineOpacity, $node.userData.lines !== false ? $graphInfo.lineWidth : 0.0,
-    derivativeX, derivativeY, $emitGLSL
+    concrete, graphInfo.color, graphInfo.fillOpacity ?? 0, graphInfo.lineOpacity, userData.lines !== false ? graphInfo.lineWidth : 0.0,
+    derivativeX, derivativeY, emitGLSL
   );
   return [{
     graphMode: "GLesmos",
@@ -216,5 +192,4 @@ if ($node.userData.glesmos) {
     poi: {}
   }]
 }
-__compute2d__
 ```

--- a/src/plugins/code-golf/code-golf.replacements
+++ b/src/plugins/code-golf/code-golf.replacements
@@ -10,10 +10,10 @@
 ```js
 $createElement("div", {
     class: ()=>({
-        "dcg-do-not-blur": !0,
-        "dcg-expressionitem": !0,
-        "dcg-highlighted-expressionitem": this.controller.isExpressionHighlighted(this.id),
-        "dcg-mathitem": !0,
+        ____$
+        "dcg-highlighted-expressionitem"
+        ____$
+        "dcg-mathitem"
         ____
     })
     ____
@@ -24,8 +24,7 @@ $createElement("div", {
 ```js
 $createElement2("div", {
     class: $$const("dcg-fade-container"),
-    onTapStart: this.bindFn(this.onMouseSelect),
-    onTap: this.bindFn(this.onMouseSelect),
+    ____$
     children: [__children__]
 })
 ```
@@ -44,11 +43,10 @@ DSM.insertElement(() => ( DSM.codeGolf?.expressionItemCostPanel(this.model, this
 ```js
 $createElement("div", {
     class: () => ({
-        "dcg-do-not-blur": !0,
-        "dcg-expressionitem": !0,
-        "dcg-highlighted-expressionitem": this.controller.isExpressionHighlighted(this.id),
-        "dcg-readonly": this.controller.isItemReadonly(this.id),
-        "dcg-expressionfolder": !0,
+        ____$
+        "dcg-highlighted-expressionitem"
+        ____$
+        "dcg-expressionfolder"
         ____
     })
     ____

--- a/src/tests/smoke.int.test.ts
+++ b/src/tests/smoke.int.test.ts
@@ -5,6 +5,10 @@ describe("Initial load", () => {
   //  I'm just trying two simple tests to make sure the browser remains.
   testWithPage("Shows DesModder Button", async (driver) => {
     await driver.assertSelector(".dsm-pillbox-and-popover");
+    const panics = await driver.evaluate(
+      () => (window as any).DSM_panics ?? []
+    );
+    expect(panics).toEqual([]);
     await driver.assertSelectorNot("#dsm-panic-popover");
     return clean;
   });


### PR DESCRIPTION
1. Change hook for GLesmos replacements (it's currently broken, this will fix)
2. Include panic messages in assertion errors, so the integration tests will actually say what match failed.
3. Add and use a non-greedy match that makes skipping over classes easier. It's not robust against rearranging the classes, but this is a decent improvement.