### PR TITLE
Fix scrollbar overflow in better-evaluation-view

### DIFF
--- a/src/plugins/better-evaluation-view/better-evaluation-view.less
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.less
@@ -1,32 +1,13 @@
 .dcg-container.dsm-better-evaluation-view {
-  // Color Swatch
-  .dcg-color-evaluation .dcg-color-evaluation {
-    vertical-align: middle;
-  }
-
-  .dcg-color-evaluation .dcg-static-mathquill-view {
-    margin-right: 5px;
-  }
-
   .dsm-color-container {
     display: flex;
-    flex-direction: row;
+    gap: 5px;
+    max-width: 100%;
     align-items: center;
   }
 
   // Scrollbar for output
-  .dcg-evaluation-container {
-    max-width: 100%;
+  .dcg-evaluation-view__wrapped-value {
     overflow-x: auto;
-    overflow-y: hidden;
-    // -3px margin is removed from .dcg-evaluation due to clipping. Move it here.
-    margin-top: -3px;
-    > .dcg-evaluation.dcg-do-blur {
-      margin-top: 0;
-      max-width: 100%;
-      .dcg-inline-math-input-view {
-        font-size: 100%;
-      }
-    }
   }
 }


### PR DESCRIPTION
Changes to the expression result output broke the scrollbar overflow, so output was getting clipped when "Show list elements" was on.

The HTML/CSS of the expression list output has changed a lot since some of this CSS was first written, from what I can tell a lot of it no longer applies.

<img width="438" height="664" alt="image" src="https://github.com/user-attachments/assets/b97486ce-e346-4a9d-8830-4b6fb62c8db0" />

<img width="854" height="558" alt="image" src="https://github.com/user-attachments/assets/7bbf2abf-a0dc-47ee-ba33-c0e7e47903fd" />
