### PR TITLE
Respect reverse contrast in video creator capture

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -263,6 +263,7 @@ interface CalcPrivate {
       config: {
         product: Product;
         settingsMenu: boolean;
+        invertedColors: boolean;
       };
       squareAxes: boolean;
       setProperty: (k: "squareAxes", v: boolean) => void;

--- a/src/plugins/video-creator/backend/capture.ts
+++ b/src/plugins/video-creator/backend/capture.ts
@@ -11,7 +11,7 @@ export const CANCELLED = Symbol("cancelled");
 async function captureAndApplyFrame(vc: VideoCreator) {
   const frame = await captureFrame(vc);
   if (frame === CANCELLED) return CANCELLED;
-  vc.pushFrame(frame);
+  await vc.pushFrame(frame);
 }
 
 interface MosaicDims {

--- a/src/plugins/video-creator/components/PreviewCarousel.less
+++ b/src/plugins/video-creator/components/PreviewCarousel.less
@@ -140,3 +140,12 @@
   top: 0;
   right: 0;
 }
+
+.dcg-container.dcg-inverted-colors {
+  // In 2d, the images truly are inverted, so invert it back.
+  // In 3d, the images are not inverted, but Desmos doesn't
+  // add an extra invert filter, so this is the original invert.
+  .dsm-vc-preview-carousel img {
+    filter: invert(100%);
+  }
+}

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -502,7 +502,40 @@ export default class VideoCreator extends PluginController {
     this.updateView();
   }
 
-  pushFrame(frame: string) {
+  async invertImage(frame: string): Promise<string> {
+    return await new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => {
+        const { width, height } = img;
+        document.body.appendChild(img);
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          throw new Error("Failed to get context for inverting image.");
+        }
+        ctx.drawImage(img, 0, 0);
+        ctx.globalCompositeOperation = "difference";
+        ctx.fillStyle = "white";
+        ctx.fillRect(0, 0, width, height);
+        document.body.appendChild(canvas);
+        resolve(canvas.toDataURL("image/png"));
+        return null;
+      };
+      img.src = frame;
+    });
+  }
+
+  async pushFrame(frame: string) {
+    if (
+      !this.cc.is3dProduct() &&
+      this.cc.graphSettings?.config?.invertedColors
+    ) {
+      // Invert colors in 2d.
+      // 3d already inverts the canvas screenshots, so no need to invert.
+      frame = await this.invertImage(frame);
+    }
     if (
       !this.isPlayingPreview &&
       this.previewIndex === this.frames.length - 1

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -507,7 +507,6 @@ export default class VideoCreator extends PluginController {
       const img = new Image();
       img.onload = () => {
         const { width, height } = img;
-        document.body.appendChild(img);
         const canvas = document.createElement("canvas");
         canvas.width = width;
         canvas.height = height;
@@ -519,7 +518,6 @@ export default class VideoCreator extends PluginController {
         ctx.globalCompositeOperation = "difference";
         ctx.fillStyle = "white";
         ctx.fillRect(0, 0, width, height);
-        document.body.appendChild(canvas);
         resolve(canvas.toDataURL("image/png"));
         return null;
       };


### PR DESCRIPTION
Fixes #533 by changing the captures. There is no extra checkbox added. Just uses the graph settings from the wrench menu.

This changes the captures, so it applies to zip export as well as the video exports.