### PR TITLE
Set the maximum width of the current action to avoid overflowing

### DIFF
--- a/src/plugins/video-creator/components/CaptureMethod.css
+++ b/src/plugins/video-creator/components/CaptureMethod.css
@@ -1,6 +1,7 @@
 .dsm-vc-current-action {
   overflow-x: auto;
   margin-bottom: 5px;
+  max-width: 320px;
 }
 
 .dsm-vc-playing-sliders {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="654" height="949" alt="before" src="https://github.com/user-attachments/assets/1b057ac4-f396-4bf4-884e-5445a2864e7d" /> | <img width="654" height="949" alt="after" src="https://github.com/user-attachments/assets/77cacff7-2a96-4f05-b9dc-2bc24123a0eb" /> |
