### PR TITLE
Dispatch tick after running showToast (and more)

### DIFF
--- a/eslint-rules/rules/no-format-in-ts.ts
+++ b/eslint-rules/rules/no-format-in-ts.ts
@@ -34,7 +34,8 @@ export default createRule({
         if (!program || !checker) return;
         if (
           node.callee.type === AST_NODE_TYPES.Identifier &&
-          node.callee.name === "format"
+          (node.callee.name === "format" ||
+            node.callee.name === "fromFormattable")
         ) {
           const { filename } = context;
           const calleeTsNode =

--- a/jest-config/jest-base.config.js
+++ b/jest-config/jest-base.config.js
@@ -30,5 +30,6 @@ module.exports = {
   ],
   moduleNameMapper: {
     "^#metadata/(.*)$": "<rootDir>/metadata/$1",
+    ".ftl$": "<rootDir>/localization/mock-ftl.ts",
   },
 };

--- a/localization/i18n-core.ts
+++ b/localization/i18n-core.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @desmodder/eslint-rules/no-format-in-ts */
 import enFTL from "./en.ftl";
 import esFTL from "./es.ftl";
 import frFTL from "./fr.ftl";
@@ -12,6 +13,18 @@ export function currentLanguage() {
 export const locales = new Map<string, FluentBundle>();
 
 const Console = console;
+
+export interface Formattable {
+  key: string;
+  args?: Record<string, FluentVariable> | null;
+  missingReplacement?: string;
+}
+
+export const fromFormattable = ({
+  key,
+  args,
+  missingReplacement,
+}: Formattable) => format(key, args, missingReplacement);
 
 export function format(
   key: string,

--- a/localization/mock-ftl.ts
+++ b/localization/mock-ftl.ts
@@ -1,0 +1,1 @@
+export default "";

--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -11,7 +11,7 @@ import {
 import { postMessageUp, mapToRecord, recordToMap } from "#utils/messages.ts";
 
 export default class DSM extends TransparentPlugins {
-  cc = this.calc.controller;
+  readonly cc = this.calc.controller;
   /**
    * pluginsEnabled keeps track of what plugins the user wants enabled,
    * regardless of forceDisabled settings.
@@ -30,7 +30,7 @@ export default class DSM extends TransparentPlugins {
   private readonly destroyHandlers: (() => void)[] = [];
 
   constructor(
-    public calc: Calc,
+    public readonly calc: Calc,
     opts: {
       /** Called after destroying the DSM (but before destroying the Calc). */
       afterDestroy?: () => void;

--- a/src/core-plugins/manage-metadata/index.ts
+++ b/src/core-plugins/manage-metadata/index.ts
@@ -11,7 +11,6 @@ import {
 } from "./sync";
 import { AllActions, DispatchedEvent } from "../../globals/extra-actions";
 import { ItemState } from "graph-state/state";
-import { format } from "#i18n";
 
 declare module "src/globals/extra-actions" {
   interface AllActions {
@@ -80,10 +79,7 @@ export default class ManageMetadata extends PluginController {
   }
 
   private showGlesmosNotEnabledToast() {
-    this.cc.showToast({
-      // eslint-disable-next-line @desmodder/eslint-rules/no-format-in-ts
-      message: format("GLesmos-not-enabled"),
-    });
+    this.util.showToast({ message: { key: "GLesmos-not-enabled" } });
   }
 
   /** Called from inside a couple dispatched functions. */

--- a/src/core-plugins/pillbox-menus/index.ts
+++ b/src/core-plugins/pillbox-menus/index.ts
@@ -67,7 +67,7 @@ export default class PillboxMenus extends PluginController<undefined> {
   }
 
   updateMenuView() {
-    this.cc.dispatch({ type: "tick" });
+    this.util.tick();
   }
 
   addPillboxButton(info: PillboxButtonSpec) {
@@ -104,7 +104,7 @@ export default class PillboxMenus extends PluginController<undefined> {
       this.cc.geometryGettingStartedMessageState !== "hidden"
     ) {
       this.cc.geometryGettingStartedMessageState = "hidden";
-      this.cc.dispatch({ type: "tick" });
+      this.util.tick();
     }
     this.pillboxMenuPinned = false;
     this.updateMenuView();

--- a/src/plugins/GLesmos/drawGLesmosSketchToCtx.ts
+++ b/src/plugins/GLesmos/drawGLesmosSketchToCtx.ts
@@ -1,7 +1,7 @@
 import ViewportTransforms from "./ViewportTransforms";
 import { initGLesmosCanvas, GLesmosCanvas } from "./glesmosCanvas";
 import { glesmosError, GLesmosShaderPackage } from "./shaders";
-import { CalcController, Fragile, ShaderFunctions } from "#globals";
+import { Calc, Fragile, ShaderFunctions } from "#globals";
 import { EmittedGLSL } from "./exportAsGLesmos";
 
 let canvas: GLesmosCanvas | null = null;
@@ -25,7 +25,7 @@ interface DrawCtx {
  * not just when the plugin is enabled, but also the time when the plugin
  * has just been disabled but the new sketch has not been received */
 export function drawGLesmosSketchToCtx(
-  cc: CalcController,
+  calc: Calc,
   drawCtx: DrawCtx,
   { id, branches }: GLesmosSketch
 ) {
@@ -34,11 +34,11 @@ export function drawGLesmosSketchToCtx(
   const glBranches = branches.map((b) => b.compiledGL);
   if (glBranches.length === 0) return;
 
-  drawOneGLesmosSketchToCtx?.(cc, drawCtx, glBranches, id);
+  drawOneGLesmosSketchToCtx?.(calc, drawCtx, glBranches, id);
 }
 
 function drawOneGLesmosSketchToCtx(
-  cc: CalcController,
+  calc: Calc,
   { ctx, projection }: DrawCtx,
   compiledGL: GLesmosShaderPackage[],
   id: string
@@ -47,7 +47,7 @@ function drawOneGLesmosSketchToCtx(
   // re-use the old canvas on a re-enable. This is a hacky fix.
   // There should be a way to clean up the GLesmos code
   // to avoid needing this.
-  canvas = canvas ?? initGLesmosCanvas(cc);
+  canvas = canvas ?? initGLesmosCanvas(calc);
 
   try {
     if (!canvas?.element) glesmosError("WebGL Context Lost!");
@@ -69,7 +69,7 @@ function drawOneGLesmosSketchToCtx(
       }
     }
   } catch (e) {
-    const model = cc.getItemModel(id);
+    const model = calc.controller.getItemModel(id);
     if (model) model.error = e instanceof Error ? e.message : e;
   }
 }

--- a/src/plugins/GLesmos/glesmos.replacements
+++ b/src/plugins/GLesmos/glesmos.replacements
@@ -190,7 +190,7 @@ if (!$ee.branches || !$ee.branches.length) return;
 
 ```js
 __guard__
-window.DesModder?.drawGLesmosSketchToCtx?.(window.Calc.controller, $drawCtx, $sketch);
+window.DesModder?.drawGLesmosSketchToCtx?.(window.Calc, $drawCtx, $sketch);
 ```
 
 ## Pass GLesmos flag to worker

--- a/src/plugins/GLesmos/glesmosCanvas.ts
+++ b/src/plugins/GLesmos/glesmosCanvas.ts
@@ -9,8 +9,8 @@ import {
   glesmosGetFastFillShader,
   setUniform,
 } from "./shaders";
-import window, { CalcController } from "#globals";
-import { format } from "#i18n";
+import window, { Calc } from "#globals";
+import { showToast } from "#utils/depUtils.ts";
 
 export type GLesmosCanvas = ReturnType<typeof initGLesmosCanvas>;
 
@@ -29,7 +29,7 @@ const FULLSCREEN_QUAD = new Float32Array([
   -1, 1, 1, 1, 1, -1, -1, 1, 1, -1, -1, -1,
 ]);
 
-export function initGLesmosCanvas(cc: CalcController) {
+export function initGLesmosCanvas(calc: Calc) {
   //= ================ INIT ELEMENTS =======================
 
   const c: HTMLCanvasElement = document.createElement("canvas");
@@ -40,10 +40,7 @@ export function initGLesmosCanvas(cc: CalcController) {
     antialias: true,
   });
   if (!gl) {
-    cc.showToast({
-      // eslint-disable-next-line @desmodder/eslint-rules/no-format-in-ts
-      message: format("GLesmos-no-support"),
-    });
+    showToast(calc, { message: { key: "GLesmos-no-support" } });
     window.DSM?.setPluginEnabled?.("GLesmos", false);
     return undefined;
   }

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -9,8 +9,8 @@ export class PluginController<
   static config: readonly ConfigItem[] | undefined = undefined;
   /** Core plugins get enabled before all others and can't be disabled. */
   static isCore = false;
-  calc = this.dsm.calc;
-  cc = this.calc.controller;
+  readonly calc = this.dsm.calc;
+  readonly cc = this.calc.controller;
 
   constructor(
     readonly dsm: DSM,

--- a/src/plugins/PluginController.ts
+++ b/src/plugins/PluginController.ts
@@ -1,5 +1,6 @@
 import { ConfigItem, GenericSettings } from ".";
 import DSM from "#DSM";
+import { createCalcUtils } from "#utils/depUtils.ts";
 
 export class PluginController<
   Settings extends GenericSettings | undefined = undefined,
@@ -24,6 +25,8 @@ export class PluginController<
    * un-register dispatcher calls, clear intervals/timeouts, etc.
    */
   afterDisable() {}
+
+  protected readonly util = createCalcUtils(this.calc);
 }
 
 export type Replacer<T = any> = undefined | ((old: T) => any);

--- a/src/plugins/paste-image/index.ts
+++ b/src/plugins/paste-image/index.ts
@@ -1,5 +1,4 @@
 import { PluginController } from "../PluginController";
-import { format } from "#i18n";
 import type { DispatchedEvent } from "#globals";
 import type { AtLeastOne } from "#utils/utils.ts";
 
@@ -21,16 +20,14 @@ export default class PasteImage extends PluginController {
     const clipboardFiles = e.clipboardData?.files;
     if (!clipboardFiles?.length) return;
     if (!this.cc.areImagesEnabled()) {
-      this.cc.showToast({
-        // eslint-disable-next-line @desmodder/eslint-rules/no-format-in-ts
-        message: format("paste-image-error-images-not-enabled"),
+      this.util.showToast({
+        message: { key: "paste-image-error-images-not-enabled" },
       });
     } else if (this.cc.isUploadingImages()) {
       this.waitForImageUploads({
         runFinally: () =>
-          this.cc.showToast({
-            // eslint-disable-next-line @desmodder/eslint-rules/no-format-in-ts
-            message: format("paste-image-error-another-upload-in-progress"),
+          this.util.showToast({
+            message: { key: "paste-image-error-another-upload-in-progress" },
           }),
       });
     } else {
@@ -41,7 +38,7 @@ export default class PasteImage extends PluginController {
       // Among the possible errors, only those related to an invalid MIME type is not handled by the image-upload-error event
       if (nonImageFiles)
         setTimeout(() =>
-          this.cc.showToast({
+          this.util.showToast({
             message: this.cc.s("graphing-calculator-error-image-invalid-file", {
               file: nonImageFiles[0].name,
             }),

--- a/src/plugins/performance-info/index.ts
+++ b/src/plugins/performance-info/index.ts
@@ -44,7 +44,7 @@ export default class PerformanceInfo extends PluginController {
   }
 
   refreshState() {
-    this.cc.showToast({ message: "Refreshing graph..." });
+    this.util.showToast({ message: "Refreshing graph..." });
     // should this be using killWorker instead?
     const oldUnsavedChanges = this.cc._hasUnsavedChanges;
     this.calc.setState(this.calc.getState(), { allowUndo: true });

--- a/src/plugins/text-mode/index.ts
+++ b/src/plugins/text-mode/index.ts
@@ -183,7 +183,7 @@ export default class TextMode extends PluginController {
   }
 
   toastError(msg: string, undoCallback?: () => void) {
-    this.cc.showToast({
+    this.util.showToast({
       message: msg,
       // `undoCallback: undefined` still adds the "Press Ctrl+Z" message
       ...(undoCallback ? { undoCallback } : {}),

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -10,11 +10,7 @@ import { OutFileType, exportFrames, initFFmpeg } from "./backend/export";
 import { escapeRegex } from "./backend/utils";
 import { MainPopupFunc } from "./components/MainPopup";
 import { ExpressionModel, FocusLocation, ValueType } from "#globals";
-import {
-  keys,
-  EvaluateSingleExpression,
-  getCurrentGraphTitle,
-} from "#utils/depUtils.ts";
+import { keys } from "#utils/depUtils.ts";
 import {
   ManagedNumberInputModel,
   ManagedNumberInputModelOpts,
@@ -191,7 +187,7 @@ export default class VideoCreator extends PluginController {
 
   getOutfileName() {
     return (
-      this.outfileName ?? getCurrentGraphTitle(this.calc) ?? DEFAULT_FILENAME
+      this.outfileName ?? this.util.getCurrentGraphTitle() ?? DEFAULT_FILENAME
     );
   }
 
@@ -219,7 +215,7 @@ export default class VideoCreator extends PluginController {
   }
 
   eval(s: string) {
-    return EvaluateSingleExpression(this.calc, s);
+    return this.util.EvaluateSingleExpression(s);
   }
 
   useMosaicRatio() {

--- a/src/plugins/video-creator/index.ts
+++ b/src/plugins/video-creator/index.ts
@@ -138,7 +138,7 @@ export default class VideoCreator extends PluginController {
   }
 
   updateView() {
-    this.cc.dispatch({ type: "tick" });
+    this.util.tick();
   }
 
   async tryInitFFmpeg() {

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -1,5 +1,4 @@
 import { Console } from "../../globals/window";
-import { getCurrentGraphTitle } from "../../utils/depUtils";
 import { PluginController } from "../PluginController";
 import { Config, configList } from "./config";
 import { listenToMessageDown, postMessageUp } from "#utils/messages.ts";
@@ -48,7 +47,7 @@ export default class Wakatime extends PluginController<Config> {
   maybeSendHeartbeat(isWrite: boolean) {
     if (!(performance.now() - this.lastUpdate > heartbeatInterval || isWrite))
       return;
-    const graphName = getCurrentGraphTitle(this.calc) ?? "Untitled Graph";
+    const graphName = this.util.getCurrentGraphTitle() ?? "Untitled Graph";
     const graphURL = window.location.href;
     const lineCount = this.calc.getExpressions().length;
 

--- a/src/plugins/wakatime/index.ts
+++ b/src/plugins/wakatime/index.ts
@@ -27,7 +27,7 @@ export default class Wakatime extends PluginController<Config> {
       if (msg.type === "heartbeat-error") {
         if (msg.isAuthError) {
           this.dsm.disablePlugin("wakatime");
-          this.cc.showToast({
+          this.util.showToast({
             message:
               "WakaTime heartbeat error: check your secret key. Plugin has been deactivated.",
             toastStyle: "error",

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,4 +1,5 @@
-import { type Calc, Fragile, Private } from "#globals";
+import { type Calc, Fragile, Private, Toast } from "#globals";
+import { Formattable, fromFormattable } from "#i18n";
 
 const { evaluateLatex } = Fragile;
 
@@ -27,6 +28,23 @@ export function getCurrentGraphTitle(calc: Calc): string | undefined {
 
 export function tick(calc: Calc): void {
   calc.controller.dispatch({ type: "tick" });
+}
+
+export type ToastFormattable = Omit<Toast, "message"> & {
+  message: Formattable;
+};
+
+function isPlainToast(toast: Toast | ToastFormattable): toast is Toast {
+  return typeof toast.message === "string";
+}
+
+export function showToast(calc: Calc, toast: Toast | ToastFormattable): void {
+  calc.controller.showToast(
+    isPlainToast(toast)
+      ? toast
+      : { ...toast, message: fromFormattable(toast.message) }
+  );
+  tick(calc);
 }
 
 type CalcUtilFunction<
@@ -59,6 +77,7 @@ export const createCalcUtils = bindCalc({
   EvaluateSingleExpression,
   getCurrentGraphTitle,
   tick,
+  showToast,
 } satisfies CalcUtils);
 
 export const { List } = Fragile;

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -25,6 +25,10 @@ export function getCurrentGraphTitle(calc: Calc): string | undefined {
   return calc._calc.globalHotkeys?.mygraphsController?.graphsController?.getCurrentGraphTitle?.();
 }
 
+export function tick(calc: Calc): void {
+  calc.controller.dispatch({ type: "tick" });
+}
+
 type CalcUtilFunction<
   P extends readonly unknown[] = readonly never[],
   R = unknown,
@@ -54,6 +58,7 @@ const bindCalc =
 export const createCalcUtils = bindCalc({
   EvaluateSingleExpression,
   getCurrentGraphTitle,
+  tick,
 } satisfies CalcUtils);
 
 export const { List } = Fragile;

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -25,4 +25,35 @@ export function getCurrentGraphTitle(calc: Calc): string | undefined {
   return calc._calc.globalHotkeys?.mygraphsController?.graphsController?.getCurrentGraphTitle?.();
 }
 
+type CalcUtilFunction<
+  P extends readonly unknown[] = readonly never[],
+  R = unknown,
+> = (calc: Calc, ...args: P) => R;
+type CalcUtilSig<F extends CalcUtilFunction> =
+  F extends CalcUtilFunction<infer P, infer R> ? [P, R] : never;
+type CalcUtilParams<F extends CalcUtilFunction> = CalcUtilSig<F>[0];
+type CalcUtilReturn<F extends CalcUtilFunction> = CalcUtilSig<F>[1];
+
+type CalcUtils = Record<string, CalcUtilFunction>;
+
+type BindCalc<U extends CalcUtils> = {
+  [K in keyof U]: (...args: CalcUtilParams<U[K]>) => CalcUtilReturn<U[K]>;
+};
+
+const bindCalc =
+  <const U extends CalcUtils>(calcUtils: U) =>
+  (calc: Calc) =>
+    Object.entries(calcUtils).reduce<BindCalc<CalcUtils>>(
+      (utils, [name, func]) => {
+        utils[name] = (...args) => func(calc, ...args);
+        return utils;
+      },
+      {}
+    ) as BindCalc<U>;
+
+export const createCalcUtils = bindCalc({
+  EvaluateSingleExpression,
+  getCurrentGraphTitle,
+} satisfies CalcUtils);
+
 export const { List } = Fragile;

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -42,7 +42,10 @@ export function showToast(calc: Calc, toast: Toast | ToastFormattable): void {
   calc.controller.showToast(
     isPlainToast(toast)
       ? toast
-      : { ...toast, message: fromFormattable(toast.message) }
+      : // Toasts are ephemeral enough that they don't really need
+        // to update on language change:
+        // eslint-disable-next-line @desmodder/eslint-rules/no-format-in-ts
+        { ...toast, message: fromFormattable(toast.message) }
   );
   tick(calc);
 }


### PR DESCRIPTION
- Add utility functions
  - `tick`: shorthand for `cc.dispatch({ type: "tick" })`
  - `showToast`: utility for displaying a toast and updating the view right after that (so it will be displayed without user action).
    It also accepts toast messages to be localized (formatted), removing the need for using `format` and adding `eslint-disable-next-line` directives.
- Add a new property `util` to `PluginController`. All its members are basically the same as utilities in depUtils.ts that have a `calc` parameter, but they are partially applied with argument `this.calc`.
 