### PR TITLE
Fix getCurrentGraphTitle

### DIFF
--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -206,14 +206,6 @@ export interface TimingData {
   updateIntersections: number;
 }
 
-export interface TopLevelComponents {
-  mygraphsController: {
-    graphsController: {
-      getCurrentGraphTitle: () => string | undefined;
-    };
-  };
-}
-
 export interface Toast {
   message: string;
   undoCallback?: () => void;
@@ -380,9 +372,6 @@ interface CalcPrivate {
       constructor: { fromObject: (vp: Viewport) => ViewportClass };
     };
     destroy: () => void;
-  };
-  _calc: {
-    globalHotkeys: TopLevelComponents;
   };
   /// / public
 

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -27,8 +27,12 @@ export interface DWindow extends Window {
     pluginsEnabled: Record<PluginID, boolean | undefined>;
     pluginSettings: Record<PluginID, GenericSettings | undefined>;
   };
-  // DesModderFragile: {};
   Desmos: Desmos;
+  shellController: {
+    graphsController: {
+      getCurrentGraphTitle: () => string;
+    };
+  };
 }
 
 type DesmosPublic = typeof Desmos;

--- a/src/plugins/video-creator/video-creator.int.test.ts
+++ b/src/plugins/video-creator/video-creator.int.test.ts
@@ -1,4 +1,4 @@
-import { testWithPageAndOpts } from "#tests";
+import { testWithPageAndOpts, clean, testWithPage } from "#tests";
 
 const CAPTURE = ".dsm-pillbox-popover .dsm-vc-capture-menu";
 const PREVIEW = ".dsm-pillbox-popover .dsm-vc-preview-menu";
@@ -85,3 +85,38 @@ describe("Video Creator", () => {
     }
   );
 });
+
+testWithPage(
+  "getCurrentGraphTitle should give undefined for untitled graphs",
+  async (driver) => {
+    const title = await driver.evaluate(() =>
+      (window as any).DSM.videoCreator.util.getCurrentGraphTitle()
+    );
+    expect(title).toEqual(undefined);
+
+    return clean;
+  }
+);
+
+testWithPageAndOpts(
+  "getCurrentGraphTitle should give undefined for untitled geometry",
+  // Separate test here because geometry just says "Untitled" instead of "Untitled Graph"
+  { path: "/geometry" },
+  async (driver) => {
+    const title = await driver.evaluate(() =>
+      (window as any).DSM.videoCreator.util.getCurrentGraphTitle()
+    );
+    expect(title).toEqual(undefined);
+  }
+);
+
+testWithPageAndOpts(
+  "getCurrentGraphTitle should work for titled graphs",
+  { path: "/calculator/clqqw0vgvu" },
+  async (driver) => {
+    const title = await driver.evaluate(() =>
+      (window as any).DSM.videoCreator.util.getCurrentGraphTitle()
+    );
+    expect(title).toEqual("Lines: Slope Intercept Form");
+  }
+);

--- a/src/plugins/video-creator/video-creator.int.test.ts
+++ b/src/plugins/video-creator/video-creator.int.test.ts
@@ -112,7 +112,7 @@ testWithPageAndOpts(
 
 testWithPageAndOpts(
   "getCurrentGraphTitle should work for titled graphs",
-  { path: "/calculator/clqqw0vgvu" },
+  { path: "/calculator/jhuyewt32p" },
   async (driver) => {
     const title = await driver.evaluate(() =>
       (window as any).DSM.videoCreator.util.getCurrentGraphTitle()

--- a/src/plugins/video-creator/video-creator.int.test.ts
+++ b/src/plugins/video-creator/video-creator.int.test.ts
@@ -110,10 +110,15 @@ testWithPageAndOpts(
   }
 );
 
-testWithPageAndOpts(
+testWithPage(
   "getCurrentGraphTitle should work for titled graphs",
-  { path: "/calculator/jhuyewt32p" },
   async (driver) => {
+    await driver.click(".dcg-open-my-graphs-button");
+    await driver.click(".dcg-my-graphs-modal-examples-header");
+    await driver.click("::-p-text(Lines: Slope Intercept Form)");
+    await driver.page.waitForSelector(
+      "::-p-text(Opened 'Lines: Slope Intercept Form')"
+    );
     const title = await driver.evaluate(() =>
       (window as any).DSM.videoCreator.util.getCurrentGraphTitle()
     );

--- a/src/utils/depUtils.ts
+++ b/src/utils/depUtils.ts
@@ -1,4 +1,4 @@
-import { type Calc, Fragile, Private, Toast } from "#globals";
+import { type Calc, DWindow, Fragile, Private, Toast } from "#globals";
 import { Formattable, fromFormattable } from "#i18n";
 
 const { evaluateLatex } = Fragile;
@@ -23,7 +23,16 @@ export const autoCommands = Private?.MathquillConfig?.getAutoCommands?.();
 export const autoOperatorNames = Private?.MathquillConfig?.getAutoOperators?.();
 
 export function getCurrentGraphTitle(calc: Calc): string | undefined {
-  return calc._calc.globalHotkeys?.mygraphsController?.graphsController?.getCurrentGraphTitle?.();
+  const title = (
+    window as any as DWindow
+  ).shellController.graphsController.getCurrentGraphTitle();
+  if (
+    title === calc.controller.s("account-shell-text-untitled-graph") ||
+    title === calc.controller.s("account-shell-text-untitled")
+  ) {
+    return undefined;
+  }
+  return title;
 }
 
 export function tick(calc: Calc): void {


### PR DESCRIPTION
Used in wakatime ("Split projects by graph") and video creator (default export name)