### PR TITLE
Set default of restrictMismatchedBrackets to 'none'

### DIFF
--- a/src/components/desmosComponents.ts
+++ b/src/components/desmosComponents.ts
@@ -73,7 +73,7 @@ export interface MathQuillConfig {
   sumStartsWithNEquals?: boolean;
   leftRightIntoCmdGoes?: string;
   supSubsRequireOperand?: boolean;
-  restrictMismatchedBrackets?: boolean;
+  restrictMismatchedBrackets?: boolean | "none";
   typingPercentWritesPercentOf?: boolean;
 }
 

--- a/src/plugins/custom-mathquill-config/index.ts
+++ b/src/plugins/custom-mathquill-config/index.ts
@@ -10,7 +10,7 @@ const defaultConfig: MathQuillConfig = {
   sumStartsWithNEquals: true,
   leftRightIntoCmdGoes: "up",
   supSubsRequireOperand: true,
-  restrictMismatchedBrackets: true,
+  restrictMismatchedBrackets: "none",
   typingPercentWritesPercentOf: true,
 };
 


### PR DESCRIPTION
`restrictMismatchedBrackets` is a boolean or the string `'none`', 
- False → all bracket matches are allowed
- True → Only `(]` and `[)` are allowed
- `'none'` → No non-matching brackets are allowed (added in https://github.com/desmosinc/mathquill/pull/279)

Use `'none'` in the default instead of true