### PR TITLE
Demo enum config UI

### DIFF
--- a/localization/en.ftl
+++ b/localization/en.ftl
@@ -245,6 +245,8 @@ better-evaluation-view-opt-colors-name = Show colors
 better-evaluation-view-opt-colors-desc = Show colors as rgb values
 better-evaluation-view-opt-colorLists-name = Show lists of colors
 better-evaluation-view-opt-colorLists-desc = Show lists of colors as lists of rgb values
+better-evaluation-view-opt-listsTEMP-name = Lists (TEMP)
+better-evaluation-view-opt-listsTEMP-desc = Pick between three options in an enum.
 
 ## Pillbox Menus
 pillbox-menus-name = Pillbox Menus (Core)

--- a/src/core-plugins/pillbox-menus/components/Menu.tsx
+++ b/src/core-plugins/pillbox-menus/components/Menu.tsx
@@ -9,6 +9,7 @@ import {
   IfElse,
   IconButton,
   Switch,
+  SegmentedControl,
 } from "#components";
 import { format } from "#i18n";
 import {
@@ -19,6 +20,7 @@ import {
   PluginID,
   plugins,
   ConfigItemNumber,
+  ConfigItemEnum,
 } from "#plugins/index.ts";
 import PillboxMenus from "..";
 import "./Menu.less";
@@ -201,6 +203,13 @@ export default class Menu extends Component<{
                     booleanOption(this.pm, item, plugin, pluginSettings),
                   string: () =>
                     stringOption(this.pm, item, plugin, pluginSettings),
+                  enum: () =>
+                    enumOption(
+                      this.pm,
+                      item as ConfigItemEnum,
+                      plugin,
+                      pluginSettings
+                    ),
                   number: () =>
                     numberOption(this.pm, item, plugin, pluginSettings),
                   "color-list": () =>
@@ -428,6 +437,35 @@ function stringOption(
         </label>
       </Tooltip>
       <ResetButton pm={pm} key={item.key} />
+    </div>
+  );
+}
+
+function enumOption(
+  pm: PillboxMenus,
+  item: ConfigItemEnum,
+  plugin: SpecificPlugin,
+  settings: GenericSettings
+) {
+  return (
+    <div class="dsm-settings-item dsm-settings-enum">
+      <SegmentedControl
+        names={item.options}
+        selectedIndex={() => {
+          const i = item.options.findIndex((e) => e === settings[item.key]);
+          if (i === -1) return 0;
+          return i;
+        }}
+        setSelectedIndex={(i) =>
+          pm.dsm.setPluginSetting(plugin.id, item.key, item.options[i])
+        }
+        ariaGroupLabel={() => format(item.key)}
+      />
+      <Tooltip tooltip={configItemDesc(plugin, item)} gravity="n">
+        <div class="dsm-settings-label" tabindex={0}>
+          {configItemName(plugin, item)}
+        </div>
+      </Tooltip>
     </div>
   );
 }

--- a/src/plugins/better-evaluation-view/config.ts
+++ b/src/plugins/better-evaluation-view/config.ts
@@ -22,6 +22,12 @@ export const configList: ConfigItem[] = [
     default: true,
     shouldShow: (current: Config) => current.lists && current.colors,
   },
+  {
+    key: "listsTEMP",
+    type: "enum",
+    options: ["none", "old", "new"],
+    default: "new",
+  },
 ];
 
 export interface Config {
@@ -29,4 +35,5 @@ export interface Config {
   lists: boolean;
   colors: boolean;
   colorLists: boolean;
+  listsTEMP: "none" | "old" | "new";
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -68,9 +68,16 @@ export interface ConfigItemColorList extends ConfigItemGeneric {
   default: string[];
 }
 
+export interface ConfigItemEnum extends ConfigItemGeneric {
+  type: "enum";
+  options: string[];
+  default: string;
+}
+
 export type ConfigItem =
   | ConfigItemBoolean
   | ConfigItemString
+  | ConfigItemEnum
   | ConfigItemNumber
   | ConfigItemColorList;
 

--- a/src/plugins/video-creator/components/MainPopup.tsx
+++ b/src/plugins/video-creator/components/MainPopup.tsx
@@ -10,7 +10,7 @@ import { format } from "#i18n";
 import ManagedNumberInput from "./ManagedNumberInput";
 import { OrientationView } from "./OrientationView";
 
-const fileTypeNames: OutFileType[] = [
+export const fileTypeNames: OutFileType[] = [
   "gif",
   "mp4",
   "webm",


### PR DESCRIPTION
Adds an extra option to BEV that does nothing. Just lets you pick between 'none', 'old', and 'new'
<img width="308" height="338" alt="image" src="https://github.com/user-attachments/assets/e4e520f6-e622-4eb9-a56d-5b29f88fd01e" />

E.g. `DSM.betterEvaluationView.settings.listsTEMP` to confirm it changes.

I don't really like it since it takes so much space. 

It could be nice to use the `SelectDropdown` UI (like used for table regressions), but that would be a slight hassle to access it in DesModder. 
<img width="324" height="349" alt="image" src="https://github.com/user-attachments/assets/8ad33f6d-03f0-4329-8928-04eb896fb2c2" />
