### PR TITLE
Filter to implicit graphMode inside evaluator for glesmos

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -220,7 +220,7 @@ export interface Grapher3d {
     axis3D: readonly [number, number, number];
     speed3D: number;
     lastRotateTime: number;
-    copyWorldRotationToWorld: () => void;
+    setWorldRotation: (rotation: Matrix3) => void;
     onTapStart: () => void;
     onTapMove: () => void;
     onTapUp: () => void;

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -150,6 +150,7 @@ interface Fragile {
     moveItemsTo: (listModel: any, from: number, to: number, n: number) => void;
   };
   currentLanguage: () => string;
+  glslHeader: string;
 }
 
 export const Fragile = new Proxy(

--- a/src/plugins/GLesmos/drawGLesmosSketchToCtx.ts
+++ b/src/plugins/GLesmos/drawGLesmosSketchToCtx.ts
@@ -1,7 +1,7 @@
 import ViewportTransforms from "./ViewportTransforms";
 import { initGLesmosCanvas, GLesmosCanvas } from "./glesmosCanvas";
 import { glesmosError, GLesmosShaderPackage } from "./shaders";
-import { CalcController } from "#globals";
+import { CalcController, Fragile } from "#globals";
 
 let canvas: GLesmosCanvas | null = null;
 
@@ -26,13 +26,13 @@ interface DrawCtx {
 export function drawGLesmosSketchToCtx(
   cc: CalcController,
   drawCtx: DrawCtx,
-  { id, branches }: GLesmosSketch,
-  glslHeader: string
+  { id, branches }: GLesmosSketch
 ) {
   branches = branches.filter((b) => b.graphMode === "GLesmos");
 
   const glBranches = branches.map((b) => b.compiledGL);
   if (glBranches.length === 0) return;
+  const { glslHeader } = Fragile;
   const compiledGL: GLesmosShaderPackage = {
     chunks: glBranches.flatMap((b) => b.chunks),
     deps: glBranches.reduce<Record<string, boolean>>(

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -91,15 +91,6 @@ Add one child before and one after.
 *Find*
 
 ```js
-`    ${$dcg_shared_module_exports[__glslHeader__]}
-    ${$f}
-    ${$c ? `varying vec2 vUV;
-` :
-```
-
-*Find*
-
-```js
 drawSketchToCtx({
   sketch: $sketch, drawContext: $drawCtx, ____
 }) {__body__}
@@ -115,9 +106,7 @@ if (!$ee.branches || !$ee.branches.length) return;
 
 ```js
 __guard__
-window.DesModder?.drawGLesmosSketchToCtx?.(window.Calc.controller, $drawCtx, $sketch,
-  $dcg_shared_module_exports[__glslHeader__]
-);
+window.DesModder?.drawGLesmosSketchToCtx?.(window.Calc.controller, $drawCtx, $sketch);
 ```
 
 ## Pass GLesmos flag to worker

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -159,6 +159,10 @@ branchesReplacement: function (
   const { userData } = graphProps;
   if (!userData.glesmos)
     return undefined;
+  // 8 == GRAPHMODE.IMPLICIT
+  if (graphInfo.graphMode !== 8) {
+    return undefined;
+  }
   const isEquality = graphInfo.operator === '=';
   const lines =
     userData.lines !== false &&

--- a/src/plugins/video-creator/orientation.ts
+++ b/src/plugins/video-creator/orientation.ts
@@ -40,7 +40,7 @@ export class Orientation {
     if (controls) {
       const unhook = hookIntoFunction(
         controls,
-        "copyWorldRotationToWorld",
+        "setWorldRotation",
         "video-creator-rotation-listener",
         0,
         () => this.updateLatexOrientationFromGraph()


### PR DESCRIPTION
Fixes glesmos bug from:
1. type "sin(xx)<0"
2. Enable Glesmos
3. Edit it to just `x`

It plots as `x=0` rather than `y=x`. This PR fixes that to correctly plot as `y=x` again.