### PR TITLE
Only suppress errors on shift-enter if there is an error

### DIFF
--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -120,7 +120,7 @@ if ($e === "Enter")
 ```js
 __from__
 else if ("Shift-Enter" === $e) {
-  if (this.model.error)
+  if (this.model.error && !DSM.multiline?.settings?.spacesToNewlines)
     DSM.hideErrors?.hideError(this.model.id);
   return this.controller.dispatch({
     type: "on-special-key-pressed",

--- a/src/plugins/hide-errors/hide-errors.replacements
+++ b/src/plugins/hide-errors/hide-errors.replacements
@@ -120,7 +120,8 @@ if ($e === "Enter")
 ```js
 __from__
 else if ("Shift-Enter" === $e) {
-  DSM.hideErrors?.hideError(this.model.id);
+  if (this.model.error)
+    DSM.hideErrors?.hideError(this.model.id);
   return this.controller.dispatch({
     type: "on-special-key-pressed",
     key: "Enter"

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -185,6 +185,8 @@ export default class Multiline extends PluginController<Config> {
   onMQKeystroke(key: string, _: KeyboardEvent): undefined | "cancel" {
     const mq = this.calc.focusedMathQuill?.mq;
 
+    // hide-errors.replacements has a special case to ensure the hide-errors
+    // Shift-Enter handler is suppressed if DSM.multiline.settings.spacesToNewlines.
     if (key === "Shift-Enter" && this.settings.spacesToNewlines) {
       if (mq) {
         mq.typedText("   ");


### PR DESCRIPTION
- Only suppress errors on shift-enter if there is an error
- Ensure shift-enter multiline has priority over shift-enter hide-error (Shouldn't change anything, just is careful)

Fixes most problems associated with #515, so I'd be okay saying #515 is fixed. The proposal in that issue (of removing errorHidden) comes at the risk of not suppressing alternating errors, so might as well not risk that.