### PR TITLE
Always keep text and thickened brackets white inside a base case

### DIFF
--- a/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
+++ b/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
@@ -29,54 +29,38 @@ export function generateBracketPairColorizationCSS(
     .join(", ")})`;
 
   return [
+    /*
+      Colorization exceptions:
+
+      - Children of a \textcolor{} or base case in label or expression
+      - Standalone commas like in `(0,0),(1,2)`
+        Otherwise they would get the color of the first color in the list.
+    */
     `
     .dcg-mq-root-block {
-        --bracket-depth1: 0;
-        --bracket-depth2: 0;
-    }
-    `,
-    `
-    .dcg-mq-bracket-container {
+      --bracket-depth1: 0;
+      --bracket-depth2: 0;
+
+      .dcg-mq-bracket-container {
         --bracket-depth2: var(--bracket-depth1);
-        color: ${colorMaker};
-    }
-    `,
-    // Reset color on children of a \textcolor{} or base case in label or expression
-    `
-    .dcg-mq-textcolor .dcg-mq-bracket-container,
-    .dcg-base-case-btn .dcg-mq-bracket-container {
-      color: unset;
-    }
-    `,
-    `
-    .dcg-mq-bracket-l path, .dcg-mq-bracket-r path {
-        stroke-width: ${thickenBrackets}%;
-        stroke: ${colorMaker};
-    }
-    `,
-    `
-    .dsm-mq-syntax-comma {
-        color: ${colorMaker};
-    }
-    `,
-    // Reset color on standalone commas, like in `(0,0),(1,2)`. Otherwise they
-    // would get the color of the first color in the list.
-    `
-    .dcg-mq-root-block > .dsm-mq-syntax-comma {
-        color: unset
-    }
-    `,
-    // Reset color on children of a \textcolor{} or base case in label or expression
-    `
-    .dcg-mq-textcolor .dsm-mq-syntax-comma,
-    .dcg-base-case-btn .dsm-mq-syntax-comma {
-      color: unset;
-    }
-    `,
-    `
-    .dcg-mq-bracket-middle {
-        --bracket-depth1: calc(var(--bracket-depth2) + 1);
-        ${colorInText ? "" : "color: black;"}
+
+        &:not(.dcg-mq-textcolor *, .dcg-base-case-btn *) {
+          .dcg-mq-paren,
+          .dsm-mq-syntax-comma,
+          *${colorInText ? "" : ":not(.dcg-mq-bracket-middle, .dcg-mq-bracket-middle *)"} {
+            color: ${colorMaker};
+          }
+        }
+
+        .dcg-mq-paren path {
+          stroke-width: ${thickenBrackets}%;
+          stroke: currentColor;
+        }
+
+        .dcg-mq-bracket-middle {
+          --bracket-depth1: calc(var(--bracket-depth2) + 1);
+        }
+      }
     }
     `,
   ];

--- a/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
+++ b/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
@@ -3,22 +3,22 @@ export function generateBracketPairColorizationCSS(
   colorInText: boolean,
   thickenBrackets: number
 ) {
-  if (!colors[0]) return [];
-
-  const colorMaker = `rgb(${colors[0]
+  const colorMaker = `rgb(${[0, 1, 2]
     .map(
-      (_, i) =>
-        `calc(${colors
-          .map((col, colindex) => {
-            const channel = col[i];
-            // Uses the periodic nature of mod to only color every Nth bracket a given color
+      (i) =>
+        `calc(${
+          colors
+            .map((col, colindex) => {
+              const channel = col[i];
+              // Uses the periodic nature of mod to only color every Nth bracket a given color
 
-            // All colors are multiplied by this "mod factor" and then added together
-            // to only "pick" the correct color.
+              // All colors are multiplied by this "mod factor" and then added together
+              // to only "pick" the correct color.
 
-            return `${channel} * pow(0, mod(var(--bracket-depth2) - ${colindex}, ${colors.length}))`;
-          })
-          .join(" + ")})`
+              return `${channel} * pow(0, mod(var(--bracket-depth2) - ${colindex}, ${colors.length}))`;
+            })
+            .join(" + ") ?? 0
+        })`
     )
     .join(", ")})`;
 

--- a/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
+++ b/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
@@ -11,18 +11,12 @@ export function generateBracketPairColorizationCSS(
         `calc(${colors
           .map((col, colindex) => {
             const channel = col[i];
-            // Uses the periodic nature of cosine to only color every Nth bracket a given color
+            // Uses the periodic nature of mod to only color every Nth bracket a given color
 
-            // All colors are multiplied by this "cosine factor" and then added together
+            // All colors are multiplied by this "mod factor" and then added together
             // to only "pick" the correct color.
 
-            // The "max(0, 10000 * cos(whatever) - 9999)" thing is done to *only* pick
-            // values where cosine is 1 (i.e. where bracketdepth - index = 0)
-
-            // I'm not using better options like abs() or mod() due to browser compatibility
-            return `${channel} * max(0, 10000 * cos(
-            2 * 3.14159265358979323 * (var(--bracket-depth2) - ${colindex}) / ${colors.length}
-            ) - 9999)`;
+            return `${channel} * pow(0, mod(var(--bracket-depth2) - ${colindex}, ${colors.length}))`;
           })
           .join(" + ")})`
     )

--- a/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
+++ b/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
@@ -1,8 +1,23 @@
-export function generateBracketPairColorizationCSS(
-  colors: [number, number, number][],
-  colorInText: boolean,
-  thickenBrackets: number
-) {
+import { Config } from "./config";
+
+// assumes valid input;
+function hex2rgb(hex: string) {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ] as const;
+}
+
+export function generateBracketPairColorizationCSS(settings: Config) {
+  const {
+    bracketPairColorizationColors: bpcColors,
+    bpcColorInText: colorInText,
+    thickenBrackets,
+  } = settings;
+
+  const colors = bpcColors.map(hex2rgb);
+
   const colorMaker = `rgb(${[0, 1, 2]
     .map(
       (i) =>

--- a/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
+++ b/src/plugins/syntax-highlighting/bracket-pair-colorization.ts
@@ -37,15 +37,14 @@ export function generateBracketPairColorizationCSS(settings: Config) {
     )
     .join(", ")})`;
 
-  return [
-    /*
-      Colorization exceptions:
+  /*
+    Colorization exceptions:
 
-      - Children of a \textcolor{} or base case in label or expression
-      - Standalone commas like in `(0,0),(1,2)`
-        Otherwise they would get the color of the first color in the list.
-    */
-    `
+    - Children of a \textcolor{} or base case in label or expression
+    - Standalone commas like in `(0,0),(1,2)`
+      Otherwise they would get the color of the first color in the list.
+  */
+  return `
     .dcg-mq-root-block {
       --bracket-depth1: 0;
       --bracket-depth2: 0;
@@ -71,6 +70,5 @@ export function generateBracketPairColorizationCSS(settings: Config) {
         }
       }
     }
-    `,
-  ];
+    `;
 }

--- a/src/plugins/syntax-highlighting/index.ts
+++ b/src/plugins/syntax-highlighting/index.ts
@@ -3,14 +3,6 @@ import { generateBracketPairColorizationCSS } from "./bracket-pair-colorization"
 import { Config, configList } from "./config";
 import "./index.less";
 
-// assumes valid input;
-export function hex2rgb(hex: string): [number, number, number] {
-  return [
-    parseInt(hex.slice(1, 3), 16),
-    parseInt(hex.slice(3, 5), 16),
-    parseInt(hex.slice(5, 7), 16),
-  ];
-}
 
 export default class SyntaxHighlighting extends PluginController<Config> {
   static id = "syntax-highlighting" as const;
@@ -26,11 +18,7 @@ export default class SyntaxHighlighting extends PluginController<Config> {
     this.resetHighlightedRanges();
 
     const bpcCss = this.settings.bracketPairColorization
-      ? generateBracketPairColorizationCSS(
-          this.settings.bracketPairColorizationColors.map((c) => hex2rgb(c)),
-          this.settings.bpcColorInText,
-          this.settings.thickenBrackets
-        )
+      ? generateBracketPairColorizationCSS(this.settings)
       : [];
 
     while ((this.styles.sheet?.cssRules?.length ?? 0) > 0) {


### PR DESCRIPTION
PR #1023 partially fixed the issue of text inside a base case being highlighted, but didn't cover all cases; e.g.,

- Text in brackets is colored black when `bpcColorInText` is off, where it should be white
- Thickened bracket strokes remain highlighted

![syntax-highlighting-base-case](https://github.com/user-attachments/assets/a773b6b4-567b-40c4-9b6a-d73049108b18)

This PR fixes these bugs by selectively applying styles and avoiding overriding, and migrates the `<style>`-based CSS manipulation to [Constructable Stylesheets](https://web.dev/articles/constructable-stylesheets).


Other minor changes:

- Simplified the `max(0, 10000 * cos(whatever) - 9999)` thing using the newly available CSS features like `mod()`
- Replaced `.dcg-mq-bracket-l` and `.dcg-mq-bracket-r` with an equivalent selector `.dcg-mq-paren`

Fixes #1004