### PR TITLE
Add empty braces after `\infty` to avoid unexpected parsing of the command

### DIFF
--- a/src/plugins/better-evaluation-view/better-evaluation-view.replacements
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.replacements
@@ -145,9 +145,9 @@ if (isNaN($val) || !isFinite($val)) {
       isNaN($val)
       ? "\\mathrm{NaN}"
       : $val === Infinity
-      ? "\\infty"
+      ? "\\infty{}"
       : $val === -Infinity
-      ? "-\\infty"
+      ? "-\\infty{}"
       : "undefined"
   };
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c7638916-56ce-459a-960b-509eeb586f84)

Currently, you can't use `i * ∞` to represent `i * ∞` because it evaluates to `NaN + NaNi` (I assume that's because desmos can't distinguish `i * ∞` from `(0 + i) * ∞`), but `√-∞` can be used instead. However, the evaluation view shows an empty box because the latex `\inftyi` returned by the label function is invalid.

This PR fixes the behavior of `numericLabel` to correctly show the evaluation for complex numbers with an imaginary part of +/- infinity.