### PR TITLE
Add dcg-main-content to mock DOM

### DIFF
--- a/src/tests/run_calc_for_tests.ts
+++ b/src/tests/run_calc_for_tests.ts
@@ -4,7 +4,9 @@ document.body.dataset.loadData = JSON.stringify({ seed: "c29cb3444b1c435c8e4422a
 document.body.innerHTML = `
   <div class="dcg-sliding-interior">
     <div id="dcg-header-container"></div>
-    <div id="graph-container"></div>
+    <div id="dcg-main-content">
+      <div id="graph-container"></div>
+    </div>
   </div>
 
   <div id="mygraphs-container"></div>


### PR DESCRIPTION
Should fix the failing unit test. The Desmos initialization was throwing "Must pass an HTMLElement for the node" because getElementById gave `null` here.