### PR TITLE
Future-proof mathquill interaction

### DIFF
--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -93,6 +93,7 @@ export interface MathQuillField {
   selection: (() => MqSelection) & ((selection: MqSelection) => MathQuillField);
   /** Returns the `dcg-math-field` */
   el: () => HTMLElement;
+  domNodeToSpan: (el: Element) => MqSelection | undefined;
   __controller: {
     options: MathQuillFieldOptions;
     cursor: MQCursor;

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -91,6 +91,8 @@ export interface MathQuillField {
   focus: () => void;
   blur: () => void;
   selection: (() => MqSelection) & ((selection: MqSelection) => MathQuillField);
+  /** Returns the `dcg-math-field` */
+  el: () => HTMLElement;
   __controller: {
     options: MathQuillFieldOptions;
     cursor: MQCursor;

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -77,6 +77,12 @@ export interface MathQuillConfig {
   typingPercentWritesPercentOf?: boolean;
 }
 
+export interface MqSelection {
+  latex: string;
+  startIndex: number;
+  endIndex: number;
+}
+
 export interface MathQuillField {
   keystroke: (key: string, e?: KeyboardEvent) => void;
   latex: (input?: string) => string;
@@ -84,6 +90,7 @@ export interface MathQuillField {
   config: (input: MathQuillConfig) => MathQuillField;
   focus: () => void;
   blur: () => void;
+  selection: (() => MqSelection) & ((selection: MqSelection) => MathQuillField);
   __controller: {
     options: MathQuillFieldOptions;
     cursor: MQCursor;

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -99,7 +99,34 @@ export interface MathQuillField {
     cursor: MQCursor;
     container: HTMLElement;
   };
-  __options: MathQuillFieldOptions;
+  controller?: {
+    getConfig: () => {
+      autoOperatorNames: {
+        has: (s: string) => boolean;
+      };
+      autoCommands: {
+        has: (s: string) => boolean;
+      };
+    };
+  };
+}
+
+// TODO-mq-compat: isAutoOperatorName and isAutoCommand are hacks
+// that could be done better maybe.
+export function isAutoOperatorName(mq: MathQuillField, ident: string) {
+  if (mq.__controller) {
+    return !!mq.__controller.options.autoOperatorNames[ident];
+  } else {
+    return mq.controller!.getConfig().autoOperatorNames.has(ident);
+  }
+}
+
+export function isAutoCommand(mq: MathQuillField, ident: string) {
+  if (mq.__controller) {
+    return !!mq.__controller.options.autoCommands[ident];
+  } else {
+    return mq.controller!.getConfig().autoCommands.has(ident);
+  }
 }
 
 export abstract class MathQuillViewComponent extends ClassComponent<{

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -81,6 +81,8 @@ export interface MqSelection {
   latex: string;
   startIndex: number;
   endIndex: number;
+  headIndex?: number;
+  anchorIndex?: number;
 }
 
 export interface MathQuillField {
@@ -111,6 +113,7 @@ export interface MathQuillField {
   };
 }
 
+// TODO-mq-compat-when-single: reduce these
 // TODO-mq-compat: isAutoOperatorName and isAutoCommand are hacks
 // that could be done better maybe.
 export function isAutoOperatorName(mq: MathQuillField, ident: string) {
@@ -126,6 +129,28 @@ export function isAutoCommand(mq: MathQuillField, ident: string) {
     return !!mq.__controller.options.autoCommands[ident];
   } else {
     return mq.controller!.getConfig().autoCommands.has(ident);
+  }
+}
+
+/** Assuming there is a nonempty selection, return the direction. */
+export function selectionDirection(mq: MathQuillField): 1 | -1 {
+  if (mq.__controller) {
+    const nodeAfterHead = mq.__controller.cursor[1]?._el;
+    if (nodeAfterHead?.parentElement?.classList.contains("dcg-mq-selection")) {
+      // The node after the head is inside the selection, so
+      // the head is on the left of the selection.
+      return -1;
+    } else {
+      // Else the head is on the right of the selection.
+      return 1;
+    }
+  } else {
+    const selection = mq.selection();
+    if (selection.headIndex === selection.startIndex) {
+      return -1;
+    } else {
+      return 1;
+    }
   }
 }
 

--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -114,8 +114,6 @@ export interface MathQuillField {
 }
 
 // TODO-mq-compat-when-single: reduce these
-// TODO-mq-compat: isAutoOperatorName and isAutoCommand are hacks
-// that could be done better maybe.
 export function isAutoOperatorName(mq: MathQuillField, ident: string) {
   if (mq.__controller) {
     return !!mq.__controller.options.autoOperatorNames[ident];

--- a/src/globals/Calc.ts
+++ b/src/globals/Calc.ts
@@ -1,6 +1,6 @@
 import { ItemModel } from "./models";
 import { GraphState, ItemState, Product } from "../../graph-state";
-import { MathQuillField } from "#components";
+import { MathQuillConfig, MathQuillField } from "#components";
 import { Matrix3 } from "./matrix3";
 import type { DispatchedEvent } from "./extra-actions";
 
@@ -344,10 +344,9 @@ interface CalcPrivate {
     subscribeToChanges: (cb: () => void) => () => void;
     getBackgroundColor: () => string;
     isInEditListMode: () => boolean;
-    getMathquillConfig: (e: { additionalOperators?: string[] }) => {
-      autoOperatorNames: string;
-      autoCommands: string;
-    };
+    getMathquillConfig: (e: {
+      additionalOperators?: string[];
+    }) => MathQuillConfig;
     is3dProduct: () => boolean;
     grapher3d?: Grapher3d;
     getGrapher: () => {

--- a/src/globals/window.ts
+++ b/src/globals/window.ts
@@ -12,7 +12,6 @@ import {
   MathQuillViewComponent,
   SegmentedControlComponent,
   TooltipComponent,
-  MathQuillConfig,
   DropdownPopoverComponent,
 } from "../components/desmosComponents";
 import { GenericSettings, PluginID } from "../plugins";
@@ -46,7 +45,6 @@ interface Desmos extends DesmosPublic {
     MathquillConfig: MathquillConfig;
   };
   MathQuill: {
-    config: (config: MathQuillConfig) => Desmos["MathQuill"];
     getApiInstanceForElement: (el: Element) => null | MathQuillApi;
   };
 }

--- a/src/mathquill/mq-cursor.ts
+++ b/src/mathquill/mq-cursor.ts
@@ -1,0 +1,81 @@
+import { MathQuillField, selectionDirection } from "../components";
+import { MqNodeViaDom } from "./mq-node";
+
+type DomCursor =
+  | { type: "cursor"; el: Element }
+  | { type: "selection"; el: Element; headSide: 1 | -1 };
+
+/**
+ * This class behaves similarly to a mathquill cursor,
+ * but it avoids reaching into mathquill internals.
+ * This works directly on the HTML that mathquill produces.
+ *
+ * A cursor is a position inside a group. There are a few ways to think of it:
+ * 1. Either at the start of the group or after a non-group node.
+ * 2. Either at the end of the group or before a non-group node.
+ * 3. Either before/after a non-group node, or at the single location inside an empty group
+ * 4. At some index `0` through `n` _inclusive_ in a group with `n` children.
+ */
+export class MqCursorViaDom {
+  private readonly mq: MathQuillField;
+  /**
+   * The domCursor represents the head of the selection.
+   * Since we only have access to DOM nodes, this is a bit awkward.
+   */
+  private readonly domCursor: DomCursor;
+
+  constructor(mq: MathQuillField, domCursor: DomCursor) {
+    this.mq = mq;
+    this.domCursor = domCursor;
+  }
+
+  nodeBefore(): MqNodeViaDom | undefined {
+    const sibling =
+      this.domCursor.type === "selection" && this.domCursor.headSide === 1
+        ? this.domCursor.el.lastElementChild
+        : this.domCursor.el.previousElementSibling;
+    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    else return undefined;
+  }
+
+  nodeAfter(): MqNodeViaDom | undefined {
+    const sibling =
+      this.domCursor.type === "selection" && this.domCursor.headSide === -1
+        ? this.domCursor.el.firstElementChild
+        : this.domCursor.el.nextElementSibling;
+    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    else return undefined;
+  }
+
+  nodeInDirection(dir: 1 | -1): MqNodeViaDom | undefined {
+    return dir === 1 ? this.nodeAfter() : this.nodeBefore();
+  }
+
+  parentGroup() {
+    const parent = this.domCursor.el.parentElement;
+    if (!parent) throw new Error("Invalid cursor.");
+    return new MqNodeViaDom(this.mq, parent);
+  }
+}
+
+/**
+ * Get the head of the selection.
+ * When the selection is a point (i.e. just the cursor), it represents that point.
+ * Otherwise, this is the head of the selection, which is what moves when you shift-arrow.
+ */
+export function getCursorHead(mq: MathQuillField): MqCursorViaDom | undefined {
+  const cursorDom = mq.el().querySelector(".dcg-mq-cursor");
+  if (cursorDom) {
+    return new MqCursorViaDom(mq, { type: "cursor", el: cursorDom });
+  }
+  const selectionDom = mq.el().querySelector(".dcg-mq-selection");
+  if (selectionDom) {
+    const direction = selectionDirection(mq);
+    return new MqCursorViaDom(mq, {
+      type: "selection",
+      el: selectionDom,
+      headSide: direction,
+    });
+  }
+  return undefined;
+}

--- a/src/mathquill/mq-node.ts
+++ b/src/mathquill/mq-node.ts
@@ -1,0 +1,87 @@
+import { MathQuillField } from "../components";
+
+/**
+ * This class behaves similarly to an individual mathquill node,
+ * but it avoids reaching into mathquill internals. This works directly
+ * on the HTML that mathquill produces.
+ *
+ * Note nodes are divided into groups and non-groups. The parent of a non-group
+ * is a group, and the parent of a group is a non-group. The root node
+ * is always a group, and the parent of the cursor is always a group.
+ *
+ * For example in `\sqrt{ab}^{3}`, there are 8 nodes:
+ * 1. `a`
+ * 2. `b`
+ * 3. The group `{ab}`
+ * 4. `\sqrt{ab}`
+ * 5. `3`
+ * 6. The group `{2}`
+ * 7. `\sqrt{ab}^{3}`
+ * 8. The root group `{\sqrt{ab}^{3}}`
+ */
+export class MqNodeViaDom {
+  private readonly mq: MathQuillField;
+  public readonly domNode: Element;
+
+  constructor(mq: MathQuillField, domNode: Element) {
+    this.mq = mq;
+    this.domNode = domNode;
+  }
+
+  parent() {
+    if (this.domNode.classList.contains("dcg-mq-root-block")) {
+      return undefined;
+    }
+    let parent = this.domNode.parentElement;
+    if (!parent) return undefined;
+    if (isSelection(parent)) {
+      parent = parent.parentElement;
+      if (!parent) return undefined;
+    }
+    return new MqNodeViaDom(this.mq, parent);
+  }
+
+  nextSibling(): MqNodeViaDom | undefined {
+    let sibling = this.domNode.nextElementSibling;
+    while (sibling?.classList.contains("dcg-mq-cursor")) {
+      sibling = sibling.nextElementSibling;
+    }
+    const parent = this.domNode.parentElement;
+    if (!sibling && parent && isSelection(parent)) {
+      sibling = parent.nextElementSibling;
+    }
+    if (sibling) {
+      return new MqNodeViaDom(this.mq, sibling);
+    }
+    return undefined;
+  }
+
+  prevSibling(): MqNodeViaDom | undefined {
+    let sibling = this.domNode.previousElementSibling;
+    while (sibling?.classList.contains("dcg-mq-cursor")) {
+      sibling = sibling.previousElementSibling;
+    }
+    const parent = this.domNode.parentElement;
+    if (!sibling && parent && isSelection(parent)) {
+      sibling = parent.previousElementSibling;
+    }
+    if (sibling) {
+      return new MqNodeViaDom(this.mq, sibling);
+    }
+    return undefined;
+  }
+
+  latex() {
+    const span = this.mq.domNodeToSpan(this.domNode);
+    if (!span) return "";
+    return span.latex.slice(span.startIndex, span.endIndex);
+  }
+}
+
+/**
+ * Selections are also in the HTML tree, but we want to avoid them
+ * for MQ tree traversal methods like .nextSibling().
+ */
+function isSelection(el: Element) {
+  return el.classList.contains("dcg-mq-selection");
+}

--- a/src/mathquill/mq-node.ts
+++ b/src/mathquill/mq-node.ts
@@ -71,6 +71,10 @@ export class MqNodeViaDom {
     return undefined;
   }
 
+  siblingInDirection(dir: 1 | -1): MqNodeViaDom | undefined {
+    return dir === -1 ? this.prevSibling() : this.nextSibling();
+  }
+
   latex() {
     const span = this.mq.domNodeToSpan(this.domNode);
     if (!span) return "";

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -1,9 +1,10 @@
 import { PluginController } from "../PluginController";
 import { MathQuillField, MathQuillView } from "src/components";
-import { getCursorHead, MqNodeViaDom } from "../intellisense/latex-parsing";
 import { ConfigItem } from "#plugins/index.ts";
 
 import "./index.less";
+import { MqNodeViaDom } from "../../mathquill/mq-node";
+import { getCursorHead } from "../../mathquill/mq-cursor";
 
 const R = +1;
 const L = -1;

--- a/src/plugins/better-navigation/index.ts
+++ b/src/plugins/better-navigation/index.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import { PluginController } from "../PluginController";
 import { MathQuillField, MathQuillView } from "src/components";
-import { getController } from "../intellisense/latex-parsing";
+import { getCursorHead, MqNodeViaDom } from "../intellisense/latex-parsing";
 import { ConfigItem } from "#plugins/index.ts";
 
 import "./index.less";
@@ -10,11 +9,12 @@ const R = +1;
 const L = -1;
 type Dir = 1 | -1;
 
-function isSupSubscriptMQElem(el?: HTMLElement) {
+function isSupSubscriptMQElem(el?: Element) {
   return el?.classList.contains("dcg-mq-supsub");
 }
 
-function isWordMQElem(el?: HTMLElement) {
+function isWordNode(node: MqNodeViaDom) {
+  const el = node.domNode;
   return (
     el &&
     (el.classList.contains("dcg-mq-digit") ||
@@ -23,23 +23,25 @@ function isWordMQElem(el?: HTMLElement) {
   );
 }
 
-function isCtrlArrowSkippableSymbolMQElem(el?: HTMLElement) {
+function isCtrlArrowSkippableSymbolNode(node: MqNodeViaDom) {
+  const el = node.domNode;
   return (
-    el?.classList.contains("dcg-mq-bracket-container") ||
-    el?.classList.contains("dcg-mq-fraction") ||
-    el?.classList.contains("dcg-mq-large-operator") ||
-    el?.classList.contains("dcg-mq-int") ||
-    el?.classList.contains("dcg-mq-sqrt-container") ||
-    el?.classList.contains("dcg-mq-nthroot-container")
+    el.classList.contains("dcg-mq-bracket-container") ||
+    el.classList.contains("dcg-mq-fraction") ||
+    el.classList.contains("dcg-mq-large-operator") ||
+    el.classList.contains("dcg-mq-int") ||
+    el.classList.contains("dcg-mq-sqrt-container") ||
+    el.classList.contains("dcg-mq-nthroot-container")
   );
 }
 
 function isAtStartOrEndOfASubscriptOrSuperscript(mq: MathQuillField, dir: Dir) {
-  const ctrlr = getController(mq);
+  const cursor = getCursorHead(mq);
+  if (!cursor) return false;
   return (
-    (ctrlr.cursor?.parent?._el?.classList.contains("dcg-mq-sup") ||
-      ctrlr.cursor?.parent?._el?.classList.contains("dcg-mq-sub")) &&
-    !ctrlr.cursor?.[dir]
+    (cursor.parentGroup().domNode.classList.contains("dcg-mq-sup") ||
+      cursor.parentGroup().domNode.classList.contains("dcg-mq-sub")) &&
+    !cursor.nodeInDirection(dir)
   );
 }
 
@@ -115,16 +117,15 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
     // remove the "Ctrl-" to get the normal arrow op to emulate
     const arrowOp = key.slice(5);
 
-    const ctrlr = getController(mq);
-
-    const next = ctrlr.cursor?.[navOption.dir];
+    const cursor = getCursorHead(mq);
+    const next = cursor?.nodeInDirection(dir);
 
     // if the next element is one of the following:
     // bracket, fraction, sum, product, integral, sqrt, nthroot
     // then skip over the entire thing when ctrl+arrowing (don't edit internals)
     // Shift-arrow already does this behavior perfectly so we first do that.
     // Then we do a normal arrow press to delete the selection.
-    if (isCtrlArrowSkippableSymbolMQElem(next?._el)) {
+    if (next && isCtrlArrowSkippableSymbolNode(next)) {
       mq.keystroke(dir === R ? "Shift-Right" : "Shift-Left");
 
       // remove selection if not extending a selection
@@ -133,16 +134,26 @@ export default class BetterNavigation extends PluginController<BetterNavSettings
       // skip over entire variable names, numbers, and operatornames
     } else if (
       isAtStartOrEndOfASubscriptOrSuperscript(mq, dir) ||
-      (next && isWordMQElem(next._el))
+      (next && isWordNode(next))
     ) {
       // leave start/end of sub/sup
-      if (isAtStartOrEndOfASubscriptOrSuperscript(mq, dir))
+      if (isAtStartOrEndOfASubscriptOrSuperscript(mq, dir)) {
         mq.keystroke(arrowOp);
+      }
 
       let i = 0;
-      while (isWordMQElem(ctrlr.cursor?.[dir]?._el) && i < 1000) {
+      let cursor;
+      let next;
+      while (
+        (cursor = getCursorHead(mq)) &&
+        (next = cursor.nodeInDirection(dir)) &&
+        isWordNode(next) &&
+        i < 1000
+      ) {
         // skip over super/subscript
-        if (isSupSubscriptMQElem(ctrlr.cursor?.[dir]?._el)) {
+        if (
+          isSupSubscriptMQElem(getCursorHead(mq)?.nodeInDirection(dir)?.domNode)
+        ) {
           mq.keystroke(dir === R ? "Shift-Right" : "Shift-Left");
 
           // remove selection if not extending selection

--- a/src/plugins/custom-mathquill-config/index.ts
+++ b/src/plugins/custom-mathquill-config/index.ts
@@ -35,42 +35,42 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
       "--delimiter-override",
       `"${CSS.escape(config.delimiterOverride)}"`
     );
-
-    const settingsObj = {
-      charsThatBreakOutOfSupSub: config.superscriptOperators
-        ? "=<>"
-        : defaultConfig.charsThatBreakOutOfSupSub,
-      disableAutoSubstitutionInSubscripts: config.subscriptReplacements
-        ? false
-        : defaultConfig.disableAutoSubstitutionInSubscripts,
-      autoSubscriptNumerals: config.noAutoSubscript
-        ? false
-        : defaultConfig.autoSubscriptNumerals,
-      sumStartsWithNEquals: config.noNEquals
-        ? false
-        : defaultConfig.sumStartsWithNEquals,
-      leftRightIntoCmdGoes: config.leftIntoSubscript
-        ? "down"
-        : defaultConfig.leftRightIntoCmdGoes,
-      supSubsRequireOperand: config.subSupWithoutOp
-        ? false
-        : defaultConfig.supSubsRequireOperand,
-      restrictMismatchedBrackets: config.allowMixedBrackets
-        ? false
-        : defaultConfig.restrictMismatchedBrackets,
-      typingPercentWritesPercentOf: config.noPercentOf
-        ? false
-        : defaultConfig.typingPercentWritesPercentOf,
-    };
-    window.Desmos.MathQuill.config(settingsObj);
   }
 
   afterEnable() {
     this.cc.getMathquillConfig = (e) => {
-      const currentConfig = this.oldConfig.call(this.cc, e);
+      const currentConfig: MathQuillConfig = this.oldConfig.call(this.cc, e);
       if (this.doAutoCommandInjections) {
         currentConfig.autoCommands += this.autoCommandInjections;
       }
+      const config = this.settings;
+      const freshConfig: MathQuillConfig = {
+        charsThatBreakOutOfSupSub: config.superscriptOperators
+          ? "=<>"
+          : defaultConfig.charsThatBreakOutOfSupSub,
+        disableAutoSubstitutionInSubscripts: config.subscriptReplacements
+          ? false
+          : defaultConfig.disableAutoSubstitutionInSubscripts,
+        autoSubscriptNumerals: config.noAutoSubscript
+          ? false
+          : defaultConfig.autoSubscriptNumerals,
+        sumStartsWithNEquals: config.noNEquals
+          ? false
+          : defaultConfig.sumStartsWithNEquals,
+        leftRightIntoCmdGoes: config.leftIntoSubscript
+          ? "down"
+          : defaultConfig.leftRightIntoCmdGoes,
+        supSubsRequireOperand: config.subSupWithoutOp
+          ? false
+          : defaultConfig.supSubsRequireOperand,
+        restrictMismatchedBrackets: config.allowMixedBrackets
+          ? false
+          : defaultConfig.restrictMismatchedBrackets,
+        typingPercentWritesPercentOf: config.noPercentOf
+          ? false
+          : defaultConfig.typingPercentWritesPercentOf,
+      };
+      Object.assign(currentConfig, freshConfig);
       return currentConfig;
     };
     this.updateConfig(this.settings);
@@ -79,7 +79,6 @@ export default class CustomMathQuillConfig extends PluginController<Config> {
   afterDisable() {
     this.doAutoCommandInjections = false;
     this.cc.rootElt.classList.remove("commaizer");
-    window.Desmos.MathQuill.config(defaultConfig);
     this.cc.getMathquillConfig = this.oldConfig;
 
     this.cc.rootElt.style.removeProperty("--delimiter-override");

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -1,7 +1,6 @@
 import {
   PartialFunctionCall,
   TryFindMQIdentResult,
-  getController,
   getCorrectableIdentifier,
   getMathquillIdentifierAtCursorPosition,
   getPartialFunctionCall,
@@ -10,7 +9,13 @@ import { IntellisenseState } from "./state";
 import { pendingIntellisenseTimeouts, setIntellisenseTimeout } from "./utils";
 import { JumpToDefinitionMenuInfo, View } from "./view";
 import { DCGView, MountedComponent, unmountFromNode } from "#DCGView";
-import { MathQuillField, MathQuillView, MqSelection } from "#components";
+import {
+  isAutoCommand,
+  isAutoOperatorName,
+  MathQuillField,
+  MathQuillView,
+  MqSelection,
+} from "#components";
 import { DispatchedEvent, ItemModel, TextModel } from "#globals";
 import { PluginController } from "#plugins/PluginController.ts";
 import { isDescendant } from "#utils/utils.ts";
@@ -263,9 +268,9 @@ export default class Intellisense extends PluginController<{
     }
 
     if (this.prevSelection && this.latestMQ) {
-      const mqRootBlock = getController(this.latestMQ).container.querySelector(
-        ".dcg-mq-root-block"
-      );
+      const mqRootBlock = this.latestMQ
+        .el()
+        .querySelector(".dcg-mq-root-block");
 
       if (!mqRootBlock) return;
 
@@ -280,9 +285,9 @@ export default class Intellisense extends PluginController<{
     if (focusedmq) this.latestMQ = focusedmq;
     if (this.latestMQ) {
       // get cursor pos relative to the top left of the mathquill's root element
-      const mqRootBlock = getController(this.latestMQ).container.querySelector(
-        ".dcg-mq-root-block"
-      );
+      const mqRootBlock = this.latestMQ
+        .el()
+        .querySelector(".dcg-mq-root-block");
 
       if (!mqRootBlock) return;
       this.prevSelection = this.latestMQ.selection();
@@ -663,9 +668,10 @@ export default class Intellisense extends PluginController<{
           if (ident.ident.length === 1) return;
 
           const identWithoutSubscripts = ident.ident.replace(/_/g, "");
+
           if (
-            this.latestMQ.__options.autoOperatorNames[identWithoutSubscripts] ||
-            this.latestMQ.__options.autoCommands[identWithoutSubscripts]
+            isAutoOperatorName(this.latestMQ, identWithoutSubscripts) ||
+            isAutoCommand(this.latestMQ, identWithoutSubscripts)
           ) {
             return;
           }

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -43,9 +43,10 @@ export interface BoundIdentifierFunction {
 }
 
 export function getMQCursorPosition(focusedMQ: MathQuillField) {
-  return getController(
-    focusedMQ
-  ).cursor?.cursorElement?.getBoundingClientRect();
+  return focusedMQ
+    .el()
+    .querySelector(".dcg-mq-cursor")
+    ?.getBoundingClientRect();
 }
 
 export default class Intellisense extends PluginController<{

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -10,7 +10,7 @@ import { IntellisenseState } from "./state";
 import { pendingIntellisenseTimeouts, setIntellisenseTimeout } from "./utils";
 import { JumpToDefinitionMenuInfo, View } from "./view";
 import { DCGView, MountedComponent, unmountFromNode } from "#DCGView";
-import { MathQuillField, MathQuillView } from "#components";
+import { MathQuillField, MathQuillView, MqSelection } from "#components";
 import { DispatchedEvent, ItemModel, TextModel } from "#globals";
 import { PluginController } from "#plugins/PluginController.ts";
 import { isDescendant } from "#utils/utils.ts";
@@ -76,7 +76,7 @@ export default class Intellisense extends PluginController<{
   latestMQ: MathQuillField | undefined;
 
   intellisenseReturnMQ: MathQuillField | undefined;
-  prevCursorPos: { x: number; y: number } | undefined;
+  prevSelection: MqSelection | undefined;
   goRightBeforeReturningToMQ: boolean = false;
 
   idcounter = 0;
@@ -263,29 +263,14 @@ export default class Intellisense extends PluginController<{
       this.latestMQ = this.intellisenseReturnMQ;
     }
 
-    if (this.prevCursorPos && this.latestMQ) {
+    if (this.prevSelection && this.latestMQ) {
       const mqRootBlock = getController(this.latestMQ).container.querySelector(
         ".dcg-mq-root-block"
       );
 
       if (!mqRootBlock) return;
 
-      const mqRootBlockRect = mqRootBlock.getBoundingClientRect();
-
-      // simulate a click to get cursor in the right spot
-      const eventHandlerSettings = {
-        bubbles: true,
-        clientX:
-          this.prevCursorPos.x - mqRootBlock.scrollLeft + mqRootBlockRect.x,
-        clientY:
-          this.prevCursorPos.y - mqRootBlock.scrollTop + mqRootBlockRect.y,
-      };
-      getController(this.latestMQ).container.dispatchEvent(
-        new MouseEvent("mousedown", eventHandlerSettings)
-      );
-      getController(this.latestMQ).container.dispatchEvent(
-        new MouseEvent("mouseup", eventHandlerSettings)
-      );
+      this.latestMQ.selection(this.prevSelection);
     }
   }
 
@@ -294,26 +279,14 @@ export default class Intellisense extends PluginController<{
   saveCursorState() {
     const focusedmq = MathQuillView.getFocusedMathquill();
     if (focusedmq) this.latestMQ = focusedmq;
-    if (
-      this.latestMQ &&
-      document.body.contains(
-        getController(this.latestMQ).cursor.cursorElement ?? null
-      )
-    ) {
+    if (this.latestMQ) {
       // get cursor pos relative to the top left of the mathquill's root element
       const mqRootBlock = getController(this.latestMQ).container.querySelector(
         ".dcg-mq-root-block"
       );
 
       if (!mqRootBlock) return;
-      const mqRootBlockRect = mqRootBlock.getBoundingClientRect();
-      const rect = getController(
-        this.latestMQ
-      ).cursor.cursorElement?.getBoundingClientRect();
-      this.prevCursorPos = {
-        x: rect?.x ?? 0 + mqRootBlock.scrollLeft - mqRootBlockRect.x,
-        y: rect?.y ?? 0 + mqRootBlock.scrollTop - mqRootBlockRect.y,
-      };
+      this.prevSelection = this.latestMQ.selection();
     }
   }
 

--- a/src/plugins/intellisense/index.tsx
+++ b/src/plugins/intellisense/index.tsx
@@ -95,8 +95,6 @@ export default class Intellisense extends PluginController<{
   jumpToDefState: JumpToDefinitionMenuInfo | undefined;
   jumpToDefIndex: number = 0;
 
-  specialIdentifierNames: string[] = [];
-
   getSelectedExpressionID(): string | undefined {
     return this.cc.getSelectedItem()?.id;
   }
@@ -308,22 +306,6 @@ export default class Intellisense extends PluginController<{
   goToPrevIntellisenseCol() {
     this.intellisenseIndex = Math.max(this.intellisenseIndex - 1, 0);
   }
-
-  focusInHandler = () => {
-    setIntellisenseTimeout(() => {
-      if (
-        this.calc.focusedMathQuill &&
-        this.specialIdentifierNames.length === 0
-      ) {
-        this.specialIdentifierNames = [
-          ...Object.keys(
-            this.calc.focusedMathQuill.mq.__options.autoOperatorNames
-          ),
-          ...Object.keys(this.calc.focusedMathQuill.mq.__options.autoCommands),
-        ];
-      }
-    });
-  };
 
   onMQKeystroke(key: string, _: KeyboardEvent): undefined | "cancel" {
     if (
@@ -618,10 +600,6 @@ export default class Intellisense extends PluginController<{
     // disable intellisense when switching expressions
     document.addEventListener("focusout", this.focusOutHandler);
 
-    // override the mathquill keystroke handler so that it opens the
-    // intellisense menu when I want it to
-    document.addEventListener("focusin", this.focusInHandler);
-
     // general intellisense keyboard handler
     document.addEventListener("keydown", this.keyDownHandler);
 
@@ -735,7 +713,6 @@ export default class Intellisense extends PluginController<{
 
     // clear event listeners
     document.removeEventListener("focusout", this.focusOutHandler);
-    document.removeEventListener("focusin", this.focusInHandler);
     document.removeEventListener("keydown", this.keyDownHandler);
     document.removeEventListener("keyup", this.keyUpHandler);
     document.removeEventListener("mouseup", this.mouseUpHandler);

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -1,6 +1,6 @@
 import { ExpressionAug } from "../../../text-mode-core";
 import { latexStringToIdentifierString } from "./view";
-import { MQCursor, MathQuillField } from "#components";
+import { MathQuillField } from "#components";
 
 export function mapAugAST(
   node: ExpressionAug["latex"],
@@ -28,6 +28,83 @@ export function mapAugAST(
   map(node);
 }
 
+class MqNodeViaDom {
+  mq: MathQuillField;
+  domNode: Element;
+
+  constructor(mq: MathQuillField, domNode: Element) {
+    this.mq = mq;
+    this.domNode = domNode;
+  }
+
+  parent() {
+    if (this.domNode.classList.contains("dcg-mq-root-block")) {
+      return undefined;
+    }
+    const parent = this.domNode.parentElement;
+    if (!parent) return undefined;
+    return new MqNodeViaDom(this.mq, parent);
+  }
+
+  nextSibling(): MqNodeViaDom | undefined {
+    let sibling = this.domNode.nextElementSibling;
+    while (sibling?.classList.contains("dcg-mq-cursor")) {
+      sibling = sibling.nextElementSibling;
+    }
+    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    return undefined;
+  }
+
+  prevSibling(): MqNodeViaDom | undefined {
+    let sibling = this.domNode.previousElementSibling;
+    while (sibling?.classList.contains("dcg-mq-cursor")) {
+      sibling = sibling.previousElementSibling;
+    }
+    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    return undefined;
+  }
+
+  latex() {
+    const span = this.mq.domNodeToSpan(this.domNode);
+    if (!span) return "";
+    return span.latex.slice(span.startIndex, span.endIndex);
+  }
+}
+
+class MqCursorViaDom {
+  mq: MathQuillField;
+  domCursor: Element;
+
+  constructor(mq: MathQuillField, domCursor: Element) {
+    this.mq = mq;
+    this.domCursor = domCursor;
+  }
+
+  nodeBefore(): MqNodeViaDom | undefined {
+    const sibling = this.domCursor.previousElementSibling;
+    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    else return undefined;
+  }
+
+  nodeAfter(): MqNodeViaDom | undefined {
+    const sibling = this.domCursor.nextElementSibling;
+    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    else return undefined;
+  }
+
+  parentGroup() {
+    const parent = this.domCursor.parentElement;
+    if (!parent) throw new Error("Invalid cursor.");
+    return new MqNodeViaDom(this.mq, parent);
+  }
+}
+
+export function getCursor(mq: MathQuillField) {
+  const cursorDom = mq.el().querySelector(".dcg-mq-cursor");
+  if (!cursorDom) return undefined;
+  return new MqCursorViaDom(mq, cursorDom);
+}
+
 export function getController(mq: MathQuillField) {
   return mq.__controller;
 }
@@ -47,13 +124,18 @@ export interface TryFindMQIdentResult {
   type: string;
 }
 
-// is an MQ node a subscript?
-function isSubscript(cursor: MQCursor) {
-  return getSubscriptInside(cursor) !== undefined;
+/** is an MQ node a subscript? */
+// TODO-jared-mq-compat: this can just check classList.contains("dcg-mq-sub")
+function isSubscript(node: MqNodeViaDom) {
+  return getSubscriptInside(node) !== undefined;
 }
 
-function getSubscriptInside(cursor: MQCursor) {
-  const ltx = cursor.latex?.();
+/**
+ * If `node` is a subscript, return the contents of the subscript.
+ * Otherwise return undefined.
+ */
+function getSubscriptInside(node: MqNodeViaDom): string | undefined {
+  const ltx = node.latex();
   if (!ltx) {
     return undefined;
   }
@@ -66,61 +148,69 @@ function getSubscriptInside(cursor: MQCursor) {
   return undefined;
 }
 
-// is an MQ node an operator name?
-function isOperatorName(cursor: MQCursor) {
-  return cursor._el?.classList.contains("dcg-mq-operator-name") ?? false;
+/** is an MQ node an operator name? */
+function isOperatorName(node: MqNodeViaDom) {
+  return node.domNode.classList.contains("dcg-mq-operator-name");
 }
 
-// is am MQ node a digit?
-function isDigit(cursor: MQCursor) {
-  return cursor._el?.classList.contains("dcg-mq-digit") ?? false;
+/** is an MQ node a digit? */
+function isDigit(node: MqNodeViaDom) {
+  return node.domNode.classList.contains("dcg-mq-digit");
 }
 
-// is an MQ node the start of an operator name?
-function isStartingOperatorName(cursor: MQCursor) {
-  return isOperatorName(cursor) && cursor.latex?.()?.[0] === "\\";
+/** is an MQ node the start of an operator name */
+function isStartingOperatorName(node: MqNodeViaDom) {
+  return isOperatorName(node) && node.latex().startsWith("\\");
 }
 
-// is an MQ node a variable name
-function isVarName(cursor: MQCursor) {
-  return cursor._el?.tagName.toUpperCase() === "VAR" && !isOperatorName(cursor);
+/** is an MQ node a variable name */
+function isVarName(node: MqNodeViaDom) {
+  return node.domNode.tagName.toUpperCase() === "VAR" && !isOperatorName(node);
 }
 
-function isIdentifierSegment(cursor?: MQCursor): cursor is MQCursor {
-  if (cursor === undefined) return false;
-  return (
-    isSubscript(cursor) ||
-    isOperatorName(cursor) ||
-    isStartingOperatorName(cursor) ||
-    isVarName(cursor)
-  );
+function isIdentifierSegment(node: MqNodeViaDom) {
+  return isSubscript(node) || isOperatorName(node) || isVarName(node);
 }
 
 // identifiers are composed of the following structure:
 // (operatorname* | varname) subscript?
 
 function rawTryGetMathquillIdent(
-  node: MQCursor | undefined,
-  cursor: MQCursor | undefined = node
+  node: MqNodeViaDom | undefined,
+  cursor: MqCursorViaDom | undefined
 ) {
-  const latexSegments: (string | undefined)[] = [];
-
-  const isInSubscript = cursor?.parent?._el?.classList.contains("dcg-mq-sub");
+  const isInSubscript = !!cursor && isSubscript(cursor.parentGroup());
 
   let goToEnd = 0;
 
   if (isInSubscript) {
-    node = cursor;
-    while (node?.[1]) {
+    let newNode = cursor?.nodeAfter();
+    while (newNode) {
       goToEnd++;
-      node = node?.[1];
+      newNode = newNode?.nextSibling();
     }
-    node = node?.parent?.parent;
+    // node will be the dcg-mq-supsub
+    node = cursor?.parentGroup().parent();
   }
 
+  return finalGetMathquillIdent(node, goToEnd, isInSubscript);
+}
+
+function getMathquillIdentLatex(node: MqNodeViaDom | undefined) {
+  return finalGetMathquillIdent(node, 0, false)?.ident;
+}
+
+function finalGetMathquillIdent(
+  node: MqNodeViaDom | undefined,
+  goToEnd: number,
+  isInSubscript: boolean
+) {
+  const latexSegments: (string | undefined)[] = [];
+
+  // Move before a subscript
   while (node && !isStartingOperatorName(node) && !isVarName(node)) {
     if (!isIdentifierSegment(node)) return;
-    node = node[-1];
+    node = node.prevSibling();
     goToEnd--;
   }
   if (!node) return;
@@ -130,7 +220,7 @@ function rawTryGetMathquillIdent(
   // get starting variable name
   if (isVarName(node)) {
     latexSegments.push(node.latex?.());
-    node = node[1];
+    node = node.nextSibling();
     goToEnd++;
     backspaces++;
 
@@ -138,7 +228,7 @@ function rawTryGetMathquillIdent(
   } else if (isStartingOperatorName(node)) {
     while (node && isOperatorName(node)) {
       latexSegments.push(node.latex?.());
-      node = node[1];
+      node = node.nextSibling();
       goToEnd++;
       backspaces++;
     }
@@ -181,9 +271,8 @@ function rawTryGetMathquillIdent(
 function tryGetMathquillIdent(
   mq: MathQuillField
 ): TryFindMQIdentResult | undefined {
-  const ctrlr = getController(mq);
-
-  const v = rawTryGetMathquillIdent(ctrlr.cursor[-1], ctrlr.cursor);
+  const cursor = getCursor(mq);
+  const v = rawTryGetMathquillIdent(cursor?.nodeBefore(), cursor);
   if (!v) return;
   const ident = latexStringToIdentifierString(v.ident);
   if (!ident) return;
@@ -217,21 +306,30 @@ export interface PartialFunctionCall {
 export function getPartialFunctionCall(
   mq: MathQuillField
 ): PartialFunctionCall | undefined {
-  let cursor: MQCursor | undefined = getController(mq).cursor;
-  while (cursor) {
+  const cursor: MqCursorViaDom | undefined = getCursor(mq);
+  /**
+   * If we haven't gone to any parents yet,
+   * `nodeBeforeCursor` is the actual node left of the cursor, such as
+   * "x" in `f(x<!>)`, where `<!>` is the cursor.
+   * But if it's something like `f([x<!>])`, after the first iteration,
+   * `nodeBeforeCursor` will be `[x]`, so it's really the node containing the cursor.
+   */
+  let nodeBeforeCursor = cursor?.nodeBefore();
+  let parentGroup = cursor?.parentGroup();
+  while (parentGroup) {
     // Check if it looks like a function call.
-    const parentheses = cursor.parent?.parent;
-    const nodeBeforeParentheses = parentheses?.[-1];
+    const parentheses = parentGroup.parent();
+    const nodeBeforeParentheses = parentheses?.prevSibling();
 
-    const ltx = rawTryGetMathquillIdent(nodeBeforeParentheses)?.ident;
-    if (ltx && isIdentStr(ltx) && parentheses?.ctrlSeq === "\\left(") {
+    const ltx = getMathquillIdentLatex(nodeBeforeParentheses);
+    if (ltx && isIdentStr(ltx) && parentheses?.latex().startsWith("\\left(")) {
       // Count number of commas to left of cursor.
       let paramIndex = 0;
-      let scanNode = cursor?.[-1];
+      let scanNode = nodeBeforeCursor;
       while (scanNode) {
         const ltx = scanNode.latex?.();
         if (ltx === ",") paramIndex++;
-        scanNode = scanNode[-1];
+        scanNode = scanNode.prevSibling();
       }
       return {
         ident: latexStringToIdentifierString(ltx)!,
@@ -240,7 +338,10 @@ export function getPartialFunctionCall(
     }
 
     // Else go to the parent.
-    cursor = cursor.parent?.parent;
+    // cursor = cursor.parent?.parent;
+    const parentNode = parentGroup.parent();
+    parentGroup = parentNode?.parent();
+    nodeBeforeCursor = parentNode;
   }
 }
 
@@ -248,7 +349,7 @@ export function getCorrectableIdentifier(mq: MathQuillField): {
   ident: string;
   back: () => void;
 } {
-  let cursor: MQCursor | undefined = mq.__controller.cursor[-1];
+  let node = getCursor(mq)?.nodeBefore();
 
   const isInSubscript =
     mq.__controller.cursor?.parent?._el?.classList.contains("dcg-mq-sub");
@@ -261,17 +362,14 @@ export function getCorrectableIdentifier(mq: MathQuillField): {
   const identifierSegments: string[] = [];
   const segmentGoBackLengths: number[] = [];
 
-  while (cursor) {
-    const subscriptInside = getSubscriptInside(cursor);
+  while (node) {
+    const subscriptInside = getSubscriptInside(node);
     const isSubscript = subscriptInside !== undefined;
     const isValid =
-      isOperatorName(cursor) ||
-      isVarName(cursor) ||
-      isSubscript ||
-      isDigit(cursor);
+      isOperatorName(node) || isVarName(node) || isSubscript || isDigit(node);
     if (!isValid) break;
 
-    const ltx = cursor?.latex?.();
+    const ltx = node.latex();
     if (ltx === undefined) break;
     const filteredLatex = ltx.replace(/[^a-zA-Z0-9]/g, "");
     // MathQuill considers "." to be a digit, so filter out that case.
@@ -281,7 +379,7 @@ export function getCorrectableIdentifier(mq: MathQuillField): {
     const goBack = isSubscript ? subscriptInside.length : 1;
     segmentGoBackLengths.push(goBack);
 
-    cursor = cursor[-1];
+    node = node.prevSibling();
   }
 
   identifierSegments.reverse();

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -225,18 +225,21 @@ export function getPartialFunctionCall(
     if (cursor[-1]) {
       cursor = cursor[-1];
     } else {
-      const oldCursor = cursor;
-      cursor = cursor.parent?.parent?.[-1];
+      // At the start of the group, check if it looks like a function call.
+      const parentheses = cursor.parent?.parent;
+      const tempCursor = parentheses?.[-1];
 
-      const ltx = rawTryGetMathquillIdent(cursor)?.ident;
-      if (ltx && isIdentStr(ltx) && cursor?.[1]?.ctrlSeq === "\\left(") {
+      const ltx = rawTryGetMathquillIdent(tempCursor)?.ident;
+      if (ltx && isIdentStr(ltx) && parentheses?.ctrlSeq === "\\left(") {
         return {
           ident: latexStringToIdentifierString(ltx)!,
           paramIndex,
         };
       }
+
+      // Else go to the parent.
       paramIndex = 0;
-      cursor = oldCursor.parent;
+      cursor = cursor.parent?.parent;
     }
   }
 }

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -218,29 +218,29 @@ export function getPartialFunctionCall(
   mq: MathQuillField
 ): PartialFunctionCall | undefined {
   let cursor: MQCursor | undefined = getController(mq).cursor;
-  let paramIndex = 0;
   while (cursor) {
-    const ltx = cursor?.latex?.();
-    if (ltx === ",") paramIndex++;
-    if (cursor[-1]) {
-      cursor = cursor[-1];
-    } else {
-      // At the start of the group, check if it looks like a function call.
-      const parentheses = cursor.parent?.parent;
-      const tempCursor = parentheses?.[-1];
+    // Check if it looks like a function call.
+    const parentheses = cursor.parent?.parent;
+    const nodeBeforeParentheses = parentheses?.[-1];
 
-      const ltx = rawTryGetMathquillIdent(tempCursor)?.ident;
-      if (ltx && isIdentStr(ltx) && parentheses?.ctrlSeq === "\\left(") {
-        return {
-          ident: latexStringToIdentifierString(ltx)!,
-          paramIndex,
-        };
+    const ltx = rawTryGetMathquillIdent(nodeBeforeParentheses)?.ident;
+    if (ltx && isIdentStr(ltx) && parentheses?.ctrlSeq === "\\left(") {
+      // Count number of commas to left of cursor.
+      let paramIndex = 0;
+      let scanNode = cursor?.[-1];
+      while (scanNode) {
+        const ltx = scanNode.latex?.();
+        if (ltx === ",") paramIndex++;
+        scanNode = scanNode[-1];
       }
-
-      // Else go to the parent.
-      paramIndex = 0;
-      cursor = cursor.parent?.parent;
+      return {
+        ident: latexStringToIdentifierString(ltx)!,
+        paramIndex,
+      };
     }
+
+    // Else go to the parent.
+    cursor = cursor.parent?.parent;
   }
 }
 

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -349,10 +349,11 @@ export function getCorrectableIdentifier(mq: MathQuillField): {
   ident: string;
   back: () => void;
 } {
-  let node = getCursor(mq)?.nodeBefore();
+  const cursor = getCursor(mq);
+  let node = cursor?.nodeBefore();
 
-  const isInSubscript =
-    mq.__controller.cursor?.parent?._el?.classList.contains("dcg-mq-sub");
+  const parentGroup = cursor?.parentGroup();
+  const isInSubscript = parentGroup && isSubscript(parentGroup);
 
   // don't bother if you're in a subscript
   if (isInSubscript) {

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -1,6 +1,6 @@
 import { ExpressionAug } from "../../../text-mode-core";
 import { latexStringToIdentifierString } from "./view";
-import { MathQuillField } from "#components";
+import { MathQuillField, selectionDirection } from "#components";
 
 export function mapAugAST(
   node: ExpressionAug["latex"],
@@ -28,7 +28,11 @@ export function mapAugAST(
   map(node);
 }
 
-class MqNodeViaDom {
+function isSelection(el: Element) {
+  return el.classList.contains("dcg-mq-selection");
+}
+
+export class MqNodeViaDom {
   mq: MathQuillField;
   domNode: Element;
 
@@ -41,8 +45,12 @@ class MqNodeViaDom {
     if (this.domNode.classList.contains("dcg-mq-root-block")) {
       return undefined;
     }
-    const parent = this.domNode.parentElement;
+    let parent = this.domNode.parentElement;
     if (!parent) return undefined;
+    if (isSelection(parent)) {
+      parent = parent.parentElement;
+      if (!parent) return undefined;
+    }
     return new MqNodeViaDom(this.mq, parent);
   }
 
@@ -51,7 +59,13 @@ class MqNodeViaDom {
     while (sibling?.classList.contains("dcg-mq-cursor")) {
       sibling = sibling.nextElementSibling;
     }
-    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    const parent = this.domNode.parentElement;
+    if (!sibling && parent && isSelection(parent)) {
+      sibling = parent.nextElementSibling;
+    }
+    if (sibling) {
+      return new MqNodeViaDom(this.mq, sibling);
+    }
     return undefined;
   }
 
@@ -60,7 +74,13 @@ class MqNodeViaDom {
     while (sibling?.classList.contains("dcg-mq-cursor")) {
       sibling = sibling.previousElementSibling;
     }
-    if (sibling) return new MqNodeViaDom(this.mq, sibling);
+    const parent = this.domNode.parentElement;
+    if (!sibling && parent && isSelection(parent)) {
+      sibling = parent.previousElementSibling;
+    }
+    if (sibling) {
+      return new MqNodeViaDom(this.mq, sibling);
+    }
     return undefined;
   }
 
@@ -71,38 +91,72 @@ class MqNodeViaDom {
   }
 }
 
+type DomCursor =
+  | { type: "cursor"; el: Element }
+  | { type: "selection"; el: Element; headSide: 1 | -1 };
+
 class MqCursorViaDom {
   mq: MathQuillField;
-  domCursor: Element;
+  /**
+   * The domCursor represents the head of the selection.
+   * Since we only have access to DOM nodes, this is a bit awkward.
+   */
+  domCursor: DomCursor;
 
-  constructor(mq: MathQuillField, domCursor: Element) {
+  constructor(mq: MathQuillField, domCursor: DomCursor) {
     this.mq = mq;
     this.domCursor = domCursor;
   }
 
   nodeBefore(): MqNodeViaDom | undefined {
-    const sibling = this.domCursor.previousElementSibling;
+    const sibling =
+      this.domCursor.type === "selection" && this.domCursor.headSide === 1
+        ? this.domCursor.el.lastElementChild
+        : this.domCursor.el.previousElementSibling;
     if (sibling) return new MqNodeViaDom(this.mq, sibling);
     else return undefined;
   }
 
   nodeAfter(): MqNodeViaDom | undefined {
-    const sibling = this.domCursor.nextElementSibling;
+    const sibling =
+      this.domCursor.type === "selection" && this.domCursor.headSide === -1
+        ? this.domCursor.el.firstElementChild
+        : this.domCursor.el.nextElementSibling;
     if (sibling) return new MqNodeViaDom(this.mq, sibling);
     else return undefined;
   }
 
+  nodeInDirection(dir: 1 | -1): MqNodeViaDom | undefined {
+    return dir === 1 ? this.nodeAfter() : this.nodeBefore();
+  }
+
   parentGroup() {
-    const parent = this.domCursor.parentElement;
+    const parent = this.domCursor.el.parentElement;
     if (!parent) throw new Error("Invalid cursor.");
     return new MqNodeViaDom(this.mq, parent);
   }
 }
 
-export function getCursor(mq: MathQuillField) {
+/**
+ * Get the head of the selection.
+ * When the selection is a point (i.e. just the cursor), it represents that point.
+ * Otherwise, this is the head of the selection, which is what moves when you shift-arrow.
+ */
+export function getCursorHead(mq: MathQuillField): MqCursorViaDom | undefined {
   const cursorDom = mq.el().querySelector(".dcg-mq-cursor");
-  if (!cursorDom) return undefined;
-  return new MqCursorViaDom(mq, cursorDom);
+  if (cursorDom) {
+    return new MqCursorViaDom(mq, { type: "cursor", el: cursorDom });
+  }
+  const selectionDom = mq.el().querySelector(".dcg-mq-selection");
+  if (selectionDom) {
+    const direction = selectionDirection(mq);
+    return new MqCursorViaDom(mq, {
+      type: "selection",
+      el: selectionDom,
+      headSide: direction,
+    });
+  }
+  return undefined;
 }
 
 export function getController(mq: MathQuillField) {
@@ -125,7 +179,7 @@ export interface TryFindMQIdentResult {
 }
 
 /** is an MQ node a subscript? */
-// TODO-jared-mq-compat: this can just check classList.contains("dcg-mq-sub")
+// TODO-mq-compat: this can just check classList.contains("dcg-mq-sub")
 function isSubscript(node: MqNodeViaDom) {
   return getSubscriptInside(node) !== undefined;
 }
@@ -271,7 +325,7 @@ function finalGetMathquillIdent(
 function tryGetMathquillIdent(
   mq: MathQuillField
 ): TryFindMQIdentResult | undefined {
-  const cursor = getCursor(mq);
+  const cursor = getCursorHead(mq);
   const v = rawTryGetMathquillIdent(cursor?.nodeBefore(), cursor);
   if (!v) return;
   const ident = latexStringToIdentifierString(v.ident);
@@ -306,7 +360,7 @@ export interface PartialFunctionCall {
 export function getPartialFunctionCall(
   mq: MathQuillField
 ): PartialFunctionCall | undefined {
-  const cursor: MqCursorViaDom | undefined = getCursor(mq);
+  const cursor: MqCursorViaDom | undefined = getCursorHead(mq);
   /**
    * If we haven't gone to any parents yet,
    * `nodeBeforeCursor` is the actual node left of the cursor, such as
@@ -349,7 +403,7 @@ export function getCorrectableIdentifier(mq: MathQuillField): {
   ident: string;
   back: () => void;
 } {
-  const cursor = getCursor(mq);
+  const cursor = getCursorHead(mq);
   let node = cursor?.nodeBefore();
 
   const parentGroup = cursor?.parentGroup();

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -50,9 +50,8 @@ export interface TryFindMQIdentResult {
 }
 
 /** is an MQ node a subscript? */
-// TODO-mq-compat: this can just check classList.contains("dcg-mq-sub")
 function isSubscript(node: MqNodeViaDom) {
-  return getSubscriptInside(node) !== undefined;
+  return node.domNode.classList.contains("dcg-mq-sub");
 }
 
 /**

--- a/src/plugins/intellisense/latex-parsing.tsx
+++ b/src/plugins/intellisense/latex-parsing.tsx
@@ -1,6 +1,8 @@
 import { ExpressionAug } from "../../../text-mode-core";
 import { latexStringToIdentifierString } from "./view";
-import { MathQuillField, selectionDirection } from "#components";
+import { MathQuillField } from "#components";
+import { MqNodeViaDom } from "../../mathquill/mq-node";
+import { getCursorHead, MqCursorViaDom } from "../../mathquill/mq-cursor";
 
 export function mapAugAST(
   node: ExpressionAug["latex"],
@@ -26,137 +28,6 @@ export function mapAugAST(
   }
 
   map(node);
-}
-
-function isSelection(el: Element) {
-  return el.classList.contains("dcg-mq-selection");
-}
-
-export class MqNodeViaDom {
-  mq: MathQuillField;
-  domNode: Element;
-
-  constructor(mq: MathQuillField, domNode: Element) {
-    this.mq = mq;
-    this.domNode = domNode;
-  }
-
-  parent() {
-    if (this.domNode.classList.contains("dcg-mq-root-block")) {
-      return undefined;
-    }
-    let parent = this.domNode.parentElement;
-    if (!parent) return undefined;
-    if (isSelection(parent)) {
-      parent = parent.parentElement;
-      if (!parent) return undefined;
-    }
-    return new MqNodeViaDom(this.mq, parent);
-  }
-
-  nextSibling(): MqNodeViaDom | undefined {
-    let sibling = this.domNode.nextElementSibling;
-    while (sibling?.classList.contains("dcg-mq-cursor")) {
-      sibling = sibling.nextElementSibling;
-    }
-    const parent = this.domNode.parentElement;
-    if (!sibling && parent && isSelection(parent)) {
-      sibling = parent.nextElementSibling;
-    }
-    if (sibling) {
-      return new MqNodeViaDom(this.mq, sibling);
-    }
-    return undefined;
-  }
-
-  prevSibling(): MqNodeViaDom | undefined {
-    let sibling = this.domNode.previousElementSibling;
-    while (sibling?.classList.contains("dcg-mq-cursor")) {
-      sibling = sibling.previousElementSibling;
-    }
-    const parent = this.domNode.parentElement;
-    if (!sibling && parent && isSelection(parent)) {
-      sibling = parent.previousElementSibling;
-    }
-    if (sibling) {
-      return new MqNodeViaDom(this.mq, sibling);
-    }
-    return undefined;
-  }
-
-  latex() {
-    const span = this.mq.domNodeToSpan(this.domNode);
-    if (!span) return "";
-    return span.latex.slice(span.startIndex, span.endIndex);
-  }
-}
-
-type DomCursor =
-  | { type: "cursor"; el: Element }
-  | { type: "selection"; el: Element; headSide: 1 | -1 };
-
-class MqCursorViaDom {
-  mq: MathQuillField;
-  /**
-   * The domCursor represents the head of the selection.
-   * Since we only have access to DOM nodes, this is a bit awkward.
-   */
-  domCursor: DomCursor;
-
-  constructor(mq: MathQuillField, domCursor: DomCursor) {
-    this.mq = mq;
-    this.domCursor = domCursor;
-  }
-
-  nodeBefore(): MqNodeViaDom | undefined {
-    const sibling =
-      this.domCursor.type === "selection" && this.domCursor.headSide === 1
-        ? this.domCursor.el.lastElementChild
-        : this.domCursor.el.previousElementSibling;
-    if (sibling) return new MqNodeViaDom(this.mq, sibling);
-    else return undefined;
-  }
-
-  nodeAfter(): MqNodeViaDom | undefined {
-    const sibling =
-      this.domCursor.type === "selection" && this.domCursor.headSide === -1
-        ? this.domCursor.el.firstElementChild
-        : this.domCursor.el.nextElementSibling;
-    if (sibling) return new MqNodeViaDom(this.mq, sibling);
-    else return undefined;
-  }
-
-  nodeInDirection(dir: 1 | -1): MqNodeViaDom | undefined {
-    return dir === 1 ? this.nodeAfter() : this.nodeBefore();
-  }
-
-  parentGroup() {
-    const parent = this.domCursor.el.parentElement;
-    if (!parent) throw new Error("Invalid cursor.");
-    return new MqNodeViaDom(this.mq, parent);
-  }
-}
-
-/**
- * Get the head of the selection.
- * When the selection is a point (i.e. just the cursor), it represents that point.
- * Otherwise, this is the head of the selection, which is what moves when you shift-arrow.
- */
-export function getCursorHead(mq: MathQuillField): MqCursorViaDom | undefined {
-  const cursorDom = mq.el().querySelector(".dcg-mq-cursor");
-  if (cursorDom) {
-    return new MqCursorViaDom(mq, { type: "cursor", el: cursorDom });
-  }
-  const selectionDom = mq.el().querySelector(".dcg-mq-selection");
-  if (selectionDom) {
-    const direction = selectionDirection(mq);
-    return new MqCursorViaDom(mq, {
-      type: "selection",
-      el: selectionDom,
-      headSide: direction,
-    });
-  }
-  return undefined;
 }
 
 export function getController(mq: MathQuillField) {

--- a/src/plugins/multiline/index.ts
+++ b/src/plugins/multiline/index.ts
@@ -8,6 +8,8 @@ import {
   getController,
   mqKeystroke,
 } from "#plugins/intellisense/latex-parsing.tsx";
+import { getCursorHead } from "../../mathquill/mq-cursor";
+import { MqNodeViaDom } from "../../mathquill/mq-node";
 
 export const R = 1;
 export const L = -1;
@@ -19,11 +21,20 @@ function focusmq(mq: MathQuillField | undefined) {
 }
 
 function isNextToTripleSpaceLineBreak(mq: MathQuillField, dir: Dir) {
+  const cursor = getCursorHead(mq);
+  if (!cursor) return false;
+  const node1 = cursor.nodeInDirection(dir);
+  const node2 = node1?.siblingInDirection(dir);
+  const node3 = node2?.siblingInDirection(dir);
   return (
-    getController(mq).cursor[dir]?._el?.dataset.isManualLineBreak &&
-    getController(mq).cursor[dir]?.[dir]?._el?.dataset.isManualLineBreak &&
-    getController(mq).cursor[dir]?.[dir]?.[dir]?._el?.dataset.isManualLineBreak
+    isManualLineBreak(node1) &&
+    isManualLineBreak(node2) &&
+    isManualLineBreak(node3)
   );
+}
+
+function isManualLineBreak(node: MqNodeViaDom | undefined) {
+  return (node?.domNode as HTMLElement | undefined)?.dataset.isManualLineBreak;
 }
 
 export default class Multiline extends PluginController<Config> {
@@ -191,7 +202,7 @@ export default class Multiline extends PluginController<Config> {
       if (mq) {
         mq.typedText("   ");
         this.enqueueVerticalifyOperation(
-          mq.__controller.container.querySelector(".dcg-mq-root-block")!
+          mq.el().querySelector(".dcg-mq-root-block")!
         );
         setTimeout(() => {
           this.dequeueAllMultilinifications();
@@ -247,23 +258,18 @@ export default class Multiline extends PluginController<Config> {
   }
 
   findCursorX() {
-    const cursor = document.querySelector(".dcg-mq-cursor");
+    const container = this.calc.focusedMathQuill?.mq.el();
+    if (!container) {
+      this.lastRememberedCursorX = undefined;
+      return;
+    }
+    const cursor = container.querySelector(".dcg-mq-cursor");
     if (cursor) {
       this.lastRememberedCursorX = cursor.getBoundingClientRect().left;
-    } else {
-      let xpos =
-        this.calc.focusedMathQuill?.mq.__controller.cursor?.[
-          -1
-        ]?._el?.getBoundingClientRect()?.right;
-      if (xpos !== undefined) {
-        this.lastRememberedCursorX = xpos;
-      } else {
-        xpos =
-          this.calc.focusedMathQuill?.mq.__controller.cursor?.[1]?._el?.getBoundingClientRect()
-            ?.left;
-        this.lastRememberedCursorX = xpos;
-      }
+      return;
     }
+    const selection = container.querySelector(".dcg-mq-selection");
+    this.lastRememberedCursorX = selection?.getBoundingClientRect()?.left;
   }
 
   mousedownHandler = () => {
@@ -392,42 +398,48 @@ export default class Multiline extends PluginController<Config> {
     const cursorPositions: number[] = [];
 
     const ctrlr = getController(focusedmq);
-    const domfragProto = Object.getPrototypeOf(ctrlr.cursor.domFrag());
+    let cleanup;
+    if (ctrlr) {
+      const domfragProto = Object.getPrototypeOf(ctrlr.cursor.domFrag());
 
-    // prevent the cursor from updating html elements
-    // by monkey patching the domfrag prototype
-    const { insAtDirEnd, insDirOf, removeClass, addClass } = domfragProto;
-    domfragProto.insAtDirEnd = function () {
-      return this;
-    };
-    domfragProto.insDirOf = function () {
-      return this;
-    };
-    domfragProto.removeClass = function () {
-      return this;
-    };
-    domfragProto.addClass = function () {
-      return this;
-    };
+      // prevent the cursor from updating html elements
+      // by monkey patching the domfrag prototype
+      const { insAtDirEnd, insDirOf, removeClass, addClass } = domfragProto;
+      domfragProto.insAtDirEnd = function () {
+        return this;
+      };
+      domfragProto.insDirOf = function () {
+        return this;
+      };
+      domfragProto.removeClass = function () {
+        return this;
+      };
+      domfragProto.addClass = function () {
+        return this;
+      };
 
-    // return the domfrag prototype to normal
-    const cleanup = () => {
-      domfragProto.insAtDirEnd = insAtDirEnd;
-      domfragProto.removeClass = removeClass;
-      domfragProto.addClass = addClass;
-      domfragProto.insDirOf = insDirOf;
-      if (select) {
-        mqKeystroke(focusedmq, oppositeArrowdir);
-        mqKeystroke(focusedmq, arrowdir);
-      }
-    };
+      // return the domfrag prototype to normal
+      cleanup = () => {
+        domfragProto.insAtDirEnd = insAtDirEnd;
+        domfragProto.removeClass = removeClass;
+        domfragProto.addClass = addClass;
+        domfragProto.insDirOf = insDirOf;
+        if (select) {
+          mqKeystroke(focusedmq, oppositeArrowdir);
+          mqKeystroke(focusedmq, arrowdir);
+        }
+      };
+    } else {
+      // new MQ: no monkey patching?
+      cleanup = () => {};
+    }
 
     // ended with break statements
     while (true) {
       // get cursor and adjacent element so we can figure out
       // if it's a line break
-      const ctrlr = getController(focusedmq);
-      let next = ctrlr.cursor?.[up ? L : R]?._el;
+      const cursor = getCursorHead(focusedmq);
+      let next = cursor?.nodeInDirection(up ? L : R)?.domNode;
 
       // are we getting the right side or the left side
       // of the element? (e.g. the bounding client rect "left" or "right" property)
@@ -439,7 +451,7 @@ export default class Multiline extends PluginController<Config> {
       // if we can't directly get the next element (e.g. end of a parenthesis block),
       // shift the cursor so that we can get access to it from the "other side"
       if (!next) {
-        next = ctrlr.cursor?.[up ? R : L]?._el;
+        next = cursor?.nodeInDirection(up ? R : L)?.domNode;
         isNextRight = !isNextRight;
       }
 


### PR DESCRIPTION
The main idea is introducing `MqCursorViaDom` to serve as the interface for nodes. It behaves pretty similarly to mathquill's existing node type, but it doesn't need to directly reference MQ nodes. Instead, it references DOM nodes (which mostly correspond 1-to-1, with the exception of selection sometimes wrapping things and cursor sometimes being in the middle).