### PR TITLE
Fix BEV problems

### DIFF
--- a/src/MainController.ts
+++ b/src/MainController.ts
@@ -116,12 +116,6 @@ export default class DSM extends TransparentPlugins {
   applyStoredSettings(
     storedSettings: Map<PluginID, GenericSettings | undefined>
   ) {
-    // Migrate "lists" property. Migration from 2026-05-26.
-    const bev = storedSettings.get("better-evaluation-view");
-    if (bev?.lists !== undefined) {
-      bev.lists = bev.lists ? "old" : "new";
-    }
-
     // Apply the rest of the settings
     for (const { id } of pluginList) {
       const stored = storedSettings.get(id);

--- a/src/plugins/better-evaluation-view/better-evaluation-view.less
+++ b/src/plugins/better-evaluation-view/better-evaluation-view.less
@@ -7,7 +7,7 @@
   }
 
   // Scrollbar for output
-  .dcg-evaluation-view__wrapped-value {
+  .dsm-bev-wide-wrapped-value {
     overflow-x: auto;
   }
 }

--- a/src/plugins/better-evaluation-view/components/ColorEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ColorEvaluation.tsx
@@ -8,7 +8,7 @@ type TypedConstantColorValue = TypedConstantValue<ColorValueType>;
 
 function _ColorEvaluation(val: TypedConstantColorValue) {
   return (
-    <div class="dcg-evaluation-view__wrapped-value">
+    <div class="dcg-evaluation-view__wrapped-value dsm-bev-wide-wrapped-value">
       <StaticMathQuillView
         latex={() => {
           const { valueType, value } = val;

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -118,7 +118,7 @@ export function ListEvaluation(
   typedConstantValue: TypedConstantValue<NormalListValueType>
 ) {
   return (
-    <div class="dcg-evaluation-view__wrapped-value">
+    <div class="dcg-evaluation-view__wrapped-value dsm-bev-wide-wrapped-value">
       <StaticMathQuillView
         latex={() => {
           const listLength = typedConstantValue.value.length;

--- a/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
+++ b/src/plugins/better-evaluation-view/components/ListEvaluation.tsx
@@ -128,7 +128,7 @@ export function ListEvaluation(
 
           return `\\left[${labelsToShow.join(",")}${
             listLength > truncationLength
-              ? `\\textcolor{gray}{...\\mathit{${listLength - truncationLength}\\ more}}`
+              ? `\\textcolor{gray}{...\\mathit{${listLength - truncationLength}\\ mo\\mathit{re}}}`
               : ""
           }\\right]`;
         }}


### PR DESCRIPTION
- The "more" in "Variant" mode no longer displays as `m\operatorname{or}e`
- "Show List Elements" no longer defaults to "Variant" upon reloading the page.
- Horizontal scrollbars no longer show on each element in "Default" mode.