### PR TITLE
Fix inaccessible video creator action capture

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -162,7 +162,7 @@ interface EvaluatorChange {
    */
   move_strategy?: { type: "updateCoordinate" | "updateSlider" }[];
   /** (Expressions, images, (ticker)?) New action to be applied on the next click. Ignore */
-  action_value?: unknown;
+  evaluated_latex?: unknown;
   /** (Regression expressions) Regression metadata */
   regression?: unknown;
   /** (Tables) column changes from dragging points */

--- a/src/globals/models.ts
+++ b/src/globals/models.ts
@@ -131,7 +131,7 @@ export enum ValueType {
 interface FormulaBase {
   exported_variables?: string[];
   is_graphable: boolean;
-  action_value?: Record<string, string>;
+  evaluated_latex?: Record<string, string>;
 }
 
 interface NonfolderItemModelBase extends ItemModelBase {

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -406,7 +406,8 @@ export default class VideoCreator extends PluginController {
     return this.cc
       .getAllItemModels()
       .filter(
-        (e) => e.type === "expression" && e.formula?.action_value !== undefined
+        (e) =>
+          e.type === "expression" && e.formula?.evaluated_latex !== undefined
       ) as ExpressionModel[];
   }
 


### PR DESCRIPTION
The action capture option became inaccessible due to an interface change to the calculator controller. Fixes #1078.